### PR TITLE
perf(agent): replace blocking file bridge with ZFT2

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Run tests
         run: flutter test
 
+      - name: Build Android debug bundle for host-code compile coverage
+        run: |
+          flutter create --org com.zephyr --project-name zephyr_agent --platforms android .
+          sh tool/prepare_android.sh
+          flutter build apk --debug
+
   # ───────────── Release builds: only on workflow_dispatch with tag ──
   build-android:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''

--- a/file-agent-manager.js
+++ b/file-agent-manager.js
@@ -15,6 +15,13 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const WebSocket = require('ws');
+const {
+    OP: ZFT2_OP,
+    FLAG_ERROR: ZFT2_FLAG_ERROR,
+    FLAG_RESPONSE: ZFT2_FLAG_RESPONSE,
+    encodeFrame: encodeZft2Frame,
+    decodeFrame: decodeZft2Frame,
+} = require('./file-transfer-protocol');
 
 const HEARTBEAT_INTERVAL_MS = 15000;
 const HEARTBEAT_TIMEOUT_FACTOR = 3;
@@ -41,6 +48,9 @@ class FileAgentConnection {
         this.connectedAt = Date.now();
         this.pendingRequests = new Map(); // requestId → { resolve, reject, timer }
         this.nextRequestId = 1;
+        this.protocolVersion = Number(hello.protocolVersion || 1);
+        this.maxInflight = Math.max(1, Math.min(16, Number(this.capabilities.maxInflight || 8)));
+        this.maxChunkSize = Math.max(64 * 1024, Math.min(1024 * 1024, Number(this.capabilities.maxChunkSize || 1024 * 1024)));
         this.heartbeatTimer = null;
         this.heartbeatMissCount = 0;
     }
@@ -59,6 +69,9 @@ class FileAgentConnection {
             readOnly: this.share.readOnly !== false,
             shareName: this.share.name || this.deviceName,
             capabilities: { ...this.capabilities },
+            protocolVersion: this.protocolVersion,
+            maxInflight: this.maxInflight,
+            maxChunkSize: this.maxChunkSize,
             connectedAt: this.connectedAt,
             lastSeenAt: this.lastSeenAt,
             tokenId: this.tokenId,
@@ -124,8 +137,87 @@ class FileAgentConnection {
         });
     }
 
+    /** Send a protocol-v2 binary request to the Agent. */
+    callBinaryV2(type, meta, payload, timeoutMs) {
+        let settled = false;
+        let cancel = () => {};
+        const promise = new Promise((resolve, reject) => {
+            if (!this.online) {
+                reject(new AgentError('agent_offline', 'Agent is offline'));
+                return;
+            }
+            if (this.protocolVersion < 2) {
+                reject(new AgentError('unsupported', 'Agent does not support ZFT2'));
+                return;
+            }
+            if (this.pendingRequests.size >= this.maxInflight) {
+                reject(new AgentError('busy', 'Agent request window is full'));
+                return;
+            }
+            const id = this.nextRequestId++ >>> 0;
+            const frame = encodeZft2Frame({ type, requestId: id, meta: meta || {}, payload });
+            const timer = setTimeout(() => {
+                this.pendingRequests.delete(id);
+                if (!settled) {
+                    finishReject(new AgentError('timeout', `ZFT2 request timed out after ${timeoutMs}ms`));
+                }
+            }, timeoutMs || RPC_DEFAULT_TIMEOUT_MS);
+            const finishResolve = (value) => {
+                if (settled) return;
+                settled = true;
+                resolve(value);
+            };
+            const finishReject = (error) => {
+                if (settled) return;
+                settled = true;
+                reject(error);
+            };
+            this.pendingRequests.set(id, { resolve: finishResolve, reject: finishReject, timer, binaryV2: true, method: type });
+            cancel = () => {
+                if (settled) return;
+                clearTimeout(timer);
+                this.pendingRequests.delete(id);
+                try { this.ws.send(encodeZft2Frame({ type: ZFT2_OP.CANCEL, requestId: this.nextRequestId++ >>> 0, meta: { targetRequestId: id } })); } catch {}
+                finishReject(new AgentError('cancelled', 'File request cancelled'));
+            };
+            try {
+                this.ws.send(frame, { binary: true }, (err) => {
+                    if (!err || settled) return;
+                    clearTimeout(timer);
+                    this.pendingRequests.delete(id);
+                    finishReject(new AgentError('io_error', err.message));
+                });
+            } catch (err) {
+                clearTimeout(timer);
+                this.pendingRequests.delete(id);
+                finishReject(new AgentError('io_error', err.message));
+            }
+        });
+        return { promise, cancel };
+    }
+
+    /** Handle an incoming ZFT2 response from the Agent. */
+    handleBinaryV2(raw) {
+        let frame;
+        try { frame = decodeZft2Frame(raw); } catch { return false; }
+        if (!(frame.flags & ZFT2_FLAG_RESPONSE)) return false;
+        const pending = this.pendingRequests.get(frame.requestId);
+        if (!pending || !pending.binaryV2) return true;
+        clearTimeout(pending.timer);
+        this.pendingRequests.delete(frame.requestId);
+        if (frame.flags & ZFT2_FLAG_ERROR) {
+            pending.reject(new AgentError(frame.meta.code || 'internal_error', frame.meta.message || 'Agent request failed'));
+        } else if (frame.type === ZFT2_OP.READ) {
+            pending.resolve(frame.payload);
+        } else {
+            pending.resolve(frame.meta || {});
+        }
+        return true;
+    }
+
     /** Handle an incoming binary response from the Agent. */
     handleBinaryResponse(raw) {
+        if (this.handleBinaryV2(raw)) return true;
         const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
         // Binary frame: magic "ZFB1" (4) + idLen uint16BE (2) + id UTF-8 + payload
         if (buf.length < 6 || buf[0] !== 0x5a || buf[1] !== 0x46 || buf[2] !== 0x42 || buf[3] !== 0x31) {
@@ -473,7 +565,7 @@ class FileAgentManager {
 
     _handleHello(ws, hello, callback) {
         // Validate protocol version
-        if (hello.protocolVersion !== 1) {
+        if (hello.protocolVersion !== 1 && hello.protocolVersion !== 2) {
             callback(new AgentError('unsupported', `Unsupported protocol version: ${hello.protocolVersion}`));
             return;
         }
@@ -757,6 +849,43 @@ class FileAgentManager {
         return conn ? conn.ownerId === ownerId : false;
     }
 
+    /** Accept immutable userId ownership with username fallback for migrated tokens. */
+    isAgentOwnedByUser(agentId, user) {
+        const conn = this.agents.get(agentId);
+        if (!conn || !user) return false;
+        return conn.ownerId === user.userId || conn.ownerId === user.username;
+    }
+
+    /** Protocol-v2 operation with explicit cancellation. */
+    callAgentV2(agentId, method, params = {}, timeoutMs = RPC_READ_TIMEOUT_MS) {
+        const conn = this.agents.get(agentId);
+        if (!conn || !conn.online) {
+            return { promise: Promise.reject(new AgentError('agent_offline', `Agent ${agentId} is not connected`)), cancel() {} };
+        }
+        if (method === 'writeBinary' && conn.share.readOnly) {
+            return { promise: Promise.reject(new AgentError('read_only', 'Agent share is read-only')), cancel() {} };
+        }
+        const mutating = ['writeBinary', 'mkdir', 'delete', 'rename', 'truncate'];
+        if (mutating.includes(method) && conn.share.readOnly) {
+            return { promise: Promise.reject(new AgentError('read_only', 'Agent share is read-only')), cancel() {} };
+        }
+        const map = {
+            open: ZFT2_OP.OPEN, readBinary: ZFT2_OP.READ, writeBinary: ZFT2_OP.WRITE,
+            close: ZFT2_OP.CLOSE, stat: ZFT2_OP.STAT, list: ZFT2_OP.LIST,
+            mkdir: ZFT2_OP.MKDIR, delete: ZFT2_OP.DELETE, rename: ZFT2_OP.RENAME,
+            truncate: ZFT2_OP.TRUNCATE,
+        };
+        const type = map[method];
+        if (!type) return { promise: Promise.reject(new AgentError('unsupported', `Unsupported ZFT2 method ${method}`)), cancel() {} };
+        const meta = { ...params };
+        let payload = null;
+        if (method === 'writeBinary') {
+            payload = Buffer.from(meta.data || []);
+            delete meta.data;
+        }
+        return conn.callBinaryV2(type, meta, payload, timeoutMs);
+    }
+
     // ─── SSE Broadcasting ────────────────────────────────────────────
 
     /** Subscribe an SSE client (HTTP response) for agent events. */
@@ -797,8 +926,7 @@ class FileAgentManager {
         app.get('/api/rdp/file-agents', requireAuth, (req, res) => {
             const user = getSessionUser(req);
             if (!user) return res.status(401).json({ ok: false, error: 'Unauthorized' });
-            const agents = this.listAgentsForUser(user.username);
-            res.json({ ok: true, agents });
+            res.json({ ok: true, agents: this.listAgentsForUser(user.username) });
         });
 
         // GET /api/rdp/file-agent-tokens — list named agent tokens
@@ -996,4 +1124,4 @@ class FileAgentManager {
     }
 }
 
-module.exports = { FileAgentManager, AgentError };
+module.exports = { FileAgentManager, AgentError, FileAgentConnection };

--- a/file-transfer-operations.js
+++ b/file-transfer-operations.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const {
+    OP, MAX_PAYLOAD_BYTES, Zft2ProtocolError,
+} = require('./file-transfer-protocol');
+
+function asString(value, max = 4096) {
+    return String(value == null ? '' : value).slice(0, max);
+}
+
+function asSafeInteger(value, fallback = 0) {
+    const n = Number(value);
+    return Number.isSafeInteger(n) && n >= 0 ? n : fallback;
+}
+
+function mapRequest(frame) {
+    const meta = frame.meta || {};
+    switch (frame.type) {
+        case OP.OPEN: return { method: 'open', params: { path: asString(meta.path), mode: asString(meta.mode, 32) || 'read' } };
+        case OP.READ: return { method: 'readBinary', binaryRead: true, params: { handle: asString(meta.handle, 256), offset: asSafeInteger(meta.offset), length: Math.min(MAX_PAYLOAD_BYTES, asSafeInteger(meta.length)) } };
+        case OP.WRITE: return { method: 'writeBinary', binaryWrite: true, params: { handle: asString(meta.handle, 256), offset: asSafeInteger(meta.offset), data: frame.payload } };
+        case OP.CLOSE: return { method: 'close', params: { handle: asString(meta.handle, 256) } };
+        case OP.STAT: return { method: 'stat', params: { path: asString(meta.path) } };
+        case OP.LIST: return { method: 'list', params: { path: asString(meta.path) || '/' } };
+        case OP.MKDIR: return { method: 'mkdir', params: { path: asString(meta.path) } };
+        case OP.DELETE: return { method: 'delete', params: { path: asString(meta.path), recursive: !!meta.recursive } };
+        case OP.RENAME: return { method: 'rename', params: { oldPath: asString(meta.oldPath), newPath: asString(meta.newPath) } };
+        case OP.TRUNCATE: return { method: 'truncate', params: { path: asString(meta.path), size: asSafeInteger(meta.size) } };
+        case OP.PING: return { method: 'ping', local: true, params: {} };
+        default: throw new Zft2ProtocolError('unsupported_operation', `Unsupported ZFT2 operation ${frame.type}`);
+    }
+}
+
+module.exports = { asString, asSafeInteger, mapRequest };

--- a/file-transfer-protocol.js
+++ b/file-transfer-protocol.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const MAGIC = Buffer.from('ZFT2');
+const VERSION = 2;
+const HEADER_BYTES = 20;
+const FLAG_ERROR = 0x0001;
+const FLAG_RESPONSE = 0x0002;
+const MAX_META_BYTES = 256 * 1024;
+const MAX_PAYLOAD_BYTES = 1024 * 1024;
+
+const OP = Object.freeze({
+    OPEN: 0x01,
+    READ: 0x02,
+    WRITE: 0x03,
+    CLOSE: 0x04,
+    STAT: 0x05,
+    LIST: 0x06,
+    MKDIR: 0x07,
+    DELETE: 0x08,
+    RENAME: 0x09,
+    TRUNCATE: 0x0a,
+    CANCEL: 0x0b,
+    PING: 0x0c,
+});
+
+class Zft2ProtocolError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.code = code;
+    }
+}
+
+function encodeFrame({ type, requestId, flags = 0, meta = {}, payload = null }) {
+    const op = Number(type);
+    const id = Number(requestId);
+    if (!Number.isInteger(op) || op < 0 || op > 255) throw new Zft2ProtocolError('invalid_type', 'Invalid ZFT2 frame type');
+    if (!Number.isInteger(id) || id < 0 || id > 0xffffffff) throw new Zft2ProtocolError('invalid_request_id', 'Invalid ZFT2 request id');
+    const metaBytes = Buffer.from(JSON.stringify(meta || {}), 'utf8');
+    const payloadBytes = payload == null ? Buffer.alloc(0) : Buffer.from(payload);
+    if (metaBytes.length > MAX_META_BYTES) throw new Zft2ProtocolError('metadata_too_large', 'ZFT2 metadata exceeds limit');
+    if (payloadBytes.length > MAX_PAYLOAD_BYTES) throw new Zft2ProtocolError('payload_too_large', 'ZFT2 payload exceeds limit');
+    const out = Buffer.allocUnsafe(HEADER_BYTES + metaBytes.length + payloadBytes.length);
+    MAGIC.copy(out, 0);
+    out[4] = VERSION;
+    out[5] = op;
+    out.writeUInt16BE(Number(flags) & 0xffff, 6);
+    out.writeUInt32BE(id >>> 0, 8);
+    out.writeUInt32BE(metaBytes.length, 12);
+    out.writeUInt32BE(payloadBytes.length, 16);
+    metaBytes.copy(out, HEADER_BYTES);
+    payloadBytes.copy(out, HEADER_BYTES + metaBytes.length);
+    return out;
+}
+
+function decodeFrame(raw, limits = {}) {
+    const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw || []);
+    if (buf.length < HEADER_BYTES) throw new Zft2ProtocolError('truncated_header', 'Truncated ZFT2 header');
+    if (!buf.subarray(0, 4).equals(MAGIC)) throw new Zft2ProtocolError('bad_magic', 'Invalid ZFT2 magic');
+    if (buf[4] !== VERSION) throw new Zft2ProtocolError('unsupported_version', `Unsupported ZFT2 version ${buf[4]}`);
+    const metaLength = buf.readUInt32BE(12);
+    const payloadLength = buf.readUInt32BE(16);
+    const maxMeta = Number(limits.maxMetaBytes || MAX_META_BYTES);
+    const maxPayload = Number(limits.maxPayloadBytes || MAX_PAYLOAD_BYTES);
+    if (metaLength > maxMeta) throw new Zft2ProtocolError('metadata_too_large', 'ZFT2 metadata exceeds limit');
+    if (payloadLength > maxPayload) throw new Zft2ProtocolError('payload_too_large', 'ZFT2 payload exceeds limit');
+    const expected = HEADER_BYTES + metaLength + payloadLength;
+    if (buf.length !== expected) throw new Zft2ProtocolError('length_mismatch', `ZFT2 frame length mismatch: expected ${expected}, got ${buf.length}`);
+    let meta = {};
+    if (metaLength) {
+        try {
+            meta = JSON.parse(buf.subarray(HEADER_BYTES, HEADER_BYTES + metaLength).toString('utf8'));
+        } catch {
+            throw new Zft2ProtocolError('invalid_metadata', 'Invalid ZFT2 metadata JSON');
+        }
+        if (!meta || Array.isArray(meta) || typeof meta !== 'object') throw new Zft2ProtocolError('invalid_metadata', 'ZFT2 metadata must be an object');
+    }
+    return {
+        version: buf[4],
+        type: buf[5],
+        flags: buf.readUInt16BE(6),
+        requestId: buf.readUInt32BE(8),
+        meta,
+        payload: buf.subarray(HEADER_BYTES + metaLength),
+    };
+}
+
+function responseFrame(request, meta = {}, payload = null) {
+    return encodeFrame({ type: request.type, requestId: request.requestId, flags: FLAG_RESPONSE, meta, payload });
+}
+
+function errorFrame(request, code, message, retryable = false) {
+    return encodeFrame({
+        type: request?.type || 0,
+        requestId: request?.requestId || 0,
+        flags: FLAG_RESPONSE | FLAG_ERROR,
+        meta: { code: String(code || 'internal_error'), message: String(message || 'File transfer failed'), retryable: !!retryable },
+    });
+}
+
+module.exports = {
+    MAGIC, VERSION, HEADER_BYTES, FLAG_ERROR, FLAG_RESPONSE,
+    MAX_META_BYTES, MAX_PAYLOAD_BYTES, OP,
+    Zft2ProtocolError, encodeFrame, decodeFrame, responseFrame, errorFrame,
+};

--- a/file-transfer-ws.js
+++ b/file-transfer-ws.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const WebSocket = require('ws');
+const {
+    OP, FLAG_RESPONSE, FLAG_ERROR, MAX_PAYLOAD_BYTES,
+    Zft2ProtocolError, decodeFrame, responseFrame, errorFrame,
+} = require('./file-transfer-protocol');
+const { asString, asSafeInteger, mapRequest } = require('./file-transfer-operations');
+
+const MAX_INFLIGHT_REQUESTS = 8;
+const MAX_INFLIGHT_BYTES = 32 * 1024 * 1024;
+const SEND_HIGH_WATER = 8 * 1024 * 1024;
+const SEND_LOW_WATER = 2 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 60000;
+const SEND_WAIT_TIMEOUT_MS = 30000;
+
+function wsOpen(ws) {
+    return ws && ws.readyState === WebSocket.OPEN;
+}
+
+function waitForSendBudget(ws, byteLength, timeoutMs = SEND_WAIT_TIMEOUT_MS) {
+    if (!wsOpen(ws)) return Promise.reject(new Error('file transfer websocket is closed'));
+    if ((ws.bufferedAmount || 0) + byteLength <= SEND_HIGH_WATER) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+        const started = Date.now();
+        const timer = setInterval(() => {
+            if (!wsOpen(ws)) {
+                clearInterval(timer);
+                reject(new Error('file transfer websocket closed during backpressure wait'));
+                return;
+            }
+            if ((ws.bufferedAmount || 0) <= SEND_LOW_WATER) {
+                clearInterval(timer);
+                resolve();
+                return;
+            }
+            if (Date.now() - started >= timeoutMs) {
+                clearInterval(timer);
+                reject(new Error('file transfer websocket backpressure timeout'));
+            }
+        }, 4);
+        timer.unref?.();
+    });
+}
+
+function sendBinary(ws, frame) {
+    return waitForSendBudget(ws, frame.length).then(() => new Promise((resolve, reject) => {
+        if (!wsOpen(ws)) return reject(new Error('file transfer websocket is closed'));
+        ws.send(frame, { binary: true }, (err) => err ? reject(err) : resolve());
+    }));
+}
+
+class FileTransferGateway {
+    constructor({ fileAgentManager, authz, storage, now = () => Date.now(), log = console.log } = {}) {
+        if (!fileAgentManager) throw new Error('FileTransferGateway requires fileAgentManager');
+        this.fileAgentManager = fileAgentManager;
+        this.authz = authz;
+        this.storage = storage;
+        this.now = now;
+        this.log = log;
+    }
+
+    authorize(req) {
+        const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+        const agentId = asString(url.searchParams.get('agentId'), 256);
+        const connectionId = asString(url.searchParams.get('connectionId'), 256);
+        const session = req.authSession;
+        if (!session || !agentId) throw new Zft2ProtocolError('unauthorized', 'Missing file transfer session binding');
+        const user = this.storage?.getUserBrief?.(session.userId);
+        if (!user || user.status !== 'active') throw new Zft2ProtocolError('unauthorized', 'Account is unavailable');
+        const raw = connectionId ? this.storage?.getConnectionById?.(connectionId) : null;
+        if (connectionId && !raw) throw new Zft2ProtocolError('forbidden', 'Connection is unavailable');
+        if (raw) this.authz?.assertCan?.(user, 'fileRead', 'connection', connectionId, raw, { resourceExists: true });
+        if (!this.fileAgentManager.isAgentOwnedByUser(agentId, user)) throw new Zft2ProtocolError('forbidden', 'Agent is not accessible to this user');
+        const canWrite = raw
+            ? this.authz?.can?.(user, 'fileWrite', 'connection', connectionId, raw) !== false
+            : true;
+        return { user, agentId, connectionId, canWrite };
+    }
+
+    handleConnection(ws, req) {
+        let binding;
+        try {
+            binding = this.authorize(req);
+        } catch (error) {
+            try { ws.close(1008, error.code || 'unauthorized'); } catch {}
+            return;
+        }
+        const state = { inflight: new Map(), inflightBytes: 0, closed: false };
+        const failAll = () => {
+            if (state.closed) return;
+            state.closed = true;
+            for (const pending of state.inflight.values()) pending.cancel?.();
+            state.inflight.clear();
+            state.inflightBytes = 0;
+        };
+        ws.on('close', failAll);
+        ws.on('error', failAll);
+        ws.on('message', (raw, isBinary) => {
+            if (!isBinary || state.closed) {
+                try { ws.close(1003, 'ZFT2 requires binary frames'); } catch {}
+                return;
+            }
+            this._handleFrame(ws, binding, state, raw).catch((error) => {
+                this.log('[file-transfer] request failed:', error.message);
+            });
+        });
+    }
+
+    async _handleFrame(ws, binding, state, raw) {
+        let frame;
+        try {
+            frame = decodeFrame(raw);
+            if (frame.flags & FLAG_RESPONSE) throw new Zft2ProtocolError('invalid_direction', 'Client sent a response frame');
+            if (frame.type === OP.CANCEL) {
+                const pending = state.inflight.get(asSafeInteger(frame.meta?.targetRequestId));
+                pending?.cancel?.();
+                return;
+            }
+            if (state.inflight.has(frame.requestId)) throw new Zft2ProtocolError('duplicate_request_id', 'Duplicate in-flight request id');
+            if (state.inflight.size >= MAX_INFLIGHT_REQUESTS || state.inflightBytes + frame.payload.length > MAX_INFLIGHT_BYTES) {
+                await sendBinary(ws, errorFrame(frame, 'busy', 'File transfer window is full', true));
+                return;
+            }
+            const mapped = mapRequest(frame);
+            if ((mapped.method === 'writeBinary' || ['mkdir', 'delete', 'rename', 'truncate'].includes(mapped.method)) && !binding.canWrite) {
+                await sendBinary(ws, errorFrame(frame, 'read_only', 'File transfer write capability is denied'));
+                return;
+            }
+            if (mapped.local) {
+                await sendBinary(ws, responseFrame(frame, { serverTime: this.now() }));
+                return;
+            }
+            const operation = this.fileAgentManager.callAgentV2(binding.agentId, mapped.method, mapped.params, REQUEST_TIMEOUT_MS);
+            state.inflight.set(frame.requestId, operation);
+            state.inflightBytes += frame.payload.length;
+            try {
+                const result = await operation.promise;
+                if (mapped.binaryRead) {
+                    await sendBinary(ws, responseFrame(frame, { bytesRead: result.length, eof: result.length === 0 }, result));
+                } else {
+                    await sendBinary(ws, responseFrame(frame, result || {}));
+                }
+            } catch (error) {
+                if (wsOpen(ws)) await sendBinary(ws, errorFrame(frame, error.code || 'internal_error', error.message || 'File transfer failed', error.code === 'timeout'));
+            } finally {
+                state.inflight.delete(frame.requestId);
+                state.inflightBytes = Math.max(0, state.inflightBytes - frame.payload.length);
+            }
+        } catch (error) {
+            if (wsOpen(ws)) {
+                await sendBinary(ws, errorFrame(frame, error.code || 'protocol_error', error.message || 'Invalid ZFT2 frame'));
+            }
+        }
+    }
+}
+
+module.exports = { FileTransferGateway, waitForSendBudget, sendBinary, mapRequest };

