### PR TITLE
fix: render smartbar labels as images

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content">
     <title>Zephyr</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌬️</text></svg>">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=20260606-smartbar-image-text">
 </head>
 <body class="app-body">
     <div class="app-shell">
@@ -239,6 +239,6 @@
     </div>
 
     <div class="toast" id="toast"></div>
-    <script src="app.js" type="module"></script>
+    <script src="app.js?v=20260606-smartbar-image-text" type="module"></script>
 </body>
 </html>

--- a/public/app.js
+++ b/public/app.js
@@ -126,6 +126,8 @@ function applyTheme(theme, { persist = false } = {}) {
         document.body?.classList.remove('theme-ripple-active');
     }, 460);
     root.setAttribute('data-theme', theme);
+    SMARTBAR_TEXT_IMAGE_CACHE.clear();
+    if (terminalTabs.length) renderTerminalSmartbar();
     if (persist) localStorage.setItem('zephyr-theme', theme);
     $('#appThemeToggle').textContent = theme === 'dark' ? '☀️' : '🌙';
     $('#settingsThemeToggle').textContent = theme === 'dark' ? '☀️' : '🌙';
@@ -892,6 +894,74 @@ function terminalInitials(name = '') {
     const raw = parts.length > 1 ? parts.slice(0, 2).map((x) => x[0]).join('') : (parts[0] || 'T').slice(0, 2);
     return raw.toUpperCase();
 }
+function escapeSvgText(str) { return String(str || '').replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m])); }
+const SMARTBAR_TEXT_IMAGE_CACHE = new Map();
+function smartbarTextThemeColor(kind = 'label') {
+    if (kind === 'plus') return '#0969da';
+    const theme = document.documentElement.getAttribute('data-theme') || getPreferredTheme();
+    if (kind === 'initials') return theme === 'dark' ? '#f0f6fc' : '#1f2328';
+    return theme === 'dark' ? '#f0f6fc' : '#24292f';
+}
+function smartbarTextMeasureContext(font) {
+    const canvas = smartbarTextMeasureContext.canvas || (smartbarTextMeasureContext.canvas = document.createElement('canvas'));
+    const ctx = canvas.getContext('2d');
+    ctx.font = font;
+    return ctx;
+}
+function measureSmartbarText(text, font) {
+    return smartbarTextMeasureContext(font).measureText(String(text || '')).width;
+}
+function fitSmartbarTextToWidth(text, maxWidth, font) {
+    const raw = String(text || '').replace(/\s+/g, ' ').trim() || 'Terminal';
+    if (measureSmartbarText(raw, font) <= maxWidth) return raw;
+    const chars = Array.from(raw);
+    let lo = 0, hi = chars.length;
+    while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (measureSmartbarText(`${chars.slice(0, mid).join('')}…`, font) <= maxWidth) lo = mid;
+        else hi = mid - 1;
+    }
+    return `${chars.slice(0, Math.max(1, lo)).join('')}…`;
+}
+function smartbarSvgDataUrl(svg) {
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+function smartbarTextImage(text, { kind = 'label', maxWidth = 82, width = null, height = null, fontSize = 11, fontWeight = 700, letterSpacing = 0 } = {}) {
+    const fontFamily = '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif';
+    const canvasFont = `${fontWeight} ${fontSize}px ${fontFamily}`;
+    const rawText = String(text || (kind === 'initials' ? 'T' : 'Terminal')).trim() || (kind === 'initials' ? 'T' : 'Terminal');
+    const fittedText = kind === 'label' ? fitSmartbarTextToWidth(rawText, maxWidth, canvasFont) : rawText;
+    const measuredWidth = Math.ceil(measureSmartbarText(fittedText, canvasFont));
+    const cssWidth = width || Math.min(maxWidth, Math.max(kind === 'initials' ? 42 : 8, measuredWidth + (kind === 'label' ? 2 : 0)));
+    const cssHeight = height || (kind === 'initials' ? 30 : 14);
+    const color = smartbarTextThemeColor(kind);
+    const cacheKey = [kind, fittedText, cssWidth, cssHeight, fontSize, fontWeight, letterSpacing, color].join('|');
+    const cached = SMARTBAR_TEXT_IMAGE_CACHE.get(cacheKey);
+    if (cached) return cached;
+    const scale = Math.min(3, Math.max(2, Math.ceil(window.devicePixelRatio || 1)));
+    const viewWidth = Math.ceil(cssWidth * scale);
+    const viewHeight = Math.ceil(cssHeight * scale);
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${viewWidth}" height="${viewHeight}" viewBox="0 0 ${viewWidth} ${viewHeight}"><text x="50%" y="52%" text-anchor="middle" dominant-baseline="central" font-family="${fontFamily}" font-size="${fontSize * scale}" font-weight="${fontWeight}" letter-spacing="${letterSpacing * scale}" fill="${color}">${escapeSvgText(fittedText)}</text></svg>`;
+    const image = { src: smartbarSvgDataUrl(svg), width: cssWidth, height: cssHeight, text: fittedText };
+    SMARTBAR_TEXT_IMAGE_CACHE.set(cacheKey, image);
+    return image;
+}
+function smartbarPlusImage() {
+    const color = smartbarTextThemeColor('plus');
+    const cacheKey = `plus|${color}`;
+    const cached = SMARTBAR_TEXT_IMAGE_CACHE.get(cacheKey);
+    if (cached) return cached;
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 60 60"><path d="M30 12v36M12 30h36" stroke="${color}" stroke-width="7" stroke-linecap="round"/></svg>`;
+    const image = { src: smartbarSvgDataUrl(svg), width: 30, height: 30, text: '+' };
+    SMARTBAR_TEXT_IMAGE_CACHE.set(cacheKey, image);
+    return image;
+}
+function smartbarImageHtml(image, className) {
+    return `<span class="${className} smartbar-rendered-image" style="width:${image.width}px;height:${image.height}px;background-image:url(&quot;${escapeHtml(image.src)}&quot;)" aria-hidden="true"></span>`;
+}
+function smartbarSessionInitialsHtml(name) { return smartbarImageHtml(smartbarTextImage(terminalInitials(name), { kind: 'initials', maxWidth: 46, width: 46, height: 30, fontSize: 20, fontWeight: 900, letterSpacing: .2 }), 'smartbar-session-initials-img'); }
+function smartbarSessionLabelHtml(name) { return smartbarImageHtml(smartbarTextImage(name || 'Terminal', { kind: 'label', maxWidth: 82, height: 14, fontSize: 11, fontWeight: 700 }), 'smartbar-session-label-img'); }
+function smartbarPlusHtml() { return `<span class="smartbar-add-icon">${smartbarImageHtml(smartbarPlusImage(), 'smartbar-plus-img')}</span>`; }
 function touchTerminalSession(id) { const t = getTerminalSession(id); if (t) t.lastUsedAt = Date.now(); recentUseStack = [id, ...recentUseStack.filter((x) => x !== id)].filter((x) => getTerminalSession(x)); }
 function orderedVisibleIds() { return openOrderStack.filter((id) => visibleTerminalTabs().some((t) => t.id === id)); }
 function computeDefaultVisualLayout() {
@@ -1010,7 +1080,7 @@ function renderTerminalSmartbar() {
         seen.add(t.id);
         return true;
     });
-    const icon = (t, index) => `<button class="smartbar-session ${t.id === activeTerminalTab ? 'active' : ''} ${t.minimized ? 'minimized' : ''}" style="--dock-index:${index}" data-smartbar-tab="${t.id}" title="${escapeHtml(t.protocol)} · ${escapeHtml(t.name)} · ${escapeHtml(t.status)}"><span class="smartbar-session-icon"><span class="proto-dot ${terminalProtocolClass(t.protocol)}"></span><b>${escapeHtml(terminalInitials(t.name))}</b></span><strong>${escapeHtml(t.name || 'Terminal')}</strong></button>`;
+    const icon = (t, index) => `<button class="smartbar-session ${t.id === activeTerminalTab ? 'active' : ''} ${t.minimized ? 'minimized' : ''}" style="--dock-index:${index}" data-smartbar-tab="${t.id}" title="${escapeHtml(t.protocol)} · ${escapeHtml(t.name)} · ${escapeHtml(t.status)}" aria-label="${escapeHtml(t.name || 'Terminal')}"><span class="smartbar-session-icon"><span class="proto-dot ${terminalProtocolClass(t.protocol)}"></span>${smartbarSessionInitialsHtml(t.name)}</span><span class="smartbar-session-label" aria-hidden="true">${smartbarSessionLabelHtml(t.name || 'Terminal')}</span></button>`;
     const launchableConnections = connections.filter((c) => ['SSH', 'RDP', 'VNC'].includes(String(c.protocol || 'SSH').toUpperCase()));
     const picker = terminalSmartbarPickerOpen ? `
         <div class="smartbar-picker" role="dialog" aria-label="选择服务器连接">
@@ -1039,7 +1109,7 @@ function renderTerminalSmartbar() {
         <div class="smartbar-panel">
             <div class="smartbar-dock" aria-label="终端 Dock">
                 ${sessions.map(icon).join('') || '<span class="smartbar-empty">暂无会话</span>'}
-                <button class="smartbar-add" style="--dock-index:${sessions.length}" data-smartbar-add title="选择服务器连接">＋</button>
+                <button class="smartbar-add" style="--dock-index:${sessions.length}" data-smartbar-add title="选择服务器连接" aria-label="选择服务器连接">${smartbarPlusHtml()}</button>
             </div>
         </div>`;
     requestAnimationFrame(() => {
@@ -1921,6 +1991,8 @@ function startSmartbarIconDrag(e, tabId) {
         const dx = ev.clientX - smartbarDragState.startX;
         const dy = ev.clientY - smartbarDragState.startY;
         if (Math.hypot(dx, dy) > 5) smartbarDragState.moved = true;
+        ev.preventDefault?.();
+        window.getSelection?.()?.removeAllRanges?.();
         schedulePaint();
         ghost.style.pointerEvents = 'none';
         const trashRect = trash.getBoundingClientRect();
@@ -1996,17 +2068,19 @@ function startSmartbarIconDrag(e, tabId) {
             { transform: 'translate(-50%, -50%) scale(.78)', opacity: 0 }
         ], { duration: 180, easing: 'cubic-bezier(.2,.8,.2,1)' }).onfinish = () => ghost.remove();
     };
-    window.addEventListener('pointermove', onMove, { passive: true });
+    window.addEventListener('pointermove', onMove, { passive: false });
     window.addEventListener('pointerup', onUp, { once: true });
     window.addEventListener('pointercancel', onCancel, { once: true });
 }
 
 function startSmartbarPress(e, tabBtn) {
     if (!tabBtn || e.button === 2) return;
+    e.preventDefault?.();
+    window.getSelection?.()?.removeAllRanges?.();
     const tabId = tabBtn.dataset.smartbarTab;
     if (!tabId) return;
     const isDesktopLike = window.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches;
-    const holdMs = isDesktopLike && e.pointerType !== 'touch' ? 260 : SMARTBAR_TOUCH_DRAG_HOLD_MS;
+    const holdMs = isDesktopLike && e.pointerType !== 'touch' ? 260 : 420;
     window.clearTimeout(smartbarPressState?.timer);
     smartbarPressState = {
         tabId,
@@ -2052,8 +2126,10 @@ function startSmartbarPress(e, tabBtn) {
         if (!smartbarPressState || ev.pointerId !== smartbarPressState.pointerId) return;
         const dx = ev.clientX - smartbarPressState.startX;
         const dy = ev.clientY - smartbarPressState.startY;
+        ev.preventDefault?.();
+        window.getSelection?.()?.removeAllRanges?.();
         if (!smartbarPressState.dragStarted && Math.hypot(dx, dy) > 24) {
-            // <2s 时移动只当作用户想滚动/点按，不提前进入拖拽。
+            beginDrag(ev);
             return;
         }
     };
@@ -2076,7 +2152,7 @@ function startSmartbarPress(e, tabBtn) {
         smartbarPressState?.tabBtn?.classList.remove('dock-press-armed');
         cleanup();
     };
-    window.addEventListener('pointermove', onMove, { passive: true });
+    window.addEventListener('pointermove', onMove, { passive: false });
     window.addEventListener('pointerup', onUp, { once: true });
     window.addEventListener('pointercancel', onCancel, { once: true });
 }
@@ -2487,8 +2563,11 @@ function bindEvents() {
     });
     $('#sessionTabs').addEventListener('pointermove', (e) => {
         const dock = e.target.closest('.smartbar-dock');
-        if (dock) updateDockMagnification(e.clientX, dock, e.clientY);
-    });
+        if (dock) {
+            if (e.target.closest('[data-smartbar-tab]')) e.preventDefault?.();
+            updateDockMagnification(e.clientX, dock, e.clientY);
+        }
+    }, { passive: false });
     $('#sessionTabs').addEventListener('pointerleave', (e) => {
         resetDockMagnification(e.currentTarget.querySelector('.smartbar-dock'));
     });