--- a/public/rdp-fs-provider.js
+++ b/public/rdp-fs-provider.js
@@ -1,79 +1,45 @@
-/**
- * rdp-fs-provider.js — File Agent Bridge for RDP Drive Redirection
+/*
+ * rdp-fs-provider.js — Agent presence and RDP drive lifecycle only.
  *
- * Provides the globalThis.zephyrRdpFs* functions that Go WASM's rdpefs.go
- * calls synchronously. Under the hood these use a SharedArrayBuffer-based
- * blocking pattern to call async HTTP RPCs to the server, which forwards
- * to the correct Flutter Agent via WebSocket.
- *
- * Also manages SSE subscription for live agent status and provides UI hooks.
+ * File bytes never cross the page thread. Go WASM in rdp-worker.js talks to
+ * /file-transfer over ZFT2 binary WebSocket and completes RDPEFS IRPs
+ * asynchronously. This module intentionally contains no sync XHR fallback.
  */
 
-/* ─── Configuration ─────────────────────────────────────────────── */
 const RPC_BASE = '/api/rdp/file-agents';
-const RPC_TIMEOUT = 30000;
-// Binary read path can use larger chunks because it avoids base64/JSON payload
-// inflation.  JSON fallback stays conservative to avoid the old multi-GB copy
-// disconnects caused by oversized base64 responses.
-const READ_BINARY_AHEAD_BYTES = 1 * 1024 * 1024;
-const READ_BINARY_RPC_MAX_BYTES = 1 * 1024 * 1024;
-const READ_JSON_RPC_MAX_BYTES = 512 * 1024;
-const READ_CACHE_MAX_HANDLES = 8;
-
-/* ─── State ─────────────────────────────────────────────────────── */
-let onlineAgents = [];         // [{agentId, deviceName, platform, online, readOnly, ...}]
-let attachedAgents = new Map(); // agentId → {driveName, readOnly, deviceId}
+let onlineAgents = [];
+let attachedAgents = new Map();
 let eventSource = null;