--- a/public/style.css
+++ b/public/style.css
@@ -686,6 +686,9 @@ body.terminal-mode-entering .terminal-smartbar .smartbar-handle {
     overscroll-behavior-x: contain;
     -webkit-overflow-scrolling: touch;
     scroll-padding-inline: 20px;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 .smartbar-dock::-webkit-scrollbar { display: none; }
 .smartbar-session,
@@ -707,12 +710,19 @@ body.terminal-mode-entering .terminal-smartbar .smartbar-handle {
     color: var(--text);
     cursor: pointer;
     flex: 0 0 auto;
+    -webkit-user-drag: none;
+    -webkit-tap-highlight-color: transparent;
     opacity: 0;
     transform: translate3d(0, 18px, 0) scale(.72) rotateX(10deg);
     transform-origin: 50% 100%;
     transition: transform .54s cubic-bezier(.16,1,.3,1), opacity .32s ease, filter .38s ease;
     will-change: transform, opacity, filter;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: none;
 }
+.smartbar-add { touch-action: manipulation; }
 .smartbar-session.dragging { opacity: .35; }
 .smartbar-session.dock-press-armed .smartbar-session-icon {
     box-shadow: 0 18px 42px rgba(88,166,255,.20), 0 0 0 4px rgba(88,166,255,.10);
@@ -731,8 +741,7 @@ body.terminal-mode-entering .terminal-smartbar .smartbar-handle {
     filter: drop-shadow(0 22px 38px rgba(0,0,0,.32));
 }
 .smartbar-session-icon,
-.smartbar-add::before {
-    content: '+';
+.smartbar-add-icon {
     position: relative;
     width: 62px;
     height: 62px;
@@ -766,18 +775,33 @@ body.terminal-mode-entering .terminal-smartbar .smartbar-handle {
 .smartbar-session:hover + .smartbar-add,
 .smartbar-add:hover + .smartbar-session { --dock-scale: 1.045; --dock-lift: -3px; }
 .smartbar-session:hover .smartbar-session-icon,
-.smartbar-add:hover::before { border-color: rgba(88,166,255,.58); border-radius: 21px; transform: translateY(-1px); box-shadow: 0 22px 48px rgba(0,0,0,.30), 0 0 0 5px rgba(88,166,255,.09); }
+.smartbar-add:hover .smartbar-add-icon { border-color: rgba(88,166,255,.58); border-radius: 21px; transform: translateY(-1px); box-shadow: 0 22px 48px rgba(0,0,0,.30), 0 0 0 5px rgba(88,166,255,.09); }
 .smartbar-session.active .smartbar-session-icon { border-color: var(--accent); box-shadow: 0 16px 38px rgba(88,166,255,.22), 0 0 0 3px rgba(88,166,255,.14); animation: dockActivePulse 2.2s ease-in-out infinite; }
 .smartbar-session.active::after { content: ''; position: absolute; left: 50%; bottom: 0; width: 5px; height: 5px; border-radius: 50%; background: var(--accent-hover); transform: translateX(-50%); box-shadow: 0 0 12px rgba(88,166,255,.72); }
 .smartbar-session.minimized { opacity: .74; }
 @keyframes dockItemBloom { 0% { opacity: 0; transform: translate3d(0, 18px, 0) scale(.78) rotateX(8deg); filter: blur(8px); } 64% { opacity: 1; transform: translate3d(0, -3px, 0) scale(1.025) rotateX(0); filter: blur(0); } 86% { transform: translate3d(0, 1px, 0) scale(.995); } 100% { opacity: 1; transform: translate3d(var(--dock-shift, 0px), var(--dock-lift), 0) scale(var(--dock-scale)) rotateZ(var(--dock-rotate)); filter: blur(0); } }
 @keyframes dockActivePulse { 0%, 100% { transform: translateY(0) scale(1); } 50% { transform: translateY(-1px) scale(1.025); } }
+.smartbar-rendered-image {
+    display: block;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-user-drag: none;
+    -webkit-touch-callout: none;
+    flex: 0 0 auto;
+}
 .smartbar-session-icon .proto-dot { position: absolute; right: 7px; bottom: 7px; width: 10px; height: 10px; }
-.smartbar-session-icon b { font-size: 20px; letter-spacing: .02em; font-weight: 900; }
-.smartbar-session strong { max-width: 82px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; line-height: 1.15; font-weight: 700; }
+.smartbar-session-initials-img { width: 46px; height: 30px; object-fit: contain; }
+.smartbar-session-label { display: flex; align-items: center; justify-content: center; width: 82px; height: 14px; overflow: hidden; }
+.smartbar-session-label-img { height: 14px; max-width: 82px; object-fit: contain; }
+.smartbar-session b,
+.smartbar-session strong { display: none; }
 .smartbar-session em { display: none; }
 .smartbar-add { font-size: 0; font-weight: 600; color: var(--accent-hover); }
-.smartbar-add::before { font-size: 30px; font-weight: 500; color: var(--accent-hover); }
+.smartbar-plus-img { width: 30px; height: 30px; object-fit: contain; }
 .smartbar-empty { color: var(--text-secondary); font-size: 12px; padding: 0 8px; align-self: center; }
 .smartbar-picker {
     position: fixed;
@@ -2250,15 +2274,13 @@ body.app-body > .toast.show { opacity: 1; transform: translate3d(0,0,0) scale(1)
         height: 78px;
     }
     .smartbar-session-icon,
-    .smartbar-add::before {
+    .smartbar-add-icon {
         width: 54px;
         height: 54px;
         border-radius: 16px;
     }
-    .smartbar-session strong {
-        max-width: 68px;
-        font-size: 10px;
-    }
+    .smartbar-session-label { width: 68px; }
+    .smartbar-session-label-img { max-width: 68px; height: 13px; }
     .smartbar-session:hover,
     .smartbar-add:hover {
         --dock-scale: 1.08;
@@ -5052,16 +5074,19 @@ body.smartbar-trash-hover .smartbar-trash-target {
         padding: 0;
     }
     body.terminal-custom-fullscreen-open .smartbar-session-icon,
-    body.terminal-custom-fullscreen-open .smartbar-add::before,
+    body.terminal-custom-fullscreen-open .smartbar-add-icon,
     body.terminal-custom-fullscreen-open .smartbar-exit-fullscreen span {
         width: 48px;
         height: 48px;
         border-radius: 17px;
     }
-    body.terminal-custom-fullscreen-open .smartbar-session strong,
+    body.terminal-custom-fullscreen-open .smartbar-session-label,
     body.terminal-custom-fullscreen-open .smartbar-exit-fullscreen strong {
         max-width: 62px;
-        font-size: 10px;
+    }
+    body.terminal-custom-fullscreen-open .smartbar-session-label-img {
+        max-width: 62px;
+        height: 13px;
     }
     body.terminal-custom-fullscreen-open .smartbar-session.active::after {
         left: 3px;
@@ -5595,17 +5620,20 @@ body.smartbar-trash-hover .smartbar-trash-target {
         transition: transform .28s cubic-bezier(.2,.8,.2,1), filter .22s ease, opacity .18s ease;
     }
     body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-session-icon,
-    body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-add::before {
+    body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-add-icon {
         width: 50px;
         height: 50px;
         border-radius: 18px;
     }
-    body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-session strong {
-        display: block;
+    body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-session-label {
+        display: flex;
         max-width: 66px;
-        font-size: 10px;
         line-height: 1.1;
         text-align: center;
+    }
+    body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-session-label-img {
+        max-width: 66px;
+        height: 13px;
     }
 }
 
@@ -5822,9 +5850,12 @@ body.smartbar-trash-hover .smartbar-trash-target {
     }
     body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-session,
     body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-add {
-        touch-action: manipulation !important;
+        touch-action: none !important;
         -webkit-tap-highlight-color: transparent;
         transition: transform .22s cubic-bezier(.16,1,.3,1), filter .22s ease, opacity .18s ease !important;
+    }
+    body.terminal-custom-fullscreen-open .terminal-smartbar .smartbar-add {
+        touch-action: manipulation !important;
     }
     .terminal-smartbar:not(.open) .smartbar-panel {
         pointer-events: none !important;


### PR DESCRIPTION
## Summary
- Render Smartbar session initials/name and add button as generated SVG image backgrounds instead of selectable text
- Disable text selection/callout on Smartbar drag targets to avoid mobile browser copy-selection conflicts
- Let mobile Smartbar session drag start quickly by moving the icon, including fullscreen vertical Dock
- Bump app.js/style.css cache query for this change

## Checks
- node --check public/app.js
- node --check public/terminal.js
- node --check server.js
- git diff --check