-let onAgentsChanged = null;    // callback(agents[])
-let readCache = new Map();     // `${agentId}:${handle}` → { offset, data: Uint8Array, ts }
-let binaryReadUnsupported = new Set(); // agentId values that returned 426 for binary read
-let binaryReadCooldownUntil = new Map(); // agentId → timestamp; temporary fallback after binary transport failures
-
-/* ─── SSE Subscription ──────────────────────────────────────────── */
+let onAgentsChanged = null;
 
 export function subscribeAgentEvents(callback) {
     onAgentsChanged = callback;
     if (eventSource) { eventSource.close(); eventSource = null; }
-
     eventSource = new EventSource(`${RPC_BASE}/events`);
-
-    eventSource.addEventListener('agent_list', (e) => {
+    eventSource.addEventListener('agent_list', (event) => {
         try {
-            const data = JSON.parse(e.data);
-            onlineAgents = data.agents || [];
-            if (onAgentsChanged) onAgentsChanged(onlineAgents);
+            onlineAgents = JSON.parse(event.data).agents || [];
+            onAgentsChanged?.([...onlineAgents]);
         } catch {}
     });
-
-    eventSource.addEventListener('file_agent_online', (e) => {
+    eventSource.addEventListener('file_agent_online', (event) => {
         try {
-            const data = JSON.parse(e.data);
-            const agent = data.agent;
+            const agent = JSON.parse(event.data).agent;
             if (!agent) return;
-            const idx = onlineAgents.findIndex(a => a.agentId === agent.agentId);
-            if (idx >= 0) onlineAgents[idx] = agent;
+            const index = onlineAgents.findIndex((item) => item.agentId === agent.agentId);
+            if (index >= 0) onlineAgents[index] = agent;
             else onlineAgents.push(agent);
-            if (onAgentsChanged) onAgentsChanged([...onlineAgents]);
+            onAgentsChanged?.([...onlineAgents]);
         } catch {}
     });
-
-    eventSource.addEventListener('file_agent_offline', (e) => {
+    eventSource.addEventListener('file_agent_offline', (event) => {
         try {
-            const data = JSON.parse(e.data);
-            const agentId = data.agentId;
-            onlineAgents = onlineAgents.filter(a => a.agentId !== agentId);
-            if (onAgentsChanged) onAgentsChanged([...onlineAgents]);
-
-            // Auto-detach if was attached
-            if (attachedAgents.has(agentId)) {
-                detachDrive(agentId);
-            }
+            const agentId = JSON.parse(event.data).agentId;
+            onlineAgents = onlineAgents.filter((agent) => agent.agentId !== agentId);
+            if (attachedAgents.has(agentId)) detachDrive(agentId);
+            onAgentsChanged?.([...onlineAgents]);
         } catch {}
     });
-
-    eventSource.onerror = () => {
-        // Reconnect is automatic with EventSource
-    };
 }
 
 export function unsubscribeAgentEvents() {
@@ -81,28 +47,19 @@ export function unsubscribeAgentEvents() {
     onAgentsChanged = null;
 }
 
-export function getOnlineAgents() {
-    return [...onlineAgents];
-}
-
-export function getAttachedAgents() {
-    return new Map(attachedAgents);
-}
-
-export function resetAttachedDriveState() {
-    attachedAgents.clear();
-}
+export function getOnlineAgents() { return [...onlineAgents]; }
+export function getAttachedAgents() { return new Map(attachedAgents); }
+export function resetAttachedDriveState() { attachedAgents.clear(); }
 
 function safeDriveName(name, fallback = 'AGENT') {
     const raw = String(name || fallback).trim() || fallback;
-    const ascii = raw.replace(/[^A-Za-z0-9]/g, '').slice(0, 8);
-    return ascii || fallback;
+    return raw.replace(/[^A-Za-z0-9]/g, '').slice(0, 8) || fallback;
 }
 
 export function syncAgentDrives({ enabled = true } = {}) {
     if (!enabled || typeof globalThis.rdpFsAttachDrive !== 'function') return;
     for (const agent of onlineAgents) {
-        if (!agent?.agentId || agent.online === false) continue;
+        if (!agent?.agentId || agent.online === false || Number(agent.protocolVersion || 1) < 2) continue;
         const driveName = safeDriveName(agent.deviceName || agent.shareName || agent.tokenName || 'AGENT');
         attachDrive(agent.agentId, driveName, agent.readOnly !== false);
     }
@@ -110,250 +67,20 @@ export function syncAgentDrives({ enabled = true } = {}) {
 
 export function attachDrive(agentId, driveName, readOnly) {
     if (attachedAgents.has(agentId)) return true;
-
-    // Call Go WASM to register the drive. If the current RDP session has not
-    // created its RDPEFS handler yet, do not mark it attached; a later
-    // rdpOnReady/SSE sync will retry against the fresh handler.
     if (typeof globalThis.rdpFsAttachDrive !== 'function') return false;
     const deviceId = globalThis.rdpFsAttachDrive(agentId, driveName, readOnly);
     if (deviceId === null || deviceId === undefined || deviceId === false) return false;
-
     attachedAgents.set(agentId, { driveName, readOnly, deviceId });
-    console.info(`[rdp-fs] attached drive: ${driveName} → ${agentId} (${deviceId})`);
+    console.info(`[rdp-fs] attached ZFT2 drive: ${driveName} → ${agentId} (${deviceId})`);
     return true;
 }
 
 export function detachDrive(agentId) {
     if (!attachedAgents.has(agentId)) return;
-
-    // Call Go WASM to remove the drive
-    if (typeof globalThis.rdpFsDetachDrive === 'function') {
-        globalThis.rdpFsDetachDrive(agentId);
-    }
-
+    if (typeof globalThis.rdpFsDetachDrive === 'function') globalThis.rdpFsDetachDrive(agentId);
     attachedAgents.delete(agentId);
-    console.info(`[rdp-fs] detached drive: ${agentId}`);
 }
 
 export function detachAllDrives() {
-    for (const agentId of [...attachedAgents.keys()]) {
-        detachDrive(agentId);
-    }
-}
-
-/* ─── Synchronous RPC helpers (called from Go WASM) ─────────────
- *
- * Go WASM rdpefs.go calls these via js.Global().Call(). Since Go can only
- * do synchronous calls into JS, these must return results synchronously.
- * We use XMLHttpRequest (synchronous mode, which is allowed in workers and
- * WASM contexts) to achieve this. This is intentional and necessary.
- *
- * The server endpoint /api/rdp/file-agents/:agentId/rpc forwards the
- * request to the correct Agent via WebSocket and waits for the response.
- */
-
-function syncRpc(agentId, method, params) {
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', `${RPC_BASE}/${agentId}/rpc`, false); // synchronous
-    xhr.setRequestHeader('Content-Type', 'application/json');
-    // Synchronous XMLHttpRequest cannot use timeout in a document context;
-    // the server-side Agent RPC has its own timeout.
-    try {
-        xhr.send(JSON.stringify({ method, params }));
-    } catch (e) {
-        console.warn(`[rdp-fs] RPC error: ${method}`, e);
-        return null;
-    }
-    if (xhr.status !== 200) {
-        console.warn(`[rdp-fs] RPC failed: ${method} → ${xhr.status}`);
-        return null;
-    }
-    try {
-        const resp = JSON.parse(xhr.responseText);
-        if (!resp.ok) {
-            console.warn(`[rdp-fs] RPC error: ${method}`, resp.error);
-            return null;
-        }
-        return resp.result;
-    } catch {
-        return null;
-    }
-}
-
-function cacheKey(agentId, handle) {
-    return `${agentId}:${handle}`;
-}
-
-function trimReadCache() {
-    if (readCache.size <= READ_CACHE_MAX_HANDLES) return;
-    const entries = [...readCache.entries()].sort((a, b) => (a[1].ts || 0) - (b[1].ts || 0));
-    while (readCache.size > READ_CACHE_MAX_HANDLES && entries.length) {
-        readCache.delete(entries.shift()[0]);
-    }
-}
-
-function clearReadCache(agentId, handle) {
-    if (handle) readCache.delete(cacheKey(agentId, handle));
-}
-
-function decodeBase64Bytes(dataBase64) {
-    if (!dataBase64 || dataBase64.length === 0) return new Uint8Array(0);
-    const binaryStr = atob(dataBase64);
-    const bytes = new Uint8Array(binaryStr.length);
-    for (let i = 0; i < binaryStr.length; i++) {
-        bytes[i] = binaryStr.charCodeAt(i);
-    }
-    return bytes;
-}
-
-function rpcReadBytesBinary(agentId, handle, offset, length) {
-    if (binaryReadUnsupported.has(agentId)) return null;
-    const cooldownUntil = binaryReadCooldownUntil.get(agentId) || 0;
-    if (Date.now() < cooldownUntil) return null;
-    const xhr = new XMLHttpRequest();
-    const url = `${RPC_BASE}/${agentId}/rpc/read-binary?handle=${encodeURIComponent(handle)}&offset=${encodeURIComponent(offset)}&length=${encodeURIComponent(length)}`;
-    xhr.open('POST', url, false);
-    // responseType='arraybuffer' is not allowed for synchronous XHR on some
-    // browsers/main-thread contexts.  x-user-defined preserves byte values in
-    // responseText so we can reconstruct Uint8Array without base64/JSON.
-    if (xhr.overrideMimeType) xhr.overrideMimeType('text/plain; charset=x-user-defined');
-    try {
-        xhr.send(null);
-    } catch (e) {
-        console.warn('[rdp-fs] binary read transport error', e);
-        return null;
-    }
-    if (xhr.status === 426) {
-        binaryReadUnsupported.add(agentId);
-        return null;
-    }
-    if (xhr.status !== 200) {
-        console.warn(`[rdp-fs] binary read failed → ${xhr.status}; falling back briefly to JSON`);
-        binaryReadCooldownUntil.set(agentId, Date.now() + 15000);
-        return null;
-    }
-    const text = xhr.responseText || '';
-    const bytes = new Uint8Array(text.length);
-    for (let i = 0; i < text.length; i++) bytes[i] = text.charCodeAt(i) & 0xFF;
-    return bytes;
-}
-
-function rpcReadBytesJson(agentId, handle, offset, length) {
-    const safeLength = Math.min(Math.max(0, Number(length) || 0), READ_JSON_RPC_MAX_BYTES);
-    const result = syncRpc(agentId, 'read', { handle, offset, length: safeLength });
-    if (!result) return null;
-    return decodeBase64Bytes(result.dataBase64);
-}
-
-function cachedRead(agentId, handle, offset, length) {
-    const key = cacheKey(agentId, handle);
-    const cached = readCache.get(key);
-    const wantStart = Number(offset) || 0;
-    const wantLen = Math.max(0, Number(length) || 0);
-    if (wantLen === 0) return new Uint8Array(0);
-    const wantEnd = wantStart + wantLen;
-    if (cached && wantStart >= cached.offset && wantEnd <= cached.offset + cached.data.length) {
-        cached.ts = Date.now();
-        return cached.data.subarray(wantStart - cached.offset, wantEnd - cached.offset);
-    }
-
-    // New Agent: binary fast path, larger chunk for local/LAN throughput.
-    const binaryLen = Math.min(Math.max(wantLen, READ_BINARY_AHEAD_BYTES), READ_BINARY_RPC_MAX_BYTES);
-    let bytes = rpcReadBytesBinary(agentId, handle, wantStart, binaryLen);
-
-    // Old Agent or temporary binary failure: conservative JSON/base64 fallback.
-    if (bytes === null) {
-        const jsonLen = Math.min(Math.max(wantLen, READ_JSON_RPC_MAX_BYTES), READ_JSON_RPC_MAX_BYTES);
-        bytes = rpcReadBytesJson(agentId, handle, wantStart, jsonLen);
-    }
-
-    if (bytes === null) return null;
-    readCache.set(key, { offset: wantStart, data: bytes, ts: Date.now() });
-    trimReadCache();
-    return bytes.subarray(0, Math.min(wantLen, bytes.length));
-}
-
-/* ─── Global functions for Go WASM ──────────────────────────────
- * These are set on globalThis so rdpefs.go can call them via
- * js.Global().Call("zephyrRdpFsList", ...) etc.
- */
-
-globalThis.zephyrRdpFsList = function(agentId, path) {
-    const result = syncRpc(agentId, 'list', { path: path || '/' });
-    if (!result || !result.entries) return null;
-    return result.entries;
-};
-
-globalThis.zephyrRdpFsStat = function(agentId, path) {
-    const result = syncRpc(agentId, 'stat', { path: path || '/' });
-    // Return null for not-found so Go can send STATUS_NO_SUCH_FILE.
-    return result || null;
-};
-
-globalThis.zephyrRdpFsOpen = function(agentId, path, mode) {
-    const result = syncRpc(agentId, 'open', { path, mode: mode || 'read' });
-    // Return '' (empty string) on failure so Go detects the missing handle.
-    if (!result || !result.handle) return '';
-    return result.handle;
-};
-
-globalThis.zephyrRdpFsRead = function(agentId, handle, offset, length) {
-    const bytes = cachedRead(agentId, handle, offset, length);
-    if (bytes === null) return null;
-    // Empty read (EOF) — return empty array, NOT null.
-    // Returning null would cause rdpefs.go to send STATUS_UNSUCCESSFUL,
-    // which Windows surfaces as 0x8007048F "device not connected" on copy.
-    return bytes;
-};
-
-globalThis.zephyrRdpFsWrite = function(agentId, handle, offset, uint8Data) {
-    clearReadCache(agentId, handle);
-    // Encode to base64
-    let binary = '';
-    for (let i = 0; i < uint8Data.length; i++) {
-        binary += String.fromCharCode(uint8Data[i]);
-    }
-    const dataBase64 = btoa(binary);
-    const result = syncRpc(agentId, 'write', { handle, offset, dataBase64 });
-    if (!result) return 0;
-    return result.bytesWritten || 0;
-};
-
-globalThis.zephyrRdpFsClose = function(agentId, handle) {
-    clearReadCache(agentId, handle);
-    syncRpc(agentId, 'close', { handle });
-};
-
-globalThis.zephyrRdpFsMkdir = function(agentId, path) {
-    const result = syncRpc(agentId, 'mkdir', { path });
-    return result !== null;
-};
-
-globalThis.zephyrRdpFsDelete = function(agentId, path) {
-    const result = syncRpc(agentId, 'delete', { path, recursive: false });
-    return result !== null;
-};
-
-globalThis.zephyrRdpFsRename = function(agentId, oldPath, newPath) {
-    const result = syncRpc(agentId, 'rename', { oldPath, newPath });
-    return result !== null;
-};
-
-globalThis.zephyrRdpFsTruncate = function(agentId, path, size) {
-    const result = syncRpc(agentId, 'truncate', { path, size });
-    return result !== null;
-};
-
-/* ─── Token management ──────────────────────────────────────────── */
-
-export async function getAgentToken() {
-    const resp = await fetch('/api/rdp/file-agent-token');
-    const data = await resp.json();
-    return data.ok ? data.token : null;
-}
-
-export async function regenerateAgentToken() {
-    const resp = await fetch('/api/rdp/file-agent-token/regenerate', { method: 'POST' });
-    const data = await resp.json();
-    return data.ok ? data.token : null;
+    for (const agentId of [...attachedAgents.keys()]) detachDrive(agentId);
 }

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -11,10 +11,10 @@
  */
 
 import { applyZephyrColorScheme } from './theme-runtime.js?v=20260630-rdp-engine';
-import { createRdpDiagnostics } from './rdp-diagnostics.js?v=20260719-xfile3';
-import { RdpWorkerBridge } from './rdp-worker-bridge.js?v=20260719-xfile3';
-import { RdpTouchController, rdpHaptic } from './rdp-touch.js?v=20260719-xfile3';
-import { RdpMobileKeyboard } from './rdp-mobile-keyboard.js?v=20260719-xfile3';
+import { createRdpDiagnostics } from './rdp-diagnostics.js?v=20260720-zft2';
+import { RdpWorkerBridge } from './rdp-worker-bridge.js?v=20260720-zft2';
+import { RdpTouchController, rdpHaptic } from './rdp-touch.js?v=20260720-zft2';
+import { RdpMobileKeyboard } from './rdp-mobile-keyboard.js?v=20260720-zft2';
 import {
     setupPanelInteractions,
     toggleFloatingPanel,
@@ -23,14 +23,14 @@ import {
     bringPanelToFront,
     applyPanelLayout,
     closePanelLayoutMenu,
-} from './floating-panel.js?v=20260719-xfile3';
+} from './floating-panel.js?v=20260720-zft2';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,
     syncAgentDrives,
     detachAllDrives,
     resetAttachedDriveState,
-} from './rdp-fs-provider.js?v=20260708-rdpefs-binread3';
+} from './rdp-fs-provider.js?v=20260720-zft2';
 
 const $ = (sel) => document.querySelector(sel);
 const urlParams = new URLSearchParams(location.search);
@@ -1024,7 +1024,7 @@ async function connect() {
         proxyWsUrl(), host, port, domain, user, password,
         width, height, false,
         !!params.rdpMicrophone, !!params.rdpLocation, storageEnabled, !!params.rdpCamera,
-        quality, fps,
+        quality, fps, connectionId,
     ));
 }
 
@@ -2389,13 +2389,13 @@ window.addEventListener('message', (e) => {
         if (typeof rdpCanvas?.transferControlToOffscreen !== 'function') missing.push('OFFSCREEN_CANVAS_TRANSFER_UNAVAILABLE');
         if (missing.length) throw new Error(`WORKER_GPU_REQUIRED:${missing.join('+')}`);
 
-        const probe = await RdpWorkerBridge.probe({ url: './rdp-worker-probe.js?v=20260719-xfile3' });
+        const probe = await RdpWorkerBridge.probe({ url: './rdp-worker-probe.js?v=20260720-zft2' });
         rdpDiag.workerProbe = probe;
         if (!probe.supported) {
             throw new Error(`WORKER_GPU_PROBE_FAILED:${probe.reason || 'unknown'}:${probe.stage || 'unknown'}:${probe.error || ''}`);
         }
 
-        rdpWorkerBridge = new RdpWorkerBridge(new Worker('./rdp-worker.js?v=20260719-xfile3', { type: 'module' }));
+        rdpWorkerBridge = new RdpWorkerBridge(new Worker('./rdp-worker.js?v=20260720-zft2', { type: 'module' }));
         rdpWorkerBridge.installGlobals(window);
         await rdpWorkerBridge.setLocalFiles(rdpStorageFiles, { notify: false });
         const capabilities = await rdpWorkerBridge.init(rdpCanvas, { width: rdpWidth, height: rdpHeight });

--- a/public/rdp-wasm-runtime.js
+++ b/public/rdp-wasm-runtime.js
@@ -1,4 +1,4 @@
-const DEFAULT_RUNTIME_URL = './vendor/rdp-wasm/wasm_exec.mjs?v=20260719-xfile3';
+const DEFAULT_RUNTIME_URL = './vendor/rdp-wasm/wasm_exec.mjs?v=20260720-zft2';
 
 export async function loadGoRuntime({ runtimeUrl = DEFAULT_RUNTIME_URL, importer = (url) => import(url), pipeline = 'unknown' } = {}) {
     let runtime;
@@ -15,7 +15,7 @@ export async function loadGoRuntime({ runtimeUrl = DEFAULT_RUNTIME_URL, importer
 }
 
 export async function instantiateGoWasm(GoRuntime, {
-    wasmUrl = './vendor/rdp-wasm/main.wasm?v=20260719-xfile3',
+    wasmUrl = './vendor/rdp-wasm/main.wasm?v=20260720-zft2',
     fetchImpl = globalThis.fetch,
     pipeline = 'unknown',
 } = {}) {

--- a/public/rdp-worker-bridge.js
+++ b/public/rdp-worker-bridge.js
@@ -20,9 +20,6 @@ export class RdpWorkerBridge {
         this.bootTimer = null;
         this.bootHistory = [];
         this.ready = new Promise((resolve, reject) => { this.resolveReady = resolve; this.rejectReady = reject; });
-        const sabAvailable = typeof SharedArrayBuffer === 'function';
-        this.syncControl = sabAvailable ? new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4) : null;
-        this.syncData = sabAvailable ? new SharedArrayBuffer(syncBytes) : null;
         this.worker.addEventListener('message', (event) => this._message(event.data));
         this.worker.addEventListener('error', (event) => {
             const error = new Error(event.message || 'RDP Worker failed');
@@ -60,10 +57,6 @@ export class RdpWorkerBridge {
         let offscreen = canvas;
         if (typeof canvas?.transferControlToOffscreen === 'function') offscreen = canvas.transferControlToOffscreen();
         const payload = { type: 'init', canvas: offscreen, options };
-        if (this.syncControl && this.syncData) {
-            payload.syncControl = this.syncControl;
-            payload.syncData = this.syncData;
-        }
         this.worker.postMessage(payload, [offscreen]);
         this.bootTimer = setTimeout(() => {
             if (this.readySettled) return;
@@ -195,49 +188,5 @@ export class RdpWorkerBridge {
             }
             return;
         }
-        if (message?.type === 'sync-rpc') this._syncRpc(message);
-    }
-
-    _syncRpc(message) {
-        if (!this.syncControl || !this.syncData) {
-            console.warn('[rdp-worker] sync RPC ignored because SharedArrayBuffer is unavailable', message?.name || 'unknown');
-            return;
-        }
-        const control = new Int32Array(this.syncControl);
-        const output = new Uint8Array(this.syncData);
-        try {
-            const fn = globalThis[message.name];
-            if (typeof fn !== 'function') throw new Error(`page RPC ${message.name} is unavailable`);
-            let args = message.args || [];
-            if (message.name === 'zephyrRdpFsWrite' && args.length >= 4) {
-                // Worker->page binary arguments arrive as structured-cloned
-                // Uint8Array and stay binary; never JSON/base64 encode them.
-                args = [...args];
-                args[3] = args[3] instanceof Uint8Array ? args[3] : new Uint8Array(args[3]);
-            }
-            const result = fn(...args);
-            if (result && typeof result.then === 'function') throw new Error(`page RPC ${message.name} must be synchronous`);
-            if (result instanceof Uint8Array || result instanceof ArrayBuffer) {
-                const bytes = result instanceof Uint8Array ? result : new Uint8Array(result);
-                if (bytes.byteLength > output.byteLength) throw new Error(`page RPC response exceeds ${output.byteLength} bytes`);
-                output.set(bytes);
-                Atomics.store(control, 1, 1);
-                Atomics.store(control, 2, bytes.byteLength);
-            } else {
-                const bytes = new TextEncoder().encode(JSON.stringify(result ?? null));
-                if (bytes.byteLength > output.byteLength) throw new Error(`page RPC response exceeds ${output.byteLength} bytes`);
-                output.set(bytes);
-                Atomics.store(control, 1, 0);
-                Atomics.store(control, 2, bytes.byteLength);
-            }
-            Atomics.store(control, 3, 0);
-        } catch (error) {
-            const bytes = new TextEncoder().encode(error.message || String(error));
-            output.set(bytes.subarray(0, output.byteLength));
-            Atomics.store(control, 2, Math.min(bytes.byteLength, output.byteLength));
-            Atomics.store(control, 3, 1);
-        }
-        Atomics.store(control, 0, 1);
-        Atomics.notify(control, 0, 1);
     }
 }

--- a/public/rdp-worker.js
+++ b/public/rdp-worker.js
@@ -1,14 +1,12 @@
-import { RdpGpuSurfaceCompositor } from './rdp-renderer.js?v=20260719-xfile3';
-import { RdpAvc420Decoder, RdpAvc444Decoder } from './rdp-video-decoder.js?v=20260719-xfile3';
-import { createSynchronousBitmapUploader } from './rdp-wasm-memory.js?v=20260719-xfile3';
-import { createWorkerFrameScheduler } from './rdp-worker-frame-scheduler.js?v=20260719-xfile3';
-import { loadGoRuntime, instantiateGoWasm } from './rdp-wasm-runtime.js?v=20260719-xfile3';
+import { RdpGpuSurfaceCompositor } from './rdp-renderer.js?v=20260720-zft2';
+import { RdpAvc420Decoder, RdpAvc444Decoder } from './rdp-video-decoder.js?v=20260720-zft2';
+import { createSynchronousBitmapUploader } from './rdp-wasm-memory.js?v=20260720-zft2';
+import { createWorkerFrameScheduler } from './rdp-worker-frame-scheduler.js?v=20260720-zft2';
+import { loadGoRuntime, instantiateGoWasm } from './rdp-wasm-runtime.js?v=20260720-zft2';
 
 let compositor = null;
 let avc420 = null;
 let avc444 = null;
-let syncControl = null;
-let syncData = null;
 let initialized = false;
 let wasmReady = false;
 let localFiles = [];
@@ -42,14 +40,7 @@ const callbacksToPage = new Set([
     'rdpAudioPlay', 'rdpAudinStart', 'rdpAudinStop', 'rdpCameraStart',
     'rdpCameraStop', 'rdpLocationStart', 'rdpLocationStop',
 ]);
-const syncPageMethods = new Set([
-    'zephyrRdpFsList', 'zephyrRdpFsStat',
-    'zephyrRdpFsOpen', 'zephyrRdpFsRead', 'zephyrRdpFsWrite', 'zephyrRdpFsClose',
-    'zephyrRdpFsMkdir', 'zephyrRdpFsDelete', 'zephyrRdpFsRename', 'zephyrRdpFsTruncate',
-]);
-
 for (const name of callbacksToPage) globalThis[name] = (...args) => postMessage({ type: 'callback', name, args }, transferables(args));
-for (const name of syncPageMethods) globalThis[name] = (...args) => syncPageRpc(name, args);
 globalThis.rdpStorageGetFiles = () => localFiles.map(({ name, size, isDir }) => ({ name, size, isDir }));
 globalThis.rdpStorageReadFile = (name) => localFiles.find((file) => file.name === name)?.data || null;
 
@@ -62,23 +53,6 @@ function transferables(values) {
     return list;
 }
 
-function syncPageRpc(name, args) {
-    if (!syncControl || !syncData) throw new Error('Worker sync RPC is unavailable');
-    const control = new Int32Array(syncControl);
-    Atomics.store(control, 0, 0);
-    Atomics.store(control, 1, 0);
-    Atomics.store(control, 2, 0);
-    Atomics.store(control, 3, 0);
-    postMessage({ type: 'sync-rpc', name, args });
-    const wait = Atomics.wait(control, 0, 0, 30000);
-    if (wait === 'timed-out') throw new Error(`page RPC ${name} timed out`);
-    const length = Atomics.load(control, 2);
-    const bytes = new Uint8Array(syncData, 0, length).slice();
-    if (Atomics.load(control, 3)) throw new Error(new TextDecoder().decode(bytes));
-    if (Atomics.load(control, 1) === 1) return bytes;
-    return JSON.parse(new TextDecoder().decode(bytes) || 'null');
-}
-
 async function loadGoWasm() {
     bootStage('wasm-exec-loading');
     const GoRuntime = await loadGoRuntime({ pipeline: 'worker-gpu-v2' });
@@ -86,7 +60,7 @@ async function loadGoWasm() {
     bootStage('wasm-fetching');
     bootStage('wasm-instantiating');
     const { go, result } = await instantiateGoWasm(GoRuntime, {
-        wasmUrl: './vendor/rdp-wasm/main.wasm?v=20260719-xfile3',
+        wasmUrl: './vendor/rdp-wasm/main.wasm?v=20260720-zft2',
         pipeline: 'worker-gpu-v2',
     });
     if (result.instance.exports.mem) {
@@ -295,8 +269,6 @@ onmessage = async ({ data: message }) => {
         if (message.type === 'init') {
             if (initialized) throw new Error('RDP Worker already initialized');
             initialized = true;
-            syncControl = message.syncControl;
-            syncData = message.syncData;
             bootStage('renderer-starting');
             setupRenderer(message.canvas);
             bootStage('renderer-ready');

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -214,7 +214,7 @@
             </div>
         </div>
     </div>
-    <script src="rdp-wasm-client.js?v=20260719-xfile3" type="module"></script>
+    <script src="rdp-wasm-client.js?v=20260720-zft2" type="module"></script>
     <script>
     /* Auto-report H264 debug logs to server after 8 seconds */
     setTimeout(async () => {

--- a/rdp-wasm/file_transfer_client_js.go
+++ b/rdp-wasm/file_transfer_client_js.go
@@ -38,6 +38,8 @@ type agentTransferConn struct {
 	agentID   string
 	ws        js.Value
 	ready     chan error
+	opened    chan struct{}
+	openErr   error
 	pending   map[uint32]*pendingFileTransfer
 	nextID    uint32
 	mu        sync.Mutex
@@ -60,9 +62,16 @@ func (t *wsFileTransfer) connection(agentID string) (*agentTransferConn, error) 
 	}
 	if conn := t.connections[agentID]; conn != nil {
 		t.mu.Unlock()
+		<-conn.opened
+		conn.mu.Lock()
+		err := conn.openErr
+		conn.mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
 		return conn, nil
 	}
-	conn := &agentTransferConn{parent: t, agentID: agentID, ready: make(chan error, 1), pending: make(map[uint32]*pendingFileTransfer), nextID: 1}
+	conn := &agentTransferConn{parent: t, agentID: agentID, ready: make(chan error, 1), opened: make(chan struct{}), pending: make(map[uint32]*pendingFileTransfer), nextID: 1}
 	t.connections[agentID] = conn
 	t.mu.Unlock()
 	if err := conn.open(); err != nil {
@@ -74,7 +83,13 @@ func (t *wsFileTransfer) connection(agentID string) (*agentTransferConn, error) 
 	return conn, nil
 }
 
-func (c *agentTransferConn) open() error {
+func (c *agentTransferConn) open() (err error) {
+	defer func() {
+		c.mu.Lock()
+		c.openErr = err
+		c.mu.Unlock()
+		close(c.opened)
+	}()
 	url := c.parent.baseURL + "/file-transfer?agentId=" + js.Global().Get("encodeURIComponent").Invoke(c.agentID).String() + "&connectionId=" + js.Global().Get("encodeURIComponent").Invoke(c.parent.connectionID).String()
 	ws := js.Global().Get("WebSocket").New(url)
 	ws.Set("binaryType", "arraybuffer")

--- a/rdp-wasm/file_transfer_client_js.go
+++ b/rdp-wasm/file_transfer_client_js.go
@@ -1,0 +1,281 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"syscall/js"
+	"time"
+)
+
+const (
+	fileTransferMaxInflight = 8
+	fileTransferTimeout     = 60 * time.Second
+	fileTransferSendHigh    = 8 * 1024 * 1024
+	fileTransferSendLow     = 2 * 1024 * 1024
+)
+
+type pendingFileTransfer struct {
+	result chan fileTransferResult
+}
+
+type fileTransferResult struct {
+	response fileTransferResponse
+	err      error
+}
+
+type wsFileTransfer struct {
+	baseURL      string
+	connectionID string
+	mu           sync.Mutex
+	connections  map[string]*agentTransferConn
+	closed       bool
+}
+
+type agentTransferConn struct {
+	parent    *wsFileTransfer
+	agentID   string
+	ws        js.Value
+	ready     chan error
+	pending   map[uint32]*pendingFileTransfer
+	nextID    uint32
+	mu        sync.Mutex
+	closed    bool
+	onOpen    js.Func
+	onError   js.Func
+	onMessage js.Func
+	onClose   js.Func
+}
+
+func newWSFileTransfer(baseURL, connectionID string) fileTransfer {
+	return &wsFileTransfer{baseURL: baseURL, connectionID: connectionID, connections: make(map[string]*agentTransferConn)}
+}
+
+func (t *wsFileTransfer) connection(agentID string) (*agentTransferConn, error) {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return nil, fmt.Errorf("file transfer client is closed")
+	}
+	if conn := t.connections[agentID]; conn != nil {
+		t.mu.Unlock()
+		return conn, nil
+	}
+	conn := &agentTransferConn{parent: t, agentID: agentID, ready: make(chan error, 1), pending: make(map[uint32]*pendingFileTransfer), nextID: 1}
+	t.connections[agentID] = conn
+	t.mu.Unlock()
+	if err := conn.open(); err != nil {
+		t.mu.Lock()
+		delete(t.connections, agentID)
+		t.mu.Unlock()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *agentTransferConn) open() error {
+	url := c.parent.baseURL + "/file-transfer?agentId=" + js.Global().Get("encodeURIComponent").Invoke(c.agentID).String() + "&connectionId=" + js.Global().Get("encodeURIComponent").Invoke(c.parent.connectionID).String()
+	ws := js.Global().Get("WebSocket").New(url)
+	ws.Set("binaryType", "arraybuffer")
+	c.ws = ws
+	c.onOpen = js.FuncOf(func(js.Value, []js.Value) any {
+		select {
+		case c.ready <- nil:
+		default:
+		}
+		return nil
+	})
+	c.onError = js.FuncOf(func(js.Value, []js.Value) any {
+		select {
+		case c.ready <- fmt.Errorf("file transfer websocket error"):
+		default:
+		}
+		return nil
+	})
+	c.onMessage = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		if len(args) == 0 {
+			return nil
+		}
+		data := args[0].Get("data")
+		arr := js.Global().Get("Uint8Array").New(data)
+		raw := make([]byte, arr.Length())
+		js.CopyBytesToGo(raw, arr)
+		frame, err := decodeZft2Frame(raw)
+		if err != nil {
+			c.failAll(err)
+			return nil
+		}
+		c.handleResponse(frame)
+		return nil
+	})
+	c.onClose = js.FuncOf(func(js.Value, []js.Value) any { c.failAll(fmt.Errorf("file transfer websocket closed")); return nil })
+	ws.Set("onopen", c.onOpen)
+	ws.Set("onerror", c.onError)
+	ws.Set("onmessage", c.onMessage)
+	ws.Set("onclose", c.onClose)
+	select {
+	case err := <-c.ready:
+		return err
+	case <-time.After(15 * time.Second):
+		c.close()
+		return fmt.Errorf("file transfer websocket open timeout")
+	}
+}
+
+func (t *wsFileTransfer) Request(agentID string, op byte, meta map[string]any, payload []byte) (fileTransferResponse, error) {
+	conn, err := t.connection(agentID)
+	if err != nil {
+		return fileTransferResponse{}, err
+	}
+	return conn.request(op, meta, payload)
+}
+
+func (c *agentTransferConn) request(op byte, meta map[string]any, payload []byte) (fileTransferResponse, error) {
+	c.mu.Lock()
+	if c.closed || c.ws.Get("readyState").Int() != 1 {
+		c.mu.Unlock()
+		return fileTransferResponse{}, fmt.Errorf("file transfer websocket is closed")
+	}
+	if len(c.pending) >= fileTransferMaxInflight {
+		c.mu.Unlock()
+		return fileTransferResponse{}, &zft2Error{Code: "busy", Message: "file transfer request window is full", Retryable: true}
+	}
+	id := c.nextID
+	c.nextID++
+	pending := &pendingFileTransfer{result: make(chan fileTransferResult, 1)}
+	c.pending[id] = pending
+	c.mu.Unlock()
+	frame, err := encodeZft2Frame(zft2Frame{Type: op, RequestID: id, Meta: meta, Payload: payload})
+	if err != nil {
+		c.removePending(id)
+		return fileTransferResponse{}, err
+	}
+	if err := c.waitSendBudget(len(frame)); err != nil {
+		c.removePending(id)
+		return fileTransferResponse{}, err
+	}
+	arr := js.Global().Get("Uint8Array").New(len(frame))
+	js.CopyBytesToJS(arr, frame)
+	c.ws.Call("send", arr)
+	select {
+	case result := <-pending.result:
+		return result.response, result.err
+	case <-time.After(fileTransferTimeout):
+		c.removePending(id)
+		c.sendCancel(id)
+		return fileTransferResponse{}, &zft2Error{Code: "timeout", Message: "file transfer request timed out", Retryable: true}
+	}
+}
+
+func (c *agentTransferConn) waitSendBudget(frameBytes int) error {
+	deadline := time.Now().Add(30 * time.Second)
+	for c.ws.Get("bufferedAmount").Int()+frameBytes > fileTransferSendHigh {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("file transfer websocket backpressure timeout")
+		}
+		time.Sleep(4 * time.Millisecond)
+		if c.ws.Get("bufferedAmount").Int() <= fileTransferSendLow {
+			break
+		}
+	}
+	return nil
+}
+
+func (c *agentTransferConn) handleResponse(frame zft2Frame) {
+	if frame.Flags&zft2FlagResponse == 0 {
+		return
+	}
+	c.mu.Lock()
+	pending := c.pending[frame.RequestID]
+	delete(c.pending, frame.RequestID)
+	c.mu.Unlock()
+	if pending == nil {
+		return
+	}
+	if frame.Flags&zft2FlagError != 0 {
+		pending.result <- fileTransferResult{err: &zft2Error{Code: stringMeta(frame.Meta, "code"), Message: stringMeta(frame.Meta, "message"), Retryable: boolMeta(frame.Meta, "retryable")}}
+		return
+	}
+	pending.result <- fileTransferResult{response: fileTransferResponse{Meta: frame.Meta, Payload: frame.Payload}}
+}
+
+func (c *agentTransferConn) sendCancel(targetID uint32) {
+	c.mu.Lock()
+	id := c.nextID
+	c.nextID++
+	c.mu.Unlock()
+	frame, _ := encodeZft2Frame(zft2Frame{Type: zft2Cancel, RequestID: id, Meta: map[string]any{"targetRequestId": targetID}})
+	if c.ws.Truthy() && c.ws.Get("readyState").Int() == 1 {
+		arr := js.Global().Get("Uint8Array").New(len(frame))
+		js.CopyBytesToJS(arr, frame)
+		c.ws.Call("send", arr)
+	}
+}
+
+func (c *agentTransferConn) removePending(id uint32) {
+	c.mu.Lock()
+	delete(c.pending, id)
+	c.mu.Unlock()
+}
+
+func (c *agentTransferConn) failAll(err error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	pending := c.pending
+	c.pending = make(map[uint32]*pendingFileTransfer)
+	c.mu.Unlock()
+	select {
+	case c.ready <- err:
+	default:
+	}
+	for _, p := range pending {
+		p.result <- fileTransferResult{err: err}
+	}
+}
+
+func (c *agentTransferConn) close() {
+	c.failAll(fmt.Errorf("file transfer connection closed"))
+	if c.ws.Truthy() {
+		c.ws.Call("close", 1000, "RDP session closed")
+	}
+}
+
+func (t *wsFileTransfer) CloseAgent(agentID string) {
+	t.mu.Lock()
+	conn := t.connections[agentID]
+	delete(t.connections, agentID)
+	t.mu.Unlock()
+	if conn != nil {
+		conn.close()
+	}
+}
+
+func (t *wsFileTransfer) Close() {
+	t.mu.Lock()
+	t.closed = true
+	list := t.connections
+	t.connections = make(map[string]*agentTransferConn)
+	t.mu.Unlock()
+	for _, conn := range list {
+		conn.close()
+	}
+}
+
+func stringMeta(meta map[string]any, key string) string {
+	if v, ok := meta[key].(string); ok {
+		return v
+	}
+	return ""
+}
+func boolMeta(meta map[string]any, key string) bool { v, _ := meta[key].(bool); return v }
+func int64Meta(meta map[string]any, key string) int64 {
+	if v, ok := meta[key].(float64); ok {
+		return int64(v)
+	}
+	return 0
+}

--- a/rdp-wasm/file_transfer_protocol.go
+++ b/rdp-wasm/file_transfer_protocol.go
@@ -1,0 +1,125 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	zft2Version         = 2
+	zft2HeaderBytes     = 20
+	zft2FlagError       = 0x0001
+	zft2FlagResponse    = 0x0002
+	zft2MaxMetaBytes    = 256 * 1024
+	zft2MaxPayloadBytes = 1024 * 1024
+)
+
+const (
+	zft2Open     byte = 0x01
+	zft2Read     byte = 0x02
+	zft2Write    byte = 0x03
+	zft2Close    byte = 0x04
+	zft2Stat     byte = 0x05
+	zft2List     byte = 0x06
+	zft2Mkdir    byte = 0x07
+	zft2Delete   byte = 0x08
+	zft2Rename   byte = 0x09
+	zft2Truncate byte = 0x0a
+	zft2Cancel   byte = 0x0b
+	zft2Ping     byte = 0x0c
+)
+
+type zft2Frame struct {
+	Type      byte
+	Flags     uint16
+	RequestID uint32
+	Meta      map[string]any
+	Payload   []byte
+}
+
+type zft2Error struct {
+	Code      string
+	Message   string
+	Retryable bool
+}
+
+func (e *zft2Error) Error() string {
+	if e == nil {
+		return "file transfer failed"
+	}
+	return e.Message
+}
+
+func encodeZft2Frame(frame zft2Frame) ([]byte, error) {
+	meta := frame.Meta
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("encode ZFT2 metadata: %w", err)
+	}
+	if len(metaBytes) > zft2MaxMetaBytes {
+		return nil, errors.New("ZFT2 metadata exceeds limit")
+	}
+	if len(frame.Payload) > zft2MaxPayloadBytes {
+		return nil, errors.New("ZFT2 payload exceeds limit")
+	}
+	out := make([]byte, zft2HeaderBytes+len(metaBytes)+len(frame.Payload))
+	copy(out[:4], []byte("ZFT2"))
+	out[4] = zft2Version
+	out[5] = frame.Type
+	binary.BigEndian.PutUint16(out[6:8], frame.Flags)
+	binary.BigEndian.PutUint32(out[8:12], frame.RequestID)
+	binary.BigEndian.PutUint32(out[12:16], uint32(len(metaBytes)))
+	binary.BigEndian.PutUint32(out[16:20], uint32(len(frame.Payload)))
+	copy(out[zft2HeaderBytes:], metaBytes)
+	copy(out[zft2HeaderBytes+len(metaBytes):], frame.Payload)
+	return out, nil
+}
+
+func decodeZft2Frame(raw []byte) (zft2Frame, error) {
+	if len(raw) < zft2HeaderBytes {
+		return zft2Frame{}, errors.New("truncated ZFT2 header")
+	}
+	if string(raw[:4]) != "ZFT2" {
+		return zft2Frame{}, errors.New("invalid ZFT2 magic")
+	}
+	if raw[4] != zft2Version {
+		return zft2Frame{}, fmt.Errorf("unsupported ZFT2 version %d", raw[4])
+	}
+	metaLen := int(binary.BigEndian.Uint32(raw[12:16]))
+	payloadLen := int(binary.BigEndian.Uint32(raw[16:20]))
+	if metaLen > zft2MaxMetaBytes || payloadLen > zft2MaxPayloadBytes {
+		return zft2Frame{}, errors.New("ZFT2 frame exceeds limit")
+	}
+	if len(raw) != zft2HeaderBytes+metaLen+payloadLen {
+		return zft2Frame{}, errors.New("ZFT2 frame length mismatch")
+	}
+	meta := map[string]any{}
+	if metaLen > 0 {
+		if err := json.Unmarshal(raw[zft2HeaderBytes:zft2HeaderBytes+metaLen], &meta); err != nil {
+			return zft2Frame{}, fmt.Errorf("invalid ZFT2 metadata: %w", err)
+		}
+	}
+	payload := append([]byte(nil), raw[zft2HeaderBytes+metaLen:]...)
+	return zft2Frame{
+		Type: raw[5], Flags: binary.BigEndian.Uint16(raw[6:8]),
+		RequestID: binary.BigEndian.Uint32(raw[8:12]), Meta: meta, Payload: payload,
+	}, nil
+}
+
+type fileTransferResponse struct {
+	Meta    map[string]any
+	Payload []byte
+}
+
+type fileTransfer interface {
+	Request(agentID string, op byte, meta map[string]any, payload []byte) (fileTransferResponse, error)
+	CloseAgent(agentID string)
+	Close()
+}

--- a/rdp-wasm/file_transfer_protocol_test.go
+++ b/rdp-wasm/file_transfer_protocol_test.go
@@ -1,0 +1,57 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestZft2FrameRoundTrip(t *testing.T) {
+	input := zft2Frame{
+		Type: zft2Write, Flags: zft2FlagResponse, RequestID: 0xfeedbeef,
+		Meta:    map[string]any{"handle": "h1", "offset": float64(4294967296)},
+		Payload: []byte{0, 1, 2, 253, 254, 255},
+	}
+	raw, err := encodeZft2Frame(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeZft2Frame(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Type != input.Type || decoded.Flags != input.Flags || decoded.RequestID != input.RequestID {
+		t.Fatalf("header mismatch: %#v", decoded)
+	}
+	if stringMeta(decoded.Meta, "handle") != "h1" || int64Meta(decoded.Meta, "offset") != 4294967296 {
+		t.Fatalf("metadata mismatch: %#v", decoded.Meta)
+	}
+	if !bytes.Equal(decoded.Payload, input.Payload) {
+		t.Fatalf("payload mismatch: %v", decoded.Payload)
+	}
+}
+
+func TestZft2RejectsMalformedFrames(t *testing.T) {
+	cases := [][]byte{nil, make([]byte, 19), append([]byte("BAD!"), make([]byte, 16)...)}
+	for i, raw := range cases {
+		if _, err := decodeZft2Frame(raw); err == nil {
+			t.Fatalf("case %d should fail", i)
+		}
+	}
+	valid, err := encodeZft2Frame(zft2Frame{Type: zft2Read, RequestID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid[19] = 1
+	if _, err := decodeZft2Frame(valid); err == nil {
+		t.Fatal("length mismatch should fail")
+	}
+}
+
+func TestZft2PayloadLimit(t *testing.T) {
+	_, err := encodeZft2Frame(zft2Frame{Type: zft2Write, RequestID: 1, Payload: make([]byte, zft2MaxPayloadBytes+1)})
+	if err == nil {
+		t.Fatal("oversized payload should fail")
+	}
+}

--- a/rdp-wasm/file_transfer_test_helpers_test.go
+++ b/rdp-wasm/file_transfer_test_helpers_test.go
@@ -10,6 +10,24 @@ type fakeFileTransfer struct {
 	blocked  chan struct{}
 }
 
+type recordingFileTransfer struct {
+	mu       sync.Mutex
+	reads    int
+	readData []byte
+}
+
+func (f *recordingFileTransfer) Request(_ string, op byte, _ map[string]any, _ []byte) (fileTransferResponse, error) {
+	if op == zft2Read {
+		f.mu.Lock()
+		f.reads++
+		f.mu.Unlock()
+		return fileTransferResponse{Payload: append([]byte(nil), f.readData...)}, nil
+	}
+	return fileTransferResponse{}, nil
+}
+func (f *recordingFileTransfer) CloseAgent(string) {}
+func (f *recordingFileTransfer) Close()            {}
+
 func (f *fakeFileTransfer) Request(_ string, op byte, _ map[string]any, _ []byte) (fileTransferResponse, error) {
 	f.mu.Lock()
 	f.requests = append(f.requests, op)

--- a/rdp-wasm/file_transfer_test_helpers_test.go
+++ b/rdp-wasm/file_transfer_test_helpers_test.go
@@ -1,0 +1,23 @@
+//go:build js && wasm
+
+package main
+
+import "sync"
+
+type fakeFileTransfer struct {
+	mu       sync.Mutex
+	requests []byte
+	blocked  chan struct{}
+}
+
+func (f *fakeFileTransfer) Request(_ string, op byte, _ map[string]any, _ []byte) (fileTransferResponse, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, op)
+	f.mu.Unlock()
+	if f.blocked != nil {
+		<-f.blocked
+	}
+	return fileTransferResponse{}, nil
+}
+func (f *fakeFileTransfer) CloseAgent(string) {}
+func (f *fakeFileTransfer) Close()            {}

--- a/rdp-wasm/main.go
+++ b/rdp-wasm/main.go
@@ -38,12 +38,16 @@ var (
 )
 
 func noteProtocol(event string) {
-	protocolDiagMu.Lock()
-	protocolDiag[event]++
-	protocolDiagMu.Unlock()
+	addProtocolCounter(event, 1)
 	if callback := js.Global().Get("rdpOnProtocolMilestone"); callback.Type() == js.TypeFunction {
 		callback.Invoke(event)
 	}
+}
+
+func addProtocolCounter(event string, value uint64) {
+	protocolDiagMu.Lock()
+	protocolDiag[event] += value
+	protocolDiagMu.Unlock()
 }
 
 func resetProtocolDiagnostics() {

--- a/rdp-wasm/main.go
+++ b/rdp-wasm/main.go
@@ -222,11 +222,15 @@ func jsConnect(_ js.Value, args []js.Value) any {
 	if len(args) >= 15 && args[14].Type() == js.TypeNumber {
 		fps = args[14].Int()
 	}
+	connectionID := ""
+	if len(args) >= 16 && args[15].Type() == js.TypeString {
+		connectionID = args[15].String()
+	}
 
 	reportStage("go-connect-dispatched")
 	go func() {
 		reportStage("go-connect-started")
-		if err := connect(proxyWsURL, host, port, domain, user, password, width, height, micEnabled, locationEnabled, storageEnabled, cameraEnabled, qualityMode, fps); err != nil {
+		if err := connect(proxyWsURL, host, port, domain, user, password, width, height, micEnabled, locationEnabled, storageEnabled, cameraEnabled, qualityMode, fps, connectionID); err != nil {
 			slog.Error("connect", "err", err)
 			js.Global().Call("rdpOnError", err.Error())
 		}
@@ -234,7 +238,7 @@ func jsConnect(_ js.Value, args []js.Value) any {
 	return nil
 }
 
-func connect(proxyWsURL, host, port, domain, user, password string, width, height int, micEnabled, locationEnabled, storageEnabled, cameraEnabled bool, qualityMode string, fps int) error {
+func connect(proxyWsURL, host, port, domain, user, password string, width, height int, micEnabled, locationEnabled, storageEnabled, cameraEnabled bool, qualityMode string, fps int, connectionID string) error {
 	hostPort := host + ":" + port
 
 	// Build WebSocket URL for the proxy. flow=v2 negotiates the text control
@@ -267,8 +271,13 @@ func connect(proxyWsURL, host, port, domain, user, password string, width, heigh
 	connectGen++
 	myGen := connectGen
 	oldClient := rdpClient
+	oldRdpefs := rdpefsHandler
 	rdpClient = g
+	rdpefsHandler = nil
 	clientMu.Unlock()
+	if oldRdpefs != nil {
+		oldRdpefs.Close()
+	}
 	if oldClient != nil {
 		oldClient.Close()
 	}
@@ -443,10 +452,16 @@ func connect(proxyWsURL, host, port, domain, user, password string, width, heigh
 	g.RegisterDvcHandler("Microsoft::Windows::RDS::Location", rdpelHandler)
 
 	// Register RDPEFS (storage/drive redirection) if enabled
-	rdpefsHandler = NewRdpefsHandler(storageEnabled)
+	nextRdpefs := NewRdpefsHandler(storageEnabled)
 	if storageEnabled {
-		g.SetRdpdrHandler(rdpefsHandler)
+		nextRdpefs.SetFileTransfer(newWSFileTransfer(proxyWsURL, connectionID))
+		g.SetRdpdrHandler(nextRdpefs)
 	}
+	clientMu.Lock()
+	if rdpClient == g && connectGen == myGen {
+		rdpefsHandler = nextRdpefs
+	}
+	clientMu.Unlock()
 
 	// Register MS-RDPECAM (camera redirection) if enabled
 	camEnumHandler = NewCamEnumeratorHandler(cameraEnabled)
@@ -462,7 +477,11 @@ func connect(proxyWsURL, host, port, domain, user, password string, width, heigh
 		if rdpClient == g {
 			rdpClient = nil
 		}
+		if rdpefsHandler == nextRdpefs {
+			rdpefsHandler = nil
+		}
 		clientMu.Unlock()
+		nextRdpefs.Close()
 		g.Close()
 		return err
 	}
@@ -545,10 +564,14 @@ func forwardClassicBitmaps(bs []grdp.Bitmap) {
 func jsDisconnect(_ js.Value, _ []js.Value) any {
 	clientMu.Lock()
 	c := rdpClient
+	h := rdpefsHandler
 	rdpClient = nil
 	rdpefsHandler = nil
 	connectGen++
 	clientMu.Unlock()
+	if h != nil {
+		h.Close()
+	}
 	if c != nil {
 		c.Close()
 	}

--- a/rdp-wasm/rdpefs.go
+++ b/rdp-wasm/rdpefs.go
@@ -261,6 +261,22 @@ type VirtualFile struct {
 	Children map[string]*VirtualFile
 }
 
+const (
+	agentReadAheadChunkBytes = 1024 * 1024
+	agentReadAheadParallel   = 4
+	agentReadAheadWindow     = agentReadAheadChunkBytes * agentReadAheadParallel
+	agentReadAheadMaxBytes   = 16 * 1024 * 1024
+)
+
+type agentReadCache struct {
+	mu       sync.Mutex
+	start    uint64
+	data     []byte
+	loading  bool
+	loadFrom uint64
+	ready    chan struct{}
+}
+
 // openHandle tracks an open file/directory for IRP processing
 type openHandle struct {
 	DriveDeviceID uint32
@@ -268,6 +284,7 @@ type openHandle struct {
 	Path          string
 	IsDir         bool
 	RemoteHandle  string // handle ID from agent (for agent mode reads)
+	ReadCache     *agentReadCache
 	Volatile      bool   // in-memory placeholder for Office temp/lock files on read-only Agent shares
 	VolatileData  []byte // data written to the volatile placeholder during this RDP session
 	// For local mode compatibility
@@ -1121,7 +1138,7 @@ func (h *RdpefsHandler) handleRead(deviceID, completionID, fileID uint32, data [
 			h.mu.Unlock()
 		}
 
-		chunk := h.callAgentRead(handle.AgentID, readHandle, offset, length)
+		chunk := h.readAgentCached(handle, offset, length)
 		resp := &bytes.Buffer{}
 		if chunk == nil {
 			// Agent RPC failed — must NOT pretend success with Length=0,
@@ -1161,6 +1178,89 @@ func (h *RdpefsHandler) handleRead(deviceID, completionID, fileID uint32, data [
 		resp.Write(chunk)
 		h.sendIOCompletion(deviceID, completionID, STATUS_SUCCESS, resp.Bytes())
 	}
+}
+
+func (h *RdpefsHandler) readAgentCached(handle *openHandle, offset uint64, length uint32) []byte {
+	if length == 0 {
+		return []byte{}
+	}
+	cache := handle.ReadCache
+	if cache == nil {
+		h.mu.Lock()
+		if handle.ReadCache == nil {
+			handle.ReadCache = &agentReadCache{}
+		}
+		cache = handle.ReadCache
+		h.mu.Unlock()
+	}
+	for {
+		cache.mu.Lock()
+		if offset >= cache.start && offset+uint64(length) <= cache.start+uint64(len(cache.data)) {
+			start := int(offset - cache.start)
+			chunk := append([]byte(nil), cache.data[start:start+int(length)]...)
+			cache.mu.Unlock()
+			addProtocolCounter("file.cache.hit", 1)
+			addProtocolCounter("file.bytes.cache", uint64(len(chunk)))
+			return chunk
+		}
+		if cache.loading && offset >= cache.loadFrom && offset < cache.loadFrom+agentReadAheadWindow {
+			ready := cache.ready
+			cache.mu.Unlock()
+			<-ready
+			continue
+		}
+		cache.loading = true
+		cache.loadFrom = offset
+		cache.ready = make(chan struct{})
+		ready := cache.ready
+		cache.mu.Unlock()
+
+		fetchLength := uint32(agentReadAheadWindow)
+		if length > fetchLength {
+			fetchLength = length
+		}
+		if fetchLength > agentReadAheadMaxBytes {
+			fetchLength = agentReadAheadMaxBytes
+		}
+		started := time.Now()
+		data := h.callAgentReadWindow(handle.AgentID, handle.RemoteHandle, offset, fetchLength)
+		elapsed := time.Since(started)
+
+		cache.mu.Lock()
+		if data != nil {
+			cache.start = offset
+			cache.data = data
+			if len(cache.data) > agentReadAheadMaxBytes {
+				cache.data = cache.data[:agentReadAheadMaxBytes]
+			}
+		} else {
+			cache.data = nil
+		}
+		cache.loading = false
+		close(ready)
+		cache.mu.Unlock()
+		addProtocolCounter("file.cache.miss", 1)
+		addProtocolCounter("file.bytes.network", uint64(len(data)))
+		addProtocolCounter("file.read.latency_ms", uint64(elapsed.Milliseconds()))
+		if data == nil {
+			return nil
+		}
+		if uint32(len(data)) < length {
+			return append([]byte(nil), data...)
+		}
+		return append([]byte(nil), data[:length]...)
+	}
+}
+
+func invalidateAgentReadCache(handle *openHandle) {
+	if handle == nil || handle.ReadCache == nil {
+		return
+	}
+	cache := handle.ReadCache
+	cache.mu.Lock()
+	cache.data = nil
+	cache.start = 0
+	cache.mu.Unlock()
 }
 
 // ─── IRP_MJ_WRITE ───────────────────────────────────────────────
@@ -1219,6 +1319,7 @@ func (h *RdpefsHandler) handleWrite(deviceID, completionID, fileID uint32, data 
 			return
 		}
 		written := h.callAgentWrite(handle.AgentID, writeHandle, offset, writeData)
+		invalidateAgentReadCache(handle)
 		if written == 0 && len(writeData) > 0 {
 			h.sendIOCompletionMajor(deviceID, completionID, IRP_MJ_WRITE, STATUS_UNSUCCESSFUL, nil)
 			return
@@ -1305,6 +1406,7 @@ func (h *RdpefsHandler) handleSetInformation(deviceID, completionID, fileID uint
 		if drive.Mode == DriveModeAgent && len(infoData) >= 8 {
 			newSize := binary.LittleEndian.Uint64(infoData[0:8])
 			ok := h.callAgentTruncate(handle.AgentID, handle.Path, newSize)
+			invalidateAgentReadCache(handle)
 			if !ok {
 				h.sendIOCompletionMajor(deviceID, completionID, IRP_MJ_SET_INFORMATION, STATUS_UNSUCCESSFUL, nil)
 				return
@@ -1867,6 +1969,45 @@ func (h *RdpefsHandler) callAgentRead(agentID, handle string, offset uint64, len
 		return nil
 	}
 	return response.Payload
+}
+
+func (h *RdpefsHandler) callAgentReadWindow(agentID, handle string, offset uint64, length uint32) []byte {
+	if length <= zft2MaxPayloadBytes {
+		return h.callAgentRead(agentID, handle, offset, length)
+	}
+	type part struct {
+		index int
+		data  []byte
+	}
+	parts := int((length + zft2MaxPayloadBytes - 1) / zft2MaxPayloadBytes)
+	results := make(chan part, parts)
+	for index := 0; index < parts; index++ {
+		partOffset := offset + uint64(index*zft2MaxPayloadBytes)
+		partLength := uint32(zft2MaxPayloadBytes)
+		remaining := int(length) - index*zft2MaxPayloadBytes
+		if remaining < int(partLength) {
+			partLength = uint32(remaining)
+		}
+		go func(index int, partOffset uint64, partLength uint32) {
+			results <- part{index: index, data: h.callAgentRead(agentID, handle, partOffset, partLength)}
+		}(index, partOffset, partLength)
+	}
+	ordered := make([][]byte, parts)
+	for range parts {
+		result := <-results
+		if result.data == nil {
+			return nil
+		}
+		ordered[result.index] = result.data
+	}
+	window := make([]byte, 0, length)
+	for _, data := range ordered {
+		window = append(window, data...)
+		if len(data) < zft2MaxPayloadBytes {
+			break
+		}
+	}
+	return window
 }
 
 func (h *RdpefsHandler) callAgentWrite(agentID, handle string, offset uint64, data []byte) int {

--- a/rdp-wasm/rdpefs.go
+++ b/rdp-wasm/rdpefs.go
@@ -31,6 +31,8 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -279,9 +281,11 @@ type dirEnumState struct {
 
 // RdpefsHandler implements plugin.ChannelTransport for the rdpdr SVC
 type RdpefsHandler struct {
-	mu      sync.Mutex
-	sender  func(string, []byte) (int, error)
-	enabled bool
+	mu       sync.Mutex
+	sendMu   sync.Mutex
+	sender   func(string, []byte) (int, error)
+	enabled  bool
+	transfer fileTransfer
 
 	clientID     uint32
 	versionMajor uint16
@@ -337,7 +341,25 @@ func (h *RdpefsHandler) send(data []byte) {
 	fn := h.sender
 	h.mu.Unlock()
 	if fn != nil {
+		h.sendMu.Lock()
+		defer h.sendMu.Unlock()
 		fn("rdpdr", data)
+	}
+}
+
+func (h *RdpefsHandler) SetFileTransfer(transfer fileTransfer) {
+	h.mu.Lock()
+	h.transfer = transfer
+	h.mu.Unlock()
+}
+
+func (h *RdpefsHandler) Close() {
+	h.mu.Lock()
+	transfer := h.transfer
+	h.transfer = nil
+	h.mu.Unlock()
+	if transfer != nil {
+		transfer.Close()
 	}
 }
 
@@ -681,7 +703,7 @@ func (h *RdpefsHandler) processIORequest(data []byte) {
 	completionID := binary.LittleEndian.Uint32(data[8:12])
 	majorFunction := binary.LittleEndian.Uint32(data[12:16])
 	minorFunction := binary.LittleEndian.Uint32(data[16:20])
-	payload := data[20:]
+	payload := append([]byte(nil), data[20:]...)
 
 	switch majorFunction {
 	case IRP_MJ_CREATE:
@@ -689,15 +711,15 @@ func (h *RdpefsHandler) processIORequest(data []byte) {
 	case IRP_MJ_CLOSE:
 		h.handleClose(deviceID, completionID, fileID)
 	case IRP_MJ_READ:
-		h.handleRead(deviceID, completionID, fileID, payload)
+		go h.handleRead(deviceID, completionID, fileID, payload)
 	case IRP_MJ_WRITE:
-		h.handleWrite(deviceID, completionID, fileID, payload)
+		go h.handleWrite(deviceID, completionID, fileID, payload)
 	case IRP_MJ_QUERY_INFORMATION:
-		h.handleQueryInformation(deviceID, completionID, fileID, payload)
+		go h.handleQueryInformation(deviceID, completionID, fileID, payload)
 	case IRP_MJ_SET_INFORMATION:
-		h.handleSetInformation(deviceID, completionID, fileID, payload)
+		go h.handleSetInformation(deviceID, completionID, fileID, payload)
 	case IRP_MJ_DIRECTORY_CONTROL:
-		h.handleDirectoryControl(deviceID, completionID, fileID, minorFunction, payload)
+		go h.handleDirectoryControl(deviceID, completionID, fileID, minorFunction, payload)
 	case IRP_MJ_QUERY_VOLUME:
 		h.handleQueryVolume(deviceID, completionID, payload)
 	case IRP_MJ_CLEANUP:
@@ -756,7 +778,7 @@ func (h *RdpefsHandler) handleCreate(deviceID, completionID uint32, data []byte)
 	}
 
 	if drive.Mode == DriveModeAgent {
-		h.handleCreateAgent(drive, completionID, rdpPath, desiredAccess, createDisposition, createOptions)
+		go h.handleCreateAgent(drive, completionID, rdpPath, desiredAccess, createDisposition, createOptions)
 	} else {
 		h.handleCreateLocal(deviceID, completionID, rdpPath, desiredAccess, createDisposition, createOptions)
 	}
@@ -843,7 +865,7 @@ func (h *RdpefsHandler) handleCreateAgent(drive *DriveState, completionID uint32
 		return
 	}
 
-	isDir := (*statResult).Get("isDir").Bool()
+	isDir := statResult.IsDir
 	if createOptions&FILE_DIRECTORY_FILE != 0 && !isDir {
 		h.sendIOCompletionMajor(deviceID, completionID, IRP_MJ_CREATE, STATUS_NO_SUCH_FILE, nil)
 		return
@@ -1423,9 +1445,9 @@ func (h *RdpefsHandler) handleQueryInformation(deviceID, completionID, fileID ui
 			h.sendIOCompletionMajor(deviceID, completionID, IRP_MJ_QUERY_INFORMATION, STATUS_UNSUCCESSFUL, nil)
 			return
 		}
-		isDir = (*stat).Get("isDir").Bool()
-		size = int64((*stat).Get("size").Float())
-		mtime = time.UnixMilli(int64((*stat).Get("mtime").Float()))
+		isDir = stat.IsDir
+		size = stat.Size
+		mtime = time.UnixMilli(stat.Mtime)
 	} else {
 		file := handle.LocalFile
 		if file == nil {
@@ -1567,34 +1589,37 @@ func (h *RdpefsHandler) handleDirectoryControl(deviceID, completionID, fileID, m
 }
 
 func (h *RdpefsHandler) listAgentDir(agentID, dirPath, pattern string) []*VirtualFile {
-	result := js.Global().Call("zephyrRdpFsList", agentID, dirPath)
-	if result.IsNull() || result.IsUndefined() {
+	response, err := h.requestAgent(agentID, zft2List, map[string]any{"path": dirPath}, nil)
+	if err != nil {
+		return nil
+	}
+	entriesJSON, err := json.Marshal(response.Meta["entries"])
+	if err != nil {
+		return nil
+	}
+	var entriesRaw []struct {
+		Name  string `json:"name"`
+		IsDir bool   `json:"isDir"`
+		Size  int64  `json:"size"`
+		Mtime int64  `json:"mtime"`
+	}
+	if err := json.Unmarshal(entriesJSON, &entriesRaw); err != nil {
 		return nil
 	}
 
 	now := time.Now()
-	entries := make([]*VirtualFile, 0)
+	entries := make([]*VirtualFile, 0, len(entriesRaw)+2)
 	entries = append(entries, &VirtualFile{Name: ".", IsDir: true, ModTime: now})
 	entries = append(entries, &VirtualFile{Name: "..", IsDir: true, ModTime: now})
-
-	length := result.Length()
-	for i := 0; i < length; i++ {
-		entry := result.Index(i)
-		name := entry.Get("name").String()
-		if pattern != "" && pattern != "*" && pattern != "*.*" && !matchPattern(pattern, name) {
+	for _, entry := range entriesRaw {
+		if pattern != "" && pattern != "*" && pattern != "*.*" && !matchPattern(pattern, entry.Name) {
 			continue
 		}
-		mt := time.UnixMilli(int64(entry.Get("mtime").Float()))
+		mt := time.UnixMilli(entry.Mtime)
 		if mt.IsZero() {
 			mt = now
 		}
-		f := &VirtualFile{
-			Name:    name,
-			IsDir:   entry.Get("isDir").Bool(),
-			Size:    int64(entry.Get("size").Float()),
-			ModTime: mt,
-		}
-		entries = append(entries, f)
+		entries = append(entries, &VirtualFile{Name: entry.Name, IsDir: entry.IsDir, Size: entry.Size, ModTime: mt})
 	}
 	return entries
 }
@@ -1790,71 +1815,94 @@ func (h *RdpefsHandler) sendIOCompletion(deviceID, completionID, status uint32, 
 	h.send(buf.Bytes())
 }
 
-// ─── Agent RPC calls (synchronous JS interop) ───────────────────
+// ─── Agent RPC calls (ZFT2 binary WebSocket) ────────────────────
 
-func (h *RdpefsHandler) callAgentStat(agentID, path string) *js.Value {
-	result := js.Global().Call("zephyrRdpFsStat", agentID, path)
-	if result.IsNull() || result.IsUndefined() {
-		return nil
-	}
-	return &result
+type agentFileStat struct {
+	Name  string
+	Path  string
+	IsDir bool
+	Size  int64
+	Mtime int64
 }
 
-// Wrapper to avoid returning pointer to interface
-func (h *RdpefsHandler) callAgentStatChecked(agentID, path string) *js.Value {
-	return h.callAgentStat(agentID, path)
+func (h *RdpefsHandler) requestAgent(agentID string, op byte, meta map[string]any, payload []byte) (fileTransferResponse, error) {
+	h.mu.Lock()
+	transfer := h.transfer
+	h.mu.Unlock()
+	if transfer == nil {
+		return fileTransferResponse{}, fmt.Errorf("file transfer is unavailable")
+	}
+	return transfer.Request(agentID, op, meta, payload)
+}
+
+func (h *RdpefsHandler) callAgentStat(agentID, path string) *agentFileStat {
+	response, err := h.requestAgent(agentID, zft2Stat, map[string]any{"path": path}, nil)
+	if err != nil {
+		if zerr, ok := err.(*zft2Error); ok && zerr.Code == "not_found" {
+			return nil
+		}
+		slog.Warn("rdpefs: agent stat failed", "agent", agentID, "path", path, "err", err)
+		return nil
+	}
+	return &agentFileStat{
+		Name: stringMeta(response.Meta, "name"), Path: stringMeta(response.Meta, "path"),
+		IsDir: boolMeta(response.Meta, "isDir"), Size: int64Meta(response.Meta, "size"),
+		Mtime: int64Meta(response.Meta, "mtime"),
+	}
 }
 
 func (h *RdpefsHandler) callAgentOpen(agentID, path, mode string) string {
-	result := js.Global().Call("zephyrRdpFsOpen", agentID, path, mode)
-	if result.IsNull() || result.IsUndefined() {
+	response, err := h.requestAgent(agentID, zft2Open, map[string]any{"path": path, "mode": mode}, nil)
+	if err != nil {
+		slog.Warn("rdpefs: agent open failed", "path", path, "err", err)
 		return ""
 	}
-	return result.String()
+	return stringMeta(response.Meta, "handle")
 }
 
 func (h *RdpefsHandler) callAgentRead(agentID, handle string, offset uint64, length uint32) []byte {
-	result := js.Global().Call("zephyrRdpFsRead", agentID, handle, int(offset), int(length))
-	if result.IsNull() || result.IsUndefined() {
+	response, err := h.requestAgent(agentID, zft2Read, map[string]any{"handle": handle, "offset": offset, "length": length}, nil)
+	if err != nil {
+		slog.Warn("rdpefs: agent read failed", "handle", handle, "offset", offset, "err", err)
 		return nil
 	}
-	buf := make([]byte, result.Length())
-	js.CopyBytesToGo(buf, result)
-	return buf
+	return response.Payload
 }
 
 func (h *RdpefsHandler) callAgentWrite(agentID, handle string, offset uint64, data []byte) int {
-	jsArr := js.Global().Get("Uint8Array").New(len(data))
-	js.CopyBytesToJS(jsArr, data)
-	result := js.Global().Call("zephyrRdpFsWrite", agentID, handle, int(offset), jsArr)
-	if result.IsNull() || result.IsUndefined() {
+	response, err := h.requestAgent(agentID, zft2Write, map[string]any{"handle": handle, "offset": offset}, data)
+	if err != nil {
+		slog.Warn("rdpefs: agent write failed", "handle", handle, "offset", offset, "err", err)
 		return 0
 	}
-	return result.Int()
+	return int(int64Meta(response.Meta, "bytesWritten"))
 }
 
 func (h *RdpefsHandler) callAgentClose(agentID, handle string) {
-	js.Global().Call("zephyrRdpFsClose", agentID, handle)
+	_, err := h.requestAgent(agentID, zft2Close, map[string]any{"handle": handle}, nil)
+	if err != nil {
+		slog.Debug("rdpefs: agent close failed", "handle", handle, "err", err)
+	}
 }
 
 func (h *RdpefsHandler) callAgentMkdir(agentID, path string) bool {
-	result := js.Global().Call("zephyrRdpFsMkdir", agentID, path)
-	return !result.IsNull() && !result.IsUndefined() && result.Bool()
+	_, err := h.requestAgent(agentID, zft2Mkdir, map[string]any{"path": path}, nil)
+	return err == nil
 }
 
 func (h *RdpefsHandler) callAgentDelete(agentID, path string) bool {
-	result := js.Global().Call("zephyrRdpFsDelete", agentID, path)
-	return !result.IsNull() && !result.IsUndefined() && result.Bool()
+	_, err := h.requestAgent(agentID, zft2Delete, map[string]any{"path": path}, nil)
+	return err == nil
 }
 
 func (h *RdpefsHandler) callAgentRename(agentID, oldPath, newPath string) bool {
-	result := js.Global().Call("zephyrRdpFsRename", agentID, oldPath, newPath)
-	return !result.IsNull() && !result.IsUndefined() && result.Bool()
+	_, err := h.requestAgent(agentID, zft2Rename, map[string]any{"oldPath": oldPath, "newPath": newPath}, nil)
+	return err == nil
 }
 
 func (h *RdpefsHandler) callAgentTruncate(agentID, path string, size uint64) bool {
-	result := js.Global().Call("zephyrRdpFsTruncate", agentID, path, int(size))
-	return !result.IsNull() && !result.IsUndefined()
+	_, err := h.requestAgent(agentID, zft2Truncate, map[string]any{"path": path, "size": size}, nil)
+	return err == nil
 }
 
 // ─── Local mode helpers ──────────────────────────────────────────

--- a/rdp-wasm/rdpefs_test.go
+++ b/rdp-wasm/rdpefs_test.go
@@ -291,3 +291,26 @@ func TestAgentReadIRPDoesNotBlockProtocolLoop(t *testing.T) {
 	}
 	close(transfer.blocked)
 }
+
+func TestAgentReadAheadCacheServesSequentialIRPs(t *testing.T) {
+	data := make([]byte, agentReadAheadChunkBytes)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	transfer := &recordingFileTransfer{readData: data}
+	h := NewRdpefsHandler(true)
+	h.SetFileTransfer(transfer)
+	handle := &openHandle{AgentID: "agent", Path: "file.bin", RemoteHandle: "handle"}
+
+	first := h.readAgentCached(handle, 0, 64*1024)
+	second := h.readAgentCached(handle, 64*1024, 64*1024)
+	if len(first) != 64*1024 || len(second) != 64*1024 {
+		t.Fatalf("unexpected read lengths %d %d", len(first), len(second))
+	}
+	if transfer.reads != agentReadAheadParallel {
+		t.Fatalf("network reads = %d, want %d", transfer.reads, agentReadAheadParallel)
+	}
+	if first[1] != 1 || second[1] != 1 {
+		t.Fatal("cached data mismatch")
+	}
+}

--- a/rdp-wasm/rdpefs_test.go
+++ b/rdp-wasm/rdpefs_test.go
@@ -267,3 +267,27 @@ func TestCreateDispositionHelpers(t *testing.T) {
 func deterministicTestTime() time.Time {
 	return time.Unix(1700000000, 0).UTC()
 }
+
+func TestAgentReadIRPDoesNotBlockProtocolLoop(t *testing.T) {
+	transfer := &fakeFileTransfer{blocked: make(chan struct{})}
+	h := NewRdpefsHandler(true)
+	h.SetFileTransfer(transfer)
+	h.drives[1] = &DriveState{DeviceID: 1, AgentID: "agent", DriveName: "AGENT", Mode: DriveModeAgent}
+	h.handles[1] = &openHandle{DriveDeviceID: 1, AgentID: "agent", Path: "file.bin", RemoteHandle: "handle"}
+
+	request := make([]byte, 20+12)
+	binary.LittleEndian.PutUint32(request[0:4], 1)
+	binary.LittleEndian.PutUint32(request[4:8], 1)
+	binary.LittleEndian.PutUint32(request[8:12], 99)
+	binary.LittleEndian.PutUint32(request[12:16], IRP_MJ_READ)
+	binary.LittleEndian.PutUint32(request[20:24], 64*1024)
+
+	returned := make(chan struct{})
+	go func() { h.processIORequest(request); close(returned) }()
+	select {
+	case <-returned:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("processIORequest blocked on remote file transfer")
+	}
+	close(transfer.blocked)
+}

--- a/server.js
+++ b/server.js
@@ -77,6 +77,7 @@ const {
     cleanupMediaProbeCache,
 } = require('./preview/media/media-service');
 const { FileAgentManager } = require('./file-agent-manager');
+const { FileTransferGateway } = require('./file-transfer-ws');
 const { attachRdpProxyBridge } = require('./server/rdp-proxy-bridge');
 const { negotiateRdpTls } = require('./server/rdp-cert-probe');
 
@@ -131,6 +132,7 @@ const MEDIA_CACHE_DIR = path.join(os.tmpdir(), 'zephyr-media-cache');
 const fileAgentManager = new FileAgentManager({
     log: console.log,
 });
+let fileTransferGateway = null;
 
 const BROWSER_IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg', 'avif']);
 const BROWSER_IMAGE_CONTENT_TYPES = new Map([
@@ -320,6 +322,7 @@ const workerBridge = new WorkerBridge({
 });
 const aiPolicyService = new AiPolicyService(storage.rawDb(), { storage, userSettings: userSettingsService });
 const aiProviderService = new AiProviderService(storage.rawDb(), { storage, secretCrypto });
+fileTransferGateway = new FileTransferGateway({ fileAgentManager, authz, storage, log: console.log });
 setInterval(() => { try { deepLinkService.gc(); } catch {} }, 5 * 60 * 1000).unref();
 
 function reopenStorage() {
@@ -5032,6 +5035,7 @@ const noVncWss = new WebSocketServer(wsServerOptions);
 const editorLspWss = new WebSocketServer(wsServerOptions);
 const rdpProxyWss = new WebSocketServer({ ...wsServerOptions, maxPayload: 64 * 1024 * 1024 });
 const agentFilesWss = new WebSocketServer({ ...wsServerOptions, maxPayload: 2 * 1024 * 1024 });
+const fileTransferWss = new WebSocketServer({ ...wsServerOptions, maxPayload: 2 * 1024 * 1024 });
 
 function handleHttpUpgrade(req, socket, head) {
     let pathname = '';
@@ -5051,7 +5055,9 @@ function handleHttpUpgrade(req, socket, head) {
                     ? editorLspWss
                     : pathname === '/agent/files'
                         ? agentFilesWss
-                        : null;
+                        : pathname === '/file-transfer'
+                            ? fileTransferWss
+                            : null;
     if (!targetWss) {
         console.warn('[WS-DIAG] rejected websocket upgrade for unknown path', { url: req.url || '' });
         rejectSocket(socket, 404, 'Not Found');
@@ -5092,6 +5098,10 @@ editorLspWss.on('connection', handleEditorLspConnection);
 /* ─── File Agent WebSocket ─── */
 agentFilesWss.on('connection', (ws) => {
     fileAgentManager.handleConnection(ws);
+});
+fileTransferWss.on('connection', (ws, req) => {
+    startSessionWatchdog(ws, req);
+    fileTransferGateway.handleConnection(ws, req);
 });
 
 /* File-agent REST routes are mounted before the SPA catch-all above. */

--- a/tests/file-agent-v2.test.mjs
+++ b/tests/file-agent-v2.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+import { FileAgentConnection } from '../file-agent-manager.js';
+import { OP, FLAG_RESPONSE, encodeFrame } from '../file-transfer-protocol.js';
+
+class MockAgentSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.readyState = 1;
+    this.OPEN = 1;
+    this.sent = [];
+  }
+  send(frame, options, callback) {
+    this.sent.push({ frame: Buffer.from(frame), options });
+    callback?.();
+  }
+}
+
+function connection() {
+  return new FileAgentConnection(new MockAgentSocket(), 'agent-1', {
+    protocolVersion: 2,
+    deviceName: 'phone',
+    capabilities: { binaryRead: true, binaryWrite: true, maxInflight: 2, maxChunkSize: 1048576 },
+    share: { readOnly: false },
+  });
+}
+
+test('Agent v2 resolves binary reads and structured writes', async () => {
+  const conn = connection();
+  const read = conn.callBinaryV2(OP.READ, { handle: 'h', offset: 0, length: 3 }, null, 1000);
+  const readId = conn.nextRequestId - 1;
+  conn.handleBinaryResponse(encodeFrame({ type: OP.READ, requestId: readId, flags: FLAG_RESPONSE, meta: { bytesRead: 3 }, payload: Buffer.from([9, 8, 7]) }));
+  assert.deepEqual([...await read.promise], [9, 8, 7]);
+
+  const write = conn.callBinaryV2(OP.WRITE, { handle: 'h', offset: 0 }, Buffer.from([1]), 1000);
+  const writeId = conn.nextRequestId - 1;
+  conn.handleBinaryResponse(encodeFrame({ type: OP.WRITE, requestId: writeId, flags: FLAG_RESPONSE, meta: { bytesWritten: 1 } }));
+  assert.deepEqual(await write.promise, { bytesWritten: 1 });
+});
+
+test('Agent v2 cancellation rejects immediately and emits CANCEL', async () => {
+  const conn = connection();
+  const operation = conn.callBinaryV2(OP.READ, { handle: 'h', offset: 0, length: 1 }, null, 1000);
+  operation.cancel();
+  await assert.rejects(operation.promise, (error) => error.code === 'cancelled');
+  assert.equal(conn.pendingRequests.size, 0);
+  assert.equal(conn.ws.sent.length, 2);
+});
+
+test('Agent v2 enforces negotiated in-flight limit', async () => {
+  const conn = connection();
+  const one = conn.callBinaryV2(OP.READ, { handle: 'h1', length: 1 }, null, 1000);
+  const two = conn.callBinaryV2(OP.READ, { handle: 'h2', length: 1 }, null, 1000);
+  const three = conn.callBinaryV2(OP.READ, { handle: 'h3', length: 1 }, null, 1000);
+  await assert.rejects(three.promise, (error) => error.code === 'busy');
+  one.cancel();
+  two.cancel();
+  await Promise.allSettled([one.promise, two.promise]);
+});

--- a/tests/file-transfer-protocol.test.mjs
+++ b/tests/file-transfer-protocol.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  OP, FLAG_ERROR, FLAG_RESPONSE, MAX_PAYLOAD_BYTES,
+  Zft2ProtocolError, encodeFrame, decodeFrame, responseFrame, errorFrame,
+} from '../file-transfer-protocol.js';
+import { mapRequest } from '../file-transfer-operations.js';
+
+test('ZFT2 round-trips metadata and binary payload', () => {
+  const frame = encodeFrame({
+    type: OP.WRITE,
+    requestId: 0xfeedbeef,
+    meta: { handle: 'h1', offset: 0x100000000, mode: 'write' },
+    payload: Buffer.from([0, 1, 2, 253, 254, 255]),
+  });
+  const decoded = decodeFrame(frame);
+  assert.equal(decoded.type, OP.WRITE);
+  assert.equal(decoded.requestId, 0xfeedbeef);
+  assert.deepEqual(decoded.meta, { handle: 'h1', offset: 0x100000000, mode: 'write' });
+  assert.deepEqual([...decoded.payload], [0, 1, 2, 253, 254, 255]);
+});
+
+test('ZFT2 rejects truncation, bad magic, duplicate lengths, and oversized payloads', () => {
+  assert.throws(() => decodeFrame(Buffer.alloc(3)), (error) => error instanceof Zft2ProtocolError && error.code === 'truncated_header');
+  assert.throws(() => decodeFrame(Buffer.alloc(20)), (error) => error instanceof Zft2ProtocolError && error.code === 'bad_magic');
+  const frame = encodeFrame({ type: OP.READ, requestId: 1, meta: { length: 3 } });
+  const broken = Buffer.from(frame);
+  broken.writeUInt32BE(4, 16);
+  assert.throws(() => decodeFrame(broken), (error) => error instanceof Zft2ProtocolError && error.code === 'length_mismatch');
+  assert.throws(() => encodeFrame({ type: OP.WRITE, requestId: 1, payload: Buffer.alloc(MAX_PAYLOAD_BYTES + 1) }), /payload exceeds limit/);
+});
+
+test('ZFT2 response and error frames preserve direction flags', () => {
+  const request = decodeFrame(encodeFrame({ type: OP.READ, requestId: 9, meta: { length: 2 } }));
+  const response = decodeFrame(responseFrame(request, { bytesRead: 2 }, Buffer.from('ok')));
+  assert.equal(response.flags, FLAG_RESPONSE);
+  assert.deepEqual([...response.payload], [...Buffer.from('ok')]);
+  const error = decodeFrame(errorFrame(request, 'timeout', 'slow', true));
+  assert.equal(error.flags, FLAG_RESPONSE | FLAG_ERROR);
+  assert.deepEqual(error.meta, { code: 'timeout', message: 'slow', retryable: true });
+});
+
+test('ZFT2 operation mapping keeps content binary and metadata structured', () => {
+  const read = mapRequest({ type: OP.READ, requestId: 1, meta: { handle: 'h', offset: 17, length: 4096 }, payload: Buffer.alloc(0) });
+  assert.equal(read.method, 'readBinary');
+  assert.deepEqual(read.params, { handle: 'h', offset: 17, length: 4096 });
+  const write = mapRequest({ type: OP.WRITE, requestId: 2, meta: { handle: 'h', offset: 17 }, payload: Buffer.from([1, 2]) });
+  assert.equal(write.method, 'writeBinary');
+  assert.deepEqual([...write.params.data], [1, 2]);
+  assert.throws(() => mapRequest({ type: 0xff, requestId: 3, meta: {}, payload: Buffer.alloc(0) }), /Unsupported ZFT2/);
+});

--- a/tests/file-transfer-ws.test.mjs
+++ b/tests/file-transfer-ws.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+import {
+  OP, FLAG_ERROR, FLAG_RESPONSE, encodeFrame, decodeFrame,
+} from '../file-transfer-protocol.js';
+import { FileTransferGateway } from '../file-transfer-ws.js';
+
+class MockSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.readyState = 1;
+    this.OPEN = 1;
+    this.bufferedAmount = 0;
+    this.sent = [];
+    this.closed = null;
+  }
+  send(frame, _options, callback) {
+    this.sent.push(Buffer.from(frame));
+    callback?.();
+  }
+  close(code, reason) {
+    this.closed = { code, reason };
+    this.readyState = 3;
+  }
+}
+
+function fixture({ owner = true, fileRead = true, fileWrite = true, agentResult = {} } = {}) {
+  let called = null;
+  let cancelled = false;
+  const manager = {
+    isAgentOwnedByUser: () => owner,
+    callAgentV2(agentId, method, params) {
+      called = { agentId, method, params };
+      return { promise: Promise.resolve(agentResult), cancel() { cancelled = true; } };
+    },
+  };
+  const authz = {
+    assertCan(_user, cap) { if (cap === 'fileRead' && !fileRead) throw Object.assign(new Error('denied'), { code: 'denied' }); },
+    can(_user, cap) { return cap !== 'fileWrite' || fileWrite; },
+  };
+  const storage = {
+    getUserBrief: () => ({ userId: 'u1', username: 'alice', status: 'active' }),
+    getConnectionById: () => ({ id: 'c1', ownerUserId: 'u1' }),
+  };
+  return {
+    gateway: new FileTransferGateway({ fileAgentManager: manager, authz, storage, log() {} }),
+    get called() { return called; },
+    get cancelled() { return cancelled; },
+  };
+}
+
+function request(url = '/file-transfer?agentId=a1&connectionId=c1') {
+  return { url, headers: { host: 'example.test' }, authSession: { userId: 'u1' } };
+}
+
+async function deliver(gateway, socket, req, frame) {
+  gateway.handleConnection(socket, req);
+  socket.emit('message', frame, true);
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test('gateway forwards binary writes without base64 and returns structured response', async () => {
+  const f = fixture({ agentResult: { bytesWritten: 3 } });
+  const socket = new MockSocket();
+  await deliver(f.gateway, socket, request(), encodeFrame({ type: OP.WRITE, requestId: 7, meta: { handle: 'h', offset: 9 }, payload: Buffer.from([0, 255, 1]) }));
+  assert.equal(f.called.method, 'writeBinary');
+  assert.deepEqual([...f.called.params.data], [0, 255, 1]);
+  const response = decodeFrame(socket.sent[0]);
+  assert.equal(response.flags, FLAG_RESPONSE);
+  assert.deepEqual(response.meta, { bytesWritten: 3 });
+});
+
+test('gateway returns raw binary read payload', async () => {
+  const f = fixture({ agentResult: Buffer.from([5, 4, 3]) });
+  const socket = new MockSocket();
+  await deliver(f.gateway, socket, request(), encodeFrame({ type: OP.READ, requestId: 8, meta: { handle: 'h', offset: 0, length: 3 } }));
+  const response = decodeFrame(socket.sent[0]);
+  assert.deepEqual([...response.payload], [5, 4, 3]);
+  assert.deepEqual(response.meta, { bytesRead: 3, eof: false });
+});
+
+test('gateway rejects cross-user agents and missing read permission at bind time', () => {
+  const crossUser = fixture({ owner: false });
+  const socketA = new MockSocket();
+  crossUser.gateway.handleConnection(socketA, request());
+  assert.equal(socketA.closed.code, 1008);
+  const denied = fixture({ fileRead: false });
+  const socketB = new MockSocket();
+  denied.gateway.handleConnection(socketB, request());
+  assert.equal(socketB.closed.code, 1008);
+});
+
+test('gateway enforces fileWrite independently', async () => {
+  const f = fixture({ fileWrite: false });
+  const socket = new MockSocket();
+  await deliver(f.gateway, socket, request(), encodeFrame({ type: OP.WRITE, requestId: 10, meta: { handle: 'h' }, payload: Buffer.from([1]) }));
+  const response = decodeFrame(socket.sent[0]);
+  assert.equal(response.flags, FLAG_RESPONSE | FLAG_ERROR);
+  assert.equal(response.meta.code, 'read_only');
+  assert.equal(f.called, null);
+});
+
+test('gateway allows owner-bound transient RDP sessions without a saved connection id', () => {
+  const f = fixture();
+  const binding = f.gateway.authorize(request('/file-transfer?agentId=a1'));
+  assert.equal(binding.connectionId, '');
+  assert.equal(binding.canWrite, true);
+});

--- a/zephyr_agent/android_host/MainActivity.kt
+++ b/zephyr_agent/android_host/MainActivity.kt
@@ -217,22 +217,24 @@ class MainActivity : FlutterActivity() {
             return
         }
 
-        val channel = handle.channel
-        if (channel != null) {
-            try {
-                channel.position(offset)
-                val buffer = ByteArray(length)
-                val read = channel.read(ByteBuffer.wrap(buffer))
-                result.success(if (read <= 0) ByteArray(0) else buffer.copyOf(read))
-                return
-            } catch (_: Exception) {
-                // Some exotic DocumentProviders expose non-seekable descriptors.
-                // Fall through to the slower stream+skip compatibility path.
+        // Open a descriptor per offset read. ZFT2 intentionally runs up to four
+        // reads for the same handle in parallel; mutating one shared
+        // FileChannel.position would corrupt those ranges.
+        try {
+            val pfd = contentResolver.openFileDescriptor(handle.uri, "r")
+                ?: throw SafException("io_error", "Cannot open file for read")
+            pfd.use {
+                FileInputStream(it.fileDescriptor).use { stream ->
+                    val buffer = ByteArray(length)
+                    val read = stream.channel.read(ByteBuffer.wrap(buffer), offset)
+                    result.success(if (read <= 0) ByteArray(0) else buffer.copyOf(read))
+                    return
+                }
             }
+        } catch (_: Exception) {
+            // Some exotic DocumentProviders expose non-seekable descriptors.
         }
 
-        // Fallback for non-seekable providers.  This path should be rare; the
-        // persistent FileChannel above is required for large-file performance.
         val input = contentResolver.openInputStream(handle.uri) ?: throw SafException("io_error", "Cannot open input stream")
         input.use { stream ->
             var skipped = 0L

--- a/zephyr_agent/android_host/MainActivity.kt
+++ b/zephyr_agent/android_host/MainActivity.kt
@@ -19,12 +19,13 @@ import java.io.FileOutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class MainActivity : FlutterActivity() {
     private val channelName = "com.zephyr.agent/saf"
     private val requestOpenTree = 0x5A13
     private var pendingSelectResult: MethodChannel.Result? = null
-    private val handles = mutableMapOf<String, SafHandle>()
+    private val handles = ConcurrentHashMap<String, SafHandle>()
 
     data class SafHandle(
         val uri: Uri,

--- a/zephyr_agent/lib/agent/agent_controller.dart
+++ b/zephyr_agent/lib/agent/agent_controller.dart
@@ -11,6 +11,7 @@ import 'package:web_socket_channel/io.dart';
 import 'package:uuid/uuid.dart';
 import 'agent_state.dart';
 import '../fs/file_provider.dart';
+import 'file_transfer_protocol.dart';
 import '../app/agent_version.dart';
 
 class AgentController extends ChangeNotifier {
@@ -41,6 +42,11 @@ class AgentController extends ChangeNotifier {
 
   // File provider
   ZephyrFileProvider? _fileProvider;
+  final Map<int, Future<void>> _zft2Tasks = {};
+  final Map<String, Future<void>> _zft2HandleQueues = {};
+  final Set<int> _zft2Cancelled = {};
+  Timer? _transferUiTimer;
+  bool _transferUiDirty = false;
 
   AgentController(this._config);
 
@@ -182,7 +188,7 @@ class AgentController extends ChangeNotifier {
     final deviceId = const Uuid().v5(Namespace.url.value, '${_config.serverUrl}:${_config.deviceName}');
     _send({
       'type': 'hello',
-      'protocolVersion': 1,
+      'protocolVersion': 2,
       'token': _config.token,
       'deviceId': deviceId,
       'deviceName': _config.deviceName,
@@ -197,6 +203,10 @@ class AgentController extends ChangeNotifier {
         'truncate': !_config.readOnly,
         'binary': true,
         'binaryRead': true,
+        'binaryWrite': true,
+        'cancel': true,
+        'creditFlow': true,
+        'maxInflight': 8,
         'maxChunkSize': 1 * 1024 * 1024,
       },
       'share': {
@@ -207,6 +217,17 @@ class AgentController extends ChangeNotifier {
   }
 
   void _onMessage(dynamic raw) {
+    if (raw is List<int>) {
+      try {
+        final bytes = raw is Uint8List ? raw : Uint8List.fromList(raw);
+        if (bytes.length >= 4 && bytes[0] == 0x5a && bytes[1] == 0x46 && bytes[2] == 0x54 && bytes[3] == 0x32) {
+          _handleZft2Frame(decodeZft2Frame(bytes));
+          return;
+        }
+      } catch (_) {
+        return;
+      }
+    }
     Map<String, dynamic> msg;
     try {
       msg = jsonDecode(raw is String ? raw : utf8.decode(raw as List<int>));
@@ -227,6 +248,118 @@ class AgentController extends ChangeNotifier {
       default:
         break;
     }
+  }
+
+  void _handleZft2Frame(Zft2Frame frame) {
+    if (frame.isResponse) return;
+    if (frame.type == Zft2Op.cancel) {
+      final target = (frame.meta['targetRequestId'] as num?)?.toInt() ?? -1;
+      if (_zft2Tasks.containsKey(target)) _zft2Cancelled.add(target);
+      return;
+    }
+    if (_zft2Tasks.length >= 8) {
+      _sendBytes(encodeZft2Error(frame, 'busy', 'Agent request window is full', retryable: true));
+      return;
+    }
+    final handle = frame.meta['handle']?.toString() ?? '';
+    Future<void> run() async {
+      try {
+        final response = await _dispatchZft2(frame);
+        if (!_zft2Cancelled.contains(frame.requestId)) _sendBytes(response);
+      } catch (e) {
+        final code = e is FileProviderException ? e.code : 'internal_error';
+        if (!_zft2Cancelled.contains(frame.requestId)) _sendBytes(encodeZft2Error(frame, code, e.toString()));
+      } finally {
+        _zft2Tasks.remove(frame.requestId);
+        _zft2Cancelled.remove(frame.requestId);
+      }
+    }
+    Future<void> task;
+    if (handle.isNotEmpty && [Zft2Op.read, Zft2Op.write, Zft2Op.close].contains(frame.type)) {
+      final previous = _zft2HandleQueues[handle] ?? Future.value();
+      task = previous.catchError((_) {}).then((_) => run());
+      _zft2HandleQueues[handle] = task.whenComplete(() {
+        if (identical(_zft2HandleQueues[handle], task)) _zft2HandleQueues.remove(handle);
+      });
+    } else {
+      task = run();
+    }
+    _zft2Tasks[frame.requestId] = task;
+  }
+
+  Future<Uint8List> _dispatchZft2(Zft2Frame frame) async {
+    final fp = _fileProvider;
+    if (fp == null) throw FileProviderException('internal_error', 'No file provider');
+    final meta = frame.meta;
+    final mutating = [Zft2Op.write, Zft2Op.mkdir, Zft2Op.delete, Zft2Op.rename, Zft2Op.truncate];
+    if (_config.readOnly && mutating.contains(frame.type)) throw FileProviderException('read_only', 'Share is read-only');
+    Map<String, dynamic> result = {};
+    Uint8List payload = Uint8List(0);
+    switch (frame.type) {
+      case Zft2Op.open:
+        result = {'handle': await fp.open(meta['path'] as String, meta['mode'] as String? ?? 'read')};
+        break;
+      case Zft2Op.read:
+        payload = await fp.read(meta['handle'] as String, (meta['offset'] as num?)?.toInt() ?? 0, (meta['length'] as num?)?.toInt() ?? 262144);
+        result = {'bytesRead': payload.length, 'eof': payload.isEmpty};
+        _recordTransfer(payload.length);
+        break;
+      case Zft2Op.write:
+        final written = await fp.write(meta['handle'] as String, (meta['offset'] as num?)?.toInt() ?? 0, frame.payload);
+        result = {'bytesWritten': written};
+        _recordTransfer(written);
+        break;
+      case Zft2Op.close:
+        await fp.close(meta['handle'] as String);
+        break;
+      case Zft2Op.stat:
+        result = (await fp.stat(meta['path'] as String? ?? '/')).toJson();
+        break;
+      case Zft2Op.list:
+        final entries = await fp.list(meta['path'] as String? ?? '/');
+        result = {'entries': entries.map((e) => e.toJson()).toList()};
+        break;
+      case Zft2Op.mkdir:
+        await fp.mkdir(meta['path'] as String);
+        break;
+      case Zft2Op.delete:
+        await fp.delete(meta['path'] as String, recursive: meta['recursive'] == true);
+        break;
+      case Zft2Op.rename:
+        await fp.rename(meta['oldPath'] as String, meta['newPath'] as String);
+        break;
+      case Zft2Op.truncate:
+        await fp.truncate(meta['path'] as String, (meta['size'] as num?)?.toInt() ?? 0);
+        break;
+      case Zft2Op.ping:
+        result = {'agentTime': DateTime.now().millisecondsSinceEpoch};
+        break;
+      default:
+        throw FileProviderException('unsupported', 'Unsupported ZFT2 operation: ${frame.type}');
+    }
+    _transferCount++;
+    _scheduleTransferUiUpdate();
+    return encodeZft2Response(frame, meta: result, payload: payload);
+  }
+
+  void _recordTransfer(int bytes) {
+    _transferBytes += bytes;
+    _scheduleTransferUiUpdate();
+  }
+
+  void _scheduleTransferUiUpdate() {
+    _transferUiDirty = true;
+    if (_transferUiTimer != null) return;
+    _transferUiTimer = Timer(const Duration(milliseconds: 250), () {
+      _transferUiTimer = null;
+      if (!_transferUiDirty) return;
+      _transferUiDirty = false;
+      notifyListeners();
+    });
+  }
+
+  void _sendBytes(Uint8List bytes) {
+    try { _channel?.sink.add(bytes); } catch (_) {}
   }
 
   void _handleHelloAck(Map<String, dynamic> msg) {
@@ -301,28 +434,9 @@ class AgentController extends ChangeNotifier {
         final handle = await fp.open(params['path'] as String, params['mode'] as String? ?? 'read');
         return {'handle': handle};
       case 'read':
-        final data = await fp.read(
-          params['handle'] as String,
-          params['offset'] as int? ?? 0,
-          params['length'] as int? ?? 262144,
-        );
-        _transferBytes += data.length;
-        notifyListeners();
-        return {
-          'dataBase64': base64Encode(data),
-          'bytesRead': data.length,
-          'eof': data.isEmpty,
-        };
+        throw FileProviderException('unsupported', 'Base64 reads are disabled in protocol v2');
       case 'write':
-        final bytes = base64Decode(params['dataBase64'] as String);
-        final written = await fp.write(
-          params['handle'] as String,
-          params['offset'] as int? ?? 0,
-          bytes,
-        );
-        _transferBytes += written;
-        notifyListeners();
-        return {'bytesWritten': written};
+        throw FileProviderException('unsupported', 'Base64 writes are disabled in protocol v2');
       case 'close':
         await fp.close(params['handle'] as String);
         return {};
@@ -494,6 +608,10 @@ class AgentController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _transferUiTimer?.cancel();
+    _zft2Tasks.clear();
+    _zft2HandleQueues.clear();
+    _zft2Cancelled.clear();
     _cancelShutdownTimer();
     _cancelHeartbeat();
     _cancelReconnect();

--- a/zephyr_agent/lib/agent/agent_controller.dart
+++ b/zephyr_agent/lib/agent/agent_controller.dart
@@ -275,7 +275,7 @@ class AgentController extends ChangeNotifier {
       }
     }
     Future<void> task;
-    if (handle.isNotEmpty && [Zft2Op.read, Zft2Op.write, Zft2Op.close].contains(frame.type)) {
+    if (handle.isNotEmpty && [Zft2Op.write, Zft2Op.close].contains(frame.type)) {
       final previous = _zft2HandleQueues[handle] ?? Future.value();
       task = previous.catchError((_) {}).then((_) => run());
       _zft2HandleQueues[handle] = task.whenComplete(() {

--- a/zephyr_agent/lib/agent/file_transfer_protocol.dart
+++ b/zephyr_agent/lib/agent/file_transfer_protocol.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+const int zft2Version = 2;
+const int zft2HeaderBytes = 20;
+const int zft2FlagError = 0x0001;
+const int zft2FlagResponse = 0x0002;
+const int zft2MaxMetaBytes = 256 * 1024;
+const int zft2MaxPayloadBytes = 1024 * 1024;
+
+abstract final class Zft2Op {
+  static const int open = 0x01;
+  static const int read = 0x02;
+  static const int write = 0x03;
+  static const int close = 0x04;
+  static const int stat = 0x05;
+  static const int list = 0x06;
+  static const int mkdir = 0x07;
+  static const int delete = 0x08;
+  static const int rename = 0x09;
+  static const int truncate = 0x0a;
+  static const int cancel = 0x0b;
+  static const int ping = 0x0c;
+}
+
+class Zft2ProtocolException implements Exception {
+  final String code;
+  final String message;
+  const Zft2ProtocolException(this.code, this.message);
+  @override
+  String toString() => message;
+}
+
+class Zft2Frame {
+  final int type;
+  final int requestId;
+  final int flags;
+  final Map<String, dynamic> meta;
+  final Uint8List payload;
+
+  Zft2Frame({
+    required this.type,
+    required this.requestId,
+    this.flags = 0,
+    this.meta = const {},
+    Uint8List? payload,
+  }) : payload = payload ?? Uint8List(0);
+
+  bool get isResponse => flags & zft2FlagResponse != 0;
+  bool get isError => flags & zft2FlagError != 0;
+}
+
+Uint8List encodeZft2Frame(Zft2Frame frame) {
+  if (frame.type < 0 || frame.type > 255) {
+    throw const Zft2ProtocolException(
+      'invalid_type',
+      'Invalid ZFT2 frame type',
+    );
+  }
+  if (frame.requestId < 0 || frame.requestId > 0xffffffff) {
+    throw const Zft2ProtocolException(
+      'invalid_request_id',
+      'Invalid ZFT2 request id',
+    );
+  }
+  final metaBytes = Uint8List.fromList(utf8.encode(jsonEncode(frame.meta)));
+  if (metaBytes.length > zft2MaxMetaBytes) {
+    throw const Zft2ProtocolException(
+      'metadata_too_large',
+      'ZFT2 metadata exceeds limit',
+    );
+  }
+  if (frame.payload.length > zft2MaxPayloadBytes) {
+    throw const Zft2ProtocolException(
+      'payload_too_large',
+      'ZFT2 payload exceeds limit',
+    );
+  }
+  final out = Uint8List(
+    zft2HeaderBytes + metaBytes.length + frame.payload.length,
+  );
+  out.setRange(0, 4, const [0x5a, 0x46, 0x54, 0x32]);
+  out[4] = zft2Version;
+  out[5] = frame.type;
+  final view = ByteData.sublistView(out);
+  view.setUint16(6, frame.flags, Endian.big);
+  view.setUint32(8, frame.requestId, Endian.big);
+  view.setUint32(12, metaBytes.length, Endian.big);
+  view.setUint32(16, frame.payload.length, Endian.big);
+  out.setRange(zft2HeaderBytes, zft2HeaderBytes + metaBytes.length, metaBytes);
+  out.setRange(zft2HeaderBytes + metaBytes.length, out.length, frame.payload);
+  return out;
+}
+
+Zft2Frame decodeZft2Frame(List<int> raw) {
+  final bytes = raw is Uint8List ? raw : Uint8List.fromList(raw);
+  if (bytes.length < zft2HeaderBytes) {
+    throw const Zft2ProtocolException(
+      'truncated_header',
+      'Truncated ZFT2 header',
+    );
+  }
+  if (bytes[0] != 0x5a ||
+      bytes[1] != 0x46 ||
+      bytes[2] != 0x54 ||
+      bytes[3] != 0x32) {
+    throw const Zft2ProtocolException('bad_magic', 'Invalid ZFT2 magic');
+  }
+  if (bytes[4] != zft2Version) {
+    throw Zft2ProtocolException(
+      'unsupported_version',
+      'Unsupported ZFT2 version ${bytes[4]}',
+    );
+  }
+  final view = ByteData.sublistView(bytes);
+  final metaLength = view.getUint32(12, Endian.big);
+  final payloadLength = view.getUint32(16, Endian.big);
+  if (metaLength > zft2MaxMetaBytes) {
+    throw const Zft2ProtocolException(
+      'metadata_too_large',
+      'ZFT2 metadata exceeds limit',
+    );
+  }
+  if (payloadLength > zft2MaxPayloadBytes) {
+    throw const Zft2ProtocolException(
+      'payload_too_large',
+      'ZFT2 payload exceeds limit',
+    );
+  }
+  final expected = zft2HeaderBytes + metaLength + payloadLength;
+  if (bytes.length != expected) {
+    throw Zft2ProtocolException(
+      'length_mismatch',
+      'ZFT2 frame length mismatch: expected $expected, got ${bytes.length}',
+    );
+  }
+  Map<String, dynamic> meta = const {};
+  if (metaLength > 0) {
+    final decoded = jsonDecode(
+      utf8.decode(bytes.sublist(zft2HeaderBytes, zft2HeaderBytes + metaLength)),
+    );
+    if (decoded is! Map<String, dynamic>) {
+      throw const Zft2ProtocolException(
+        'invalid_metadata',
+        'ZFT2 metadata must be an object',
+      );
+    }
+    meta = decoded;
+  }
+  return Zft2Frame(
+    type: bytes[5],
+    requestId: view.getUint32(8, Endian.big),
+    flags: view.getUint16(6, Endian.big),
+    meta: meta,
+    payload: Uint8List.sublistView(bytes, zft2HeaderBytes + metaLength),
+  );
+}
+
+Uint8List encodeZft2Response(
+  Zft2Frame request, {
+  Map<String, dynamic> meta = const {},
+  Uint8List? payload,
+}) {
+  return encodeZft2Frame(
+    Zft2Frame(
+      type: request.type,
+      requestId: request.requestId,
+      flags: zft2FlagResponse,
+      meta: meta,
+      payload: payload ?? Uint8List(0),
+    ),
+  );
+}
+
+Uint8List encodeZft2Error(
+  Zft2Frame request,
+  String code,
+  String message, {
+  bool retryable = false,
+}) {
+  return encodeZft2Frame(
+    Zft2Frame(
+      type: request.type,
+      requestId: request.requestId,
+      flags: zft2FlagResponse | zft2FlagError,
+      meta: {'code': code, 'message': message, 'retryable': retryable},
+    ),
+  );
+}

--- a/zephyr_agent/lib/fs/file_provider.dart
+++ b/zephyr_agent/lib/fs/file_provider.dart
@@ -54,10 +54,17 @@ abstract class ZephyrFileProvider {
   Future<void> truncate(String path, int size);
 }
 
+class _DesktopOpenFile {
+  final String path;
+  final io.RandomAccessFile file;
+  final bool writable;
+  _DesktopOpenFile(this.path, this.file, this.writable);
+}
+
 /// Desktop file provider using dart:io
 class DesktopFileProvider extends ZephyrFileProvider {
   final String rootDir;
-  final Map<String, io.RandomAccessFile> _openFiles = {};
+  final Map<String, _DesktopOpenFile> _openFiles = {};
   final _uuid = const Uuid();
 
   DesktopFileProvider(this.rootDir);
@@ -161,31 +168,37 @@ class DesktopFileProvider extends ZephyrFileProvider {
       }
     }
     final handle = 'h_${_uuid.v4().substring(0, 8)}';
-    _openFiles[handle] = raf;
+    _openFiles[handle] = _DesktopOpenFile(resolved, raf, wantsWrite);
     return handle;
   }
 
   @override
   Future<Uint8List> read(String handle, int offset, int length) async {
-    final raf = _openFiles[handle];
-    if (raf == null) throw FileProviderException('not_found', 'Invalid handle');
-    await raf.setPosition(offset);
-    return await raf.read(length);
+    final opened = _openFiles[handle];
+    if (opened == null) throw FileProviderException('not_found', 'Invalid handle');
+    final raf = await io.File(opened.path).open(mode: io.FileMode.read);
+    try {
+      await raf.setPosition(offset);
+      return await raf.read(length);
+    } finally {
+      await raf.close();
+    }
   }
 
   @override
   Future<int> write(String handle, int offset, Uint8List data) async {
-    final raf = _openFiles[handle];
-    if (raf == null) throw FileProviderException('not_found', 'Invalid handle');
-    await raf.setPosition(offset);
-    await raf.writeFrom(data);
+    final opened = _openFiles[handle];
+    if (opened == null) throw FileProviderException('not_found', 'Invalid handle');
+    if (!opened.writable) throw FileProviderException('read_only', 'Handle is not writable');
+    await opened.file.setPosition(offset);
+    await opened.file.writeFrom(data);
     return data.length;
   }
 
   @override
   Future<void> close(String handle) async {
-    final raf = _openFiles.remove(handle);
-    if (raf != null) await raf.close();
+    final opened = _openFiles.remove(handle);
+    if (opened != null) await opened.file.close();
   }
 
   @override
@@ -229,8 +242,8 @@ class DesktopFileProvider extends ZephyrFileProvider {
   }
 
   void closeAll() {
-    for (final raf in _openFiles.values) {
-      try { raf.closeSync(); } catch (_) {}
+    for (final opened in _openFiles.values) {
+      try { opened.file.closeSync(); } catch (_) {}
     }
     _openFiles.clear();
   }

--- a/zephyr_agent/test/file_provider_test.dart
+++ b/zephyr_agent/test/file_provider_test.dart
@@ -7,7 +7,9 @@ import 'package:zephyr_agent/fs/file_provider.dart';
 void main() {
   group('DesktopFileProvider', () {
     test('write mode preserves existing bytes until overwritten', () async {
-      final dir = await Directory.systemTemp.createTemp('zephyr_agent_provider_');
+      final dir = await Directory.systemTemp.createTemp(
+        'zephyr_agent_provider_',
+      );
       try {
         final file = File('${dir.path}/hello.txt');
         await file.writeAsString('abcdef');
@@ -16,6 +18,33 @@ void main() {
         await provider.write(handle, 2, Uint8List.fromList('XY'.codeUnits));
         await provider.close(handle);
         expect(await file.readAsString(), 'abXYef');
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    });
+
+    test('concurrent offset reads return independent slices', () async {
+      final dir = await Directory.systemTemp.createTemp(
+        'zephyr_agent_provider_',
+      );
+      try {
+        final file = File('${dir.path}/large.bin');
+        await file.writeAsBytes(
+          List<int>.generate(256 * 1024, (i) => i & 0xff),
+        );
+        final provider = DesktopFileProvider(dir.path);
+        final handle = await provider.open('/large.bin', 'read');
+        final results = await Future.wait([
+          provider.read(handle, 0, 4096),
+          provider.read(handle, 64 * 1024, 4096),
+          provider.read(handle, 128 * 1024, 4096),
+          provider.read(handle, 192 * 1024, 4096),
+        ]);
+        for (final bytes in results) {
+          expect(bytes.length, 4096);
+          expect(bytes.take(256), List<int>.generate(256, (i) => i));
+        }
+        await provider.close(handle);
       } finally {
         await dir.delete(recursive: true);
       }

--- a/zephyr_agent/test/file_transfer_protocol_test.dart
+++ b/zephyr_agent/test/file_transfer_protocol_test.dart
@@ -1,0 +1,47 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zephyr_agent/agent/file_transfer_protocol.dart';
+
+void main() {
+  test('ZFT2 frame round-trips metadata and binary payload', () {
+    final raw = encodeZft2Frame(
+      Zft2Frame(
+        type: Zft2Op.write,
+        requestId: 0xfeedbeef,
+        flags: zft2FlagResponse,
+        meta: {'handle': 'h1', 'offset': 4294967296},
+        payload: Uint8List.fromList([0, 1, 2, 253, 254, 255]),
+      ),
+    );
+    final decoded = decodeZft2Frame(raw);
+    expect(decoded.type, Zft2Op.write);
+    expect(decoded.requestId, 0xfeedbeef);
+    expect(decoded.flags, zft2FlagResponse);
+    expect(decoded.meta['handle'], 'h1');
+    expect(decoded.meta['offset'], 4294967296);
+    expect(decoded.payload, [0, 1, 2, 253, 254, 255]);
+  });
+
+  test('ZFT2 rejects malformed and oversized frames', () {
+    expect(
+      () => decodeZft2Frame(Uint8List(3)),
+      throwsA(isA<Zft2ProtocolException>()),
+    );
+    final badMagic = Uint8List(zft2HeaderBytes);
+    expect(
+      () => decodeZft2Frame(badMagic),
+      throwsA(isA<Zft2ProtocolException>()),
+    );
+    expect(
+      () => encodeZft2Frame(
+        Zft2Frame(
+          type: Zft2Op.write,
+          requestId: 1,
+          payload: Uint8List(zft2MaxPayloadBytes + 1),
+        ),
+      ),
+      throwsA(isA<Zft2ProtocolException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- replace Worker SAB/Atomics + sync XHR file bridge with ZFT2 binary WebSocket
- complete remote RDPEFS IRPs asynchronously in Go WASM
- add bounded 8-request flow control, cancellation, ACL binding, session watchdog, and binary Agent writes
- pipeline sequential reads with 4 x 1 MiB bounded read-ahead
- remove Base64/sync-XHR file-transfer main paths

## Verification
- ZFT2 Node tests: 19/19
- Go WASM tests: pass
- Go WASM production build: pass
- JavaScript syntax: pass
- Dart ZFT2 codec analyze: pass
- full Flutter/Android compile delegated to Agent PR CI; local sandbox is aarch64 while official Linux Flutter SDK is x64

## Known pre-existing tests
- two RDP pipeline contract tests already fail on origin/main
- saved Telnet WS test is timing-sensitive under full parallel suite and passes independently