### PR TITLE
feat: refine activity and settings interfaces

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -15,6 +15,7 @@
             <a class="brand" href="#dashboard"><span id="brandIcon">🌬️</span><strong id="brandName">Zephyr</strong></a>
             <nav class="nav-tabs" aria-label="主导航">
                 <button class="nav-tab active" data-view="dashboard">仪表盘</button>
+                <button class="nav-tab" data-view="activity">活动</button>
                 <button class="nav-tab" data-view="terminal">终端</button>
                 <button class="nav-tab" data-view="remote">远程执行</button>
                 <button class="nav-tab force-hidden" id="notesNavTab" data-view="notes">笔记</button>
@@ -44,10 +45,37 @@
                     <select id="sortSelect"><option value="createdAt">按创建时间</option><option value="name">按名称</option><option value="lastConnectedAt">按最近连接</option><option value="protocol">按协议</option></select>
                 </div>
                 <div class="connection-grid" id="connectionGrid"></div>
-                <div class="activity-panel">
-                    <div class="panel-title-row"><h2>最近活动</h2><button class="tool-btn danger" id="clearActivityBtn" type="button">清理日志</button></div>
-                    <div id="activityList" class="activity-list"></div>
+            </section>
+
+            <section class="view activity-view" id="view-activity">
+                <div class="section-head activity-section-head">
+                    <div>
+                        <p class="eyebrow">Activity</p>
+                        <h1>活动记录</h1>
+                        <p class="activity-intro">查看连接、账户与系统操作的详细记录。</p>
+                    </div>
+                    <button class="tool-btn danger force-hidden" id="clearActivityBtn" type="button">清理日志</button>
                 </div>
+                <div class="activity-filter-bar" aria-label="活动时间筛选">
+                    <div class="activity-range-tabs" role="group" aria-label="快捷时间范围">
+                        <button class="activity-range-btn" type="button" data-activity-range="today">今天</button>
+                        <button class="activity-range-btn active" type="button" data-activity-range="7d">近 7 天</button>
+                        <button class="activity-range-btn" type="button" data-activity-range="30d">近 30 天</button>
+                        <button class="activity-range-btn" type="button" data-activity-range="all">全部</button>
+                        <button class="activity-range-btn" type="button" data-activity-range="custom">自定义</button>
+                    </div>
+                    <div class="activity-custom-range force-hidden" id="activityCustomRange">
+                        <label>开始日期<input id="activityStartDate" type="date"></label>
+                        <span aria-hidden="true">至</span>
+                        <label>结束日期<input id="activityEndDate" type="date"></label>
+                        <button class="btn btn-primary" id="applyActivityRange" type="button">应用</button>
+                    </div>
+                </div>
+                <div class="activity-summary" aria-live="polite">
+                    <strong id="activityResultCount">0 条记录</strong>
+                    <span id="activityRangeLabel">近 7 天</span>
+                </div>
+                <div id="activityList" class="activity-list activity-detail-list"></div>
             </section>
 
             <section class="view terminal-view" id="view-terminal" aria-label="终端工作台">
@@ -314,22 +342,47 @@
                     </div>
                     <div class="settings-content">
                         <div class="settings-panel active" id="settings-security">
-                            <h2>修改密码</h2>
-                            <form id="passwordForm" class="settings-form">
-                                <input type="password" id="settingsCurrentPassword" placeholder="当前密码" required>
-                                <input type="password" id="settingsNewPassword" placeholder="新密码" minlength="4" required>
-                                <input type="password" id="settingsConfirmPassword" placeholder="确认新密码" minlength="4" required>
-                                <button class="btn btn-primary" type="submit">保存密码</button>
-                            </form>
-                            <h2>账号资料</h2><form id="profileForm" class="settings-form"><input id="profileUsername" placeholder="默认登录用户名"><p class="field-hint">修改后登录页默认用户名与登录账号会同步更新。</p><input id="profileEmail" type="email" placeholder="管理员邮箱（用于重置密码）"><button class="btn btn-primary">保存资料</button></form>
-                             <h2>TOTP 两步验证</h2><div class="mini-list" id="totpBox"></div><form id="totpEnableForm" class="settings-form force-hidden"><div id="totpQrBox"></div><input id="totpEnableCode" placeholder="输入 6 位验证码"><button class="btn btn-primary">确认开启</button></form><form id="totpDisableForm" class="settings-form"><input type="password" id="totpDisablePassword" placeholder="当前密码"><input id="totpDisableCode" placeholder="TOTP 验证码"><button class="btn danger">关闭 TOTP</button></form>
-                             <h2>Passkey</h2><button class="btn" id="addPasskeyBtn">添加 Passkey</button><div class="mini-list" id="passkeyList"></div>
-                             <h2>登录邮件通知</h2><label class="check-line"><input type="checkbox" id="notifyLoginPersonal"> 接收我的登录邮件通知</label>
+                            <div class="security-card-row">
+                                <section class="security-card">
+                                    <h2>修改密码</h2>
+                                    <form id="passwordForm" class="settings-form">
+                                        <div class="security-input-stack">
+                                            <div class="form-group"><label for="settingsCurrentPassword">请输入当前密码</label><input type="password" id="settingsCurrentPassword" placeholder=" " required></div>
+                                            <div class="form-group"><label for="settingsNewPassword">请输入新密码</label><input type="password" id="settingsNewPassword" placeholder=" " minlength="4" required></div>
+                                            <div class="form-group"><label for="settingsConfirmPassword">请确认新密码</label><input type="password" id="settingsConfirmPassword" placeholder=" " minlength="4" required></div>
+                                        </div>
+                                        <button class="btn btn-primary" type="submit">保存密码</button>
+                                    </form>
+                                </section>
+                                <section class="security-card">
+                                    <h2>修改个人信息</h2>
+                                    <form id="profileForm" class="settings-form"><div class="security-input-stack"><div class="form-group"><label for="profileUsername">请输入新用户名</label><input id="profileUsername" placeholder=" "></div><div class="form-group"><label for="profileEmail">请输入新邮箱</label><input id="profileEmail" type="email" placeholder=" "></div></div><button class="btn btn-primary">保存资料</button></form>
+                                </section>
+                            </div>
+                            <div class="security-card-row">
+                                <section class="security-card">
+                                    <div class="security-card-head"><h2>TOTP 两步验证</h2><div id="totpAction"></div></div><div class="mini-list" id="totpBox"></div><form id="totpEnableForm" class="settings-form force-hidden"><div id="totpQrBox"></div><div class="security-input-stack"><div class="form-group"><label for="totpEnableCode">请输入 6 位验证码</label><input id="totpEnableCode" placeholder=" "></div></div><button class="btn btn-primary">确认开启</button></form><form id="totpDisableForm" class="settings-form"><div class="security-input-stack"><div class="form-group"><label for="totpDisablePassword">请输入当前密码</label><input type="password" id="totpDisablePassword" placeholder=" "></div><div class="form-group"><label for="totpDisableCode">请输入 TOTP 验证码</label><input id="totpDisableCode" placeholder=" "></div></div><button class="btn danger">关闭 TOTP</button></form>
+                                </section>
+                                <section class="security-card">
+                                    <div class="security-card-head"><h2>Passkey</h2><button class="security-card-action" id="addPasskeyBtn" type="button">添加 Passkey</button></div><div class="mini-list" id="passkeyList"></div>
+                                </section>
+                            </div>
+                            <div class="security-card-row">
+                                <section class="security-card">
+                                    <h2>登录邮件通知</h2>
+                                    <label class="settings-switch-option" for="notifyLoginPersonal">
+                                        <span class="settings-switch-copy"><strong>接收登录邮件通知</strong><small>检测到我的账号登录时发送邮件提醒</small></span>
+                                        <span class="connection-share-switch"><input type="checkbox" id="notifyLoginPersonal"><span aria-hidden="true"></span></span>
+                                    </label>
+                                </section>
+                                <section class="security-card">
+                                    <div class="panel-title-row"><h2 id="loginEventsTitle">我的登录记录</h2><button class="tool-btn danger" type="button" id="clearLoginEventsBtn">清理日志</button></div><div class="mini-list" id="loginEventList"></div>
+                                </section>
+                            </div>
                              <div id="platformSecuritySettings">
                                  <h2>IP 白名单与防爆破</h2><form id="securityPolicyForm" class="settings-form"><label class="check-line"><input type="checkbox" id="ipWhitelistEnabled"> 启用 IP 白名单</label><textarea id="ipWhitelist" placeholder="每行一个 IP 或 CIDR，例如 192.168.1.0/24"></textarea><label class="check-line"><input type="checkbox" id="bruteForceEnabled"> 启用防爆破封禁</label><input id="bruteForceMaxFailures" type="number" min="1" placeholder="失败次数"><input id="bruteForceBanMinutes" type="number" min="1" placeholder="封禁分钟"><button class="btn btn-primary">保存安全策略</button></form><div class="mini-list" id="ipBanList"></div>
                                  <h2>CAPTCHA</h2><form id="captchaForm" class="settings-form"><label class="check-line"><input type="checkbox" id="captchaEnabled"> 启用 CAPTCHA</label><select id="captchaProvider"><option value="turnstile">Cloudflare Turnstile</option><option value="hcaptcha">hCaptcha</option><option value="google">Google reCAPTCHA v2</option><option value="tencent">腾讯云验证码</option><option value="aliyun">阿里云验证码 2.0</option></select><input id="captchaSiteKey" placeholder="Site Key / AppId / CaptchaId"><div class="form-group password-field"><input id="captchaSecretKey" type="password" placeholder="Secret Key / AppSecretKey"><button type="button" id="toggleCaptchaSecret" title="显示/隐藏 CAPTCHA 密钥">👁️</button></div><button type="button" class="link-btn" id="revealCaptchaSecret">查看已保存 CAPTCHA 密钥</button><p class="field-hint">默认隐藏已保存 CAPTCHA 密钥；留空或保持星号不会覆盖已保存密钥。查看时如已开启 TOTP 需输入动态验证码，否则输入当前登录密码。</p><button class="btn btn-primary">保存 CAPTCHA</button></form>
                              </div>
-                             <div class="panel-title-row"><h2 id="loginEventsTitle">我的登录记录</h2><button class="tool-btn danger" type="button" id="clearLoginEventsBtn">清理日志</button></div><div class="mini-list" id="loginEventList"></div>
                         </div>
                         <div class="settings-panel" id="settings-appearance">
                             <h2>个性化设置</h2>
@@ -446,56 +499,44 @@
                             </form>
                         </div>
                         <div class="settings-panel" id="settings-network">
-                            <h2>代理池</h2>
-                            <form id="proxyForm" class="settings-form inline-form">
-                                <input type="hidden" id="proxyId"><input id="proxyName" placeholder="名称"><select id="proxyType"><option value="socks5">SOCKS5</option><option value="http">HTTP CONNECT</option></select><input id="proxyHost" placeholder="IP / 主机"><input id="proxyPort" type="number" value="1080"><input id="proxyUsername" placeholder="用户名"><input id="proxyPassword" placeholder="密码"><button class="btn btn-primary" type="submit">保存代理</button>
-                            </form>
+                            <div class="panel-title-row proxy-panel-title"><h2>代理池</h2><button class="btn btn-primary proxy-add-btn" type="button" id="addProxyBtn">＋ 新建代理</button></div>
                             <div class="mini-list" id="proxyList"></div>
                         </div>
                         <div class="settings-panel" id="settings-ssh-keys">
-                            <h2>SSH 密钥库</h2>
-                            <form id="sshKeyForm" class="settings-form">
-                                <input type="hidden" id="sshKeyId">
-                                <input id="sshKeyName" placeholder="密钥名称，例如：生产环境 deploy key">
-                                <textarea id="sshKeyPrivateKey" placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"></textarea>
-                                <input id="sshKeyPassphrase" type="password" placeholder="私钥口令（可选）">
-                                <input id="sshKeyRemark" placeholder="备注（可选）">
-                                <p class="field-hint">保存后可在添加/编辑 SSH 连接时直接选择；编辑时默认隐藏私钥，查看时如已开启 TOTP 需输入动态验证码，否则输入当前登录密码。</p>
-                                <div class="form-actions"><button class="btn btn-primary" type="submit">保存 SSH 密钥</button><button class="btn" type="button" id="resetSshKeyForm">清空</button></div>
-                            </form>
+                            <div class="panel-title-row proxy-panel-title"><h2>SSH 密钥库</h2><button class="btn btn-primary proxy-add-btn" type="button" id="addSshKeyBtn">＋ 新增 SSH 密钥</button></div>
                             <div class="mini-list" id="sshKeyList"></div>
                         </div>
                         <div class="settings-panel" id="settings-snippets">
-                            <div class="panel-title-row"><h2>SSH 代码片段</h2></div>
-                            <form id="snippetForm" class="settings-form snippet-form">
-                                <input id="snippetId" type="hidden">
-                                <label>名称</label>
-                                <input id="snippetName" maxlength="60" placeholder="例如：查看 Docker 状态">
-                                <label>命令内容</label>
-                                <textarea id="snippetCommand" rows="6" placeholder="docker ps\n# 支持多行命令"></textarea>
-                                <label>分组 / 标签</label>
-                                <input id="snippetGroup" maxlength="40" placeholder="例如：Docker / Linux / 自定义">
-                                <label class="check-line"><input type="checkbox" id="snippetAutoRun"> 点击片段时直接执行（否则填入输入框）</label>
-                                <div class="form-actions"><button class="btn btn-primary" type="submit">保存片段</button><button class="btn" type="button" id="cancelSnippetEditBtn">清空</button></div>
-                            </form>
+                            <div class="panel-title-row proxy-panel-title"><h2>SSH 代码片段</h2><button class="btn btn-primary proxy-add-btn" type="button" id="addSnippetBtn">＋ 新增代码片段</button></div>
                             <div class="snippet-settings-list" id="snippetSettingsList"></div>
                         </div>
                         <div class="settings-panel" id="settings-ai">
-                            <div class="panel-title-row"><h2>AI 助理总开关</h2><button class="btn btn-primary" type="button" id="aiAddProviderBtn">添加模型供应商</button></div>
+                            <div class="panel-title-row ai-settings-title"><h2>AI 助理</h2></div>
                             <form id="aiSettingsForm" class="settings-form ai-settings-form">
-                                <label class="check-line"><input type="checkbox" id="aiEnabled"> 启用 AI 助理</label>
+                                <section class="security-card ai-settings-card">
+                                <h2>基础设置</h2>
+                                <label class="settings-switch-option" for="aiEnabled">
+                                    <span class="settings-switch-copy"><strong>启用 AI 助理</strong><small>在导航和工作区中显示 AI 功能</small></span>
+                                    <span class="connection-share-switch"><input type="checkbox" id="aiEnabled"><span aria-hidden="true"></span></span>
+                                </label>
                                 <label>助理名称</label><input id="aiAssistantName" maxlength="40" placeholder="Zephyr AI">
                                 <label>默认模型供应商</label>
                                 <input type="hidden" id="aiDefaultProvider" value="">
                                 <button type="button" class="ui-btn ai-picker-btn ai-settings-picker" id="aiDefaultProviderBtn" data-ai-field-picker="defaultProvider">自动选择第一个可用供应商</button>
                                 <label>默认模型</label><input id="aiDefaultModel" placeholder="留空自动使用供应商默认/第一个模型">
                                 <label>系统提示词</label><textarea id="aiSystemPrompt" rows="5" placeholder="给 AI 助理的全局行为要求，可留空。"></textarea>
-                                <h3>上下文长度</h3>
+                                <div class="form-actions ai-card-actions"><button class="btn btn-primary" type="submit">保存基础设置</button></div>
+                                </section>
+                                <section class="security-card ai-settings-card">
+                                <h2>上下文长度</h2>
                                 <div class="form-row ai-context-row"><div class="form-group"><label>上下文窗口 Tokens</label><input id="aiContextWindowTokens" type="number" min="1024" step="1024" placeholder="128000"></div><div class="form-group"><label>最大输入字符数</label><input id="aiContextMaxInputChars" type="number" min="8000" step="1000" placeholder="180000"></div></div>
                                 <div class="form-row ai-context-row"><div class="form-group"><label>保留最近消息数</label><input id="aiContextKeepMessages" type="number" min="4" max="160" step="1" placeholder="40"></div><div class="form-group"><label>工具结果注入字符数</label><input id="aiContextToolResultChars" type="number" min="1000" step="1000" placeholder="60000"></div></div>
                                 <div class="form-row ai-context-row"><div class="form-group"><label>AI 工具调用轮次上限</label><input id="aiContextMaxToolRounds" type="number" min="0" step="1" placeholder="0 表示无上限"></div><div class="form-group"><label>说明</label><p class="field-hint">默认 0 = 无上限；如果模型循环调用工具，可设置成 20 / 50 等硬上限。</p></div></div>
                                 <label class="check-line"><input type="checkbox" id="aiCodeCompletionEnabled"> 文件编辑器启用 AI 代码补全</label>
-                                <h3>工具权限</h3>
+                                <div class="form-actions ai-card-actions"><button class="btn btn-primary" type="submit">保存上下文设置</button></div>
+                                </section>
+                                <section class="security-card ai-settings-card">
+                                <h2>工具权限</h2>
                                 <div class="ai-permission-grid">
                                     <label class="check-line"><input type="checkbox" id="aiPermWebSearch"> 网页搜索</label>
                                     <label class="check-line"><input type="checkbox" id="aiPermWebFetch"> 网页正文读取</label>
@@ -509,36 +550,84 @@
                                     <label class="check-line"><input type="checkbox" id="aiPermNotesWrite"> 创建、修改和删除笔记</label>
                                     <label class="check-line"><input type="checkbox" id="aiPermEnv"> AI 环境变量</label>
                                 </div>
-                                <h3>长期 Memory / 任务规划器</h3>
+                                <div class="form-actions ai-card-actions"><button class="btn btn-primary" type="submit">保存工具权限</button></div>
+                                </section>
+                                <section class="security-card ai-settings-card">
+                                <h2>Memory 与规划器</h2>
                                 <label class="check-line"><input type="checkbox" id="aiMemoryEnabled"> 启用长期 Memory / 项目记忆</label>
                                 <label>最多保存 Memory 条数</label><input id="aiMemoryMaxItems" type="number" min="1" max="2000" step="1" placeholder="500">
                                 <label class="check-line"><input type="checkbox" id="aiPlannerEnabled"> 启用任务规划器</label>
                                 <label class="check-line"><input type="checkbox" id="aiRequirePlanBeforeTools"> 复杂任务优先要求先规划</label>
-                                <h3>敏感操作确认</h3>
+                                <div class="form-actions ai-card-actions"><button class="btn btn-primary" type="submit">保存规划设置</button></div>
+                                </section>
+                                <section class="security-card ai-settings-card">
+                                <h2>敏感操作确认</h2>
                                 <label class="check-line"><input type="checkbox" id="aiRequireConfirmation"> 敏感操作需要用户确认</label>
                                 <label class="check-line"><input type="checkbox" id="aiAutoConfirm"> 自动确认敏感操作</label>
                                 <label>自动确认延迟（毫秒）</label><input id="aiAutoConfirmDelayMs" type="number" min="0" max="60000" step="100" placeholder="2500">
                                 <p class="field-hint">敏感操作包括远程执行、远程写文件等。关闭确认或开启自动确认会显著提高风险。</p>
-                                <h3>权限规则（Go Runtime）</h3>
-                                <p class="field-hint">优先级：deny &gt; ask &gt; allow &gt; 模式默认。规则形如 <code>remote_execute(rm -rf*)</code> 或 <code>list_connections</code>。每行一条。</p>
-                                <label>默认模式</label>
-                                <div class="ai-segment ai-segment-block" id="aiPermRuleMode" data-value="ask" data-cols="3" role="tablist" aria-label="权限默认模式">
-                                    <span class="ai-segment-thumb" aria-hidden="true"></span>
-                                    <button type="button" class="ai-segment-btn active" data-value="ask" role="tab" aria-selected="true" title="写操作询问">Ask</button>
-                                    <button type="button" class="ai-segment-btn" data-value="auto" role="tab" aria-selected="false" title="只读自动，写操作询问">Auto</button>
-                                    <button type="button" class="ai-segment-btn" data-value="yolo" role="tab" aria-selected="false" title="除 deny 外全自动（危险）">Yolo</button>
-                                </div>
-                                <p class="field-hint ai-perm-mode-hint" id="aiPermModeHint">Ask：写操作默认询问</p>
-                                <label>Deny（永久拒绝）</label>
-                                <textarea id="aiPermDeny" rows="3" placeholder="remote_execute(rm -rf*)&#10;connection_delete(*)"></textarea>
-                                <label>Allow（永不询问）</label>
-                                <textarea id="aiPermAllow" rows="3" placeholder="remote_execute(systemctl status*)&#10;remote_read_file(*)"></textarea>
-                                <label>Ask（强制询问）</label>
-                                <textarea id="aiPermAsk" rows="2" placeholder="remote_write_file(*)"></textarea>
-                                <button class="btn btn-primary" type="submit">保存 AI 设置</button>
+                                <div class="form-actions ai-card-actions"><button class="btn btn-primary" type="submit">保存确认设置</button></div>
+                                </section>
                             </form>
-                            <h2>模型供应商</h2>
+                                <div class="ai-runtime-grid">
+                                <section class="security-card settings-form ai-settings-card ai-runtime-card">
+                                    <h2>权限规则（Go Runtime）</h2>
+                                    <p class="field-hint">优先级：deny &gt; ask &gt; allow &gt; 模式默认。规则形如 <code>remote_execute(rm -rf*)</code> 或 <code>list_connections</code>。每行一条。</p>
+                                    <label>默认模式</label>
+                                    <div class="ai-segment ai-segment-block" id="aiPermRuleMode" data-value="ask" data-cols="3" role="tablist" aria-label="权限默认模式">
+                                        <span class="ai-segment-thumb" aria-hidden="true"></span>
+                                        <button type="button" class="ai-segment-btn active" data-value="ask" role="tab" aria-selected="true" title="写操作询问">Ask</button>
+                                        <button type="button" class="ai-segment-btn" data-value="auto" role="tab" aria-selected="false" title="只读自动，写操作询问">Auto</button>
+                                        <button type="button" class="ai-segment-btn" data-value="yolo" role="tab" aria-selected="false" title="除 deny 外全自动（危险）">Yolo</button>
+                                    </div>
+                                    <p class="field-hint ai-perm-mode-hint" id="aiPermModeHint">Ask：写操作默认询问</p>
+                                    <label>Deny（永久拒绝）</label>
+                                    <textarea id="aiPermDeny" rows="3" placeholder="remote_execute(rm -rf*)&#10;connection_delete(*)"></textarea>
+                                    <label>Allow（永不询问）</label>
+                                    <textarea id="aiPermAllow" rows="3" placeholder="remote_execute(systemctl status*)&#10;remote_read_file(*)"></textarea>
+                                    <label>Ask（强制询问）</label>
+                                    <textarea id="aiPermAsk" rows="2" placeholder="remote_write_file(*)"></textarea>
+                                    <div class="form-actions ai-card-actions"><button class="btn btn-primary" type="button" data-ai-save-settings>保存权限规则</button></div>
+                                </section>
+                                <section class="security-card ai-resource-card ai-runtime-card">
+                                <h2>MCP 服务器（Go AI Runtime）</h2>
+                                <p class="field-hint">仅在启用 <code>ZEPHYR_AI_URL</code> 时生效。stdio 在服务端执行；http 为远程 MCP。工具名形如 <code>mcp__name__tool</code>。</p>
+                                <form id="aiMcpForm" class="settings-form ai-mcp-form">
+                                    <input type="hidden" id="aiMcpId">
+                                    <div class="form-row">
+                                        <div class="form-group"><label>名称</label><input id="aiMcpName" placeholder="例如 filesystem" maxlength="80"></div>
+                                        <div class="form-group"><label>类型</label>
+                                            <div class="ai-segment ai-segment-block" id="aiMcpType" data-value="stdio" data-cols="2" role="tablist" aria-label="MCP 传输类型">
+                                                <span class="ai-segment-thumb" aria-hidden="true"></span>
+                                                <button type="button" class="ai-segment-btn active" data-value="stdio" role="tab" aria-selected="true">stdio</button>
+                                                <button type="button" class="ai-segment-btn" data-value="http" role="tab" aria-selected="false">http</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-group" id="aiMcpStdioFields">
+                                        <label>命令</label><input id="aiMcpCommand" placeholder="npx">
+                                        <label>参数（空格分隔）</label><input id="aiMcpArgs" placeholder="-y @modelcontextprotocol/server-filesystem /data">
+                                        <label>环境变量（KEY=VAL 每行一个）</label><textarea id="aiMcpEnv" rows="3" placeholder="FOO=bar"></textarea>
+                                    </div>
+                                    <div class="form-group force-hidden" id="aiMcpHttpFields">
+                                        <label>URL</label><input id="aiMcpUrl" placeholder="https://mcp.example.com/mcp">
+                                        <label>Headers（Header: value 每行）</label><textarea id="aiMcpHeaders" rows="3" placeholder="Authorization: Bearer …"></textarea>
+                                    </div>
+                                    <label>信任为只读的工具名（逗号分隔，原始 MCP 名）</label>
+                                    <input id="aiMcpTrustedReadOnly" placeholder="read_file, list_dir">
+                                    <label>调用超时（秒）</label><input id="aiMcpTimeout" type="number" min="1" max="7200" value="300">
+                                    <label class="check-line"><input type="checkbox" id="aiMcpEnabled" checked> 启用</label>
+                                    <div class="form-actions"><button class="btn btn-primary" type="submit">保存 MCP</button><button class="btn" type="button" id="aiMcpResetBtn">清空</button></div>
+                                </form>
+                                <div class="ai-mcp-list" id="aiMcpList"></div>
+                                </section>
+                                </div>
+                            <div class="ai-resource-grid">
+                            <section class="security-card ai-resource-card">
+                            <div class="panel-title-row"><h2>模型供应商</h2><button class="btn btn-primary proxy-add-btn" type="button" id="aiAddProviderBtn">添加模型供应商</button></div>
                             <div class="ai-provider-list" id="aiProviderList"></div>
+                            </section>
+                            <section class="security-card ai-resource-card">
                             <h2>AI 环境变量</h2>
                             <form id="aiEnvForm" class="settings-form ai-env-form">
                                 <input type="hidden" id="aiEnvId">
@@ -550,6 +639,8 @@
                                 <p class="field-hint">默认完全不向 AI 暴露变量；可单独允许 AI 看到变量名/说明，或仅对非敏感配置允许直接看到值。未直接暴露的值仍需 get_env_var + 敏感确认。</p>
                             </form>
                             <div class="ai-env-list" id="aiEnvList"></div>
+                            </section>
+                            <section class="security-card ai-resource-card">
                             <h2>长期 Memory / 项目记忆</h2>
                             <form id="aiMemoryForm" class="settings-form ai-memory-form">
                                 <input type="hidden" id="aiMemoryId">
@@ -560,8 +651,12 @@
                                 <div class="form-actions"><button class="btn btn-primary" type="submit">保存 Memory</button><button class="btn" type="button" id="aiMemoryResetBtn">清空</button></div>
                             </form>
                             <div class="ai-memory-list" id="aiMemoryList"></div>
+                            </section>
+                            <section class="security-card ai-resource-card">
                             <h2>任务计划器</h2>
                             <div class="ai-plan-list" id="aiPlanList"></div>
+                            </section>
+                            <section class="security-card ai-resource-card">
                             <h2>Skills 能力包</h2>
                             <form id="aiSkillForm" class="settings-form ai-skill-form">
                                 <input type="hidden" id="aiSkillId">
@@ -572,36 +667,8 @@
                                 <div class="form-actions"><button class="btn btn-primary" type="submit">保存 Skill</button><button class="btn" type="button" id="aiSkillResetBtn">清空</button></div>
                             </form>
                             <div class="ai-skill-list" id="aiSkillList"></div>
-                            <h2>MCP 服务器（Go AI Runtime）</h2>
-                            <p class="field-hint">仅在启用 <code>ZEPHYR_AI_URL</code> 时生效。stdio 在服务端执行；http 为远程 MCP。工具名形如 <code>mcp__name__tool</code>。</p>
-                            <form id="aiMcpForm" class="settings-form ai-mcp-form">
-                                <input type="hidden" id="aiMcpId">
-                                <div class="form-row">
-                                    <div class="form-group"><label>名称</label><input id="aiMcpName" placeholder="例如 filesystem" maxlength="80"></div>
-                                    <div class="form-group"><label>类型</label>
-                                        <div class="ai-segment ai-segment-block" id="aiMcpType" data-value="stdio" data-cols="2" role="tablist" aria-label="MCP 传输类型">
-                                            <span class="ai-segment-thumb" aria-hidden="true"></span>
-                                            <button type="button" class="ai-segment-btn active" data-value="stdio" role="tab" aria-selected="true">stdio</button>
-                                            <button type="button" class="ai-segment-btn" data-value="http" role="tab" aria-selected="false">http</button>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="form-group" id="aiMcpStdioFields">
-                                    <label>命令</label><input id="aiMcpCommand" placeholder="npx">
-                                    <label>参数（空格分隔）</label><input id="aiMcpArgs" placeholder="-y @modelcontextprotocol/server-filesystem /data">
-                                    <label>环境变量（KEY=VAL 每行一个）</label><textarea id="aiMcpEnv" rows="3" placeholder="FOO=bar"></textarea>
-                                </div>
-                                <div class="form-group force-hidden" id="aiMcpHttpFields">
-                                    <label>URL</label><input id="aiMcpUrl" placeholder="https://mcp.example.com/mcp">
-                                    <label>Headers（Header: value 每行）</label><textarea id="aiMcpHeaders" rows="3" placeholder="Authorization: Bearer …"></textarea>
-                                </div>
-                                <label>信任为只读的工具名（逗号分隔，原始 MCP 名）</label>
-                                <input id="aiMcpTrustedReadOnly" placeholder="read_file, list_dir">
-                                <label>调用超时（秒）</label><input id="aiMcpTimeout" type="number" min="1" max="7200" value="300">
-                                <label class="check-line"><input type="checkbox" id="aiMcpEnabled" checked> 启用</label>
-                                <div class="form-actions"><button class="btn btn-primary" type="submit">保存 MCP</button><button class="btn" type="button" id="aiMcpResetBtn">清空</button></div>
-                            </form>
-                            <div class="ai-mcp-list" id="aiMcpList"></div>
+                            </section>
+                            </div>
                         </div>
                         <div class="settings-panel" id="settings-agent">
                             <h2>Zephyr Agent Token</h2>
@@ -786,9 +853,15 @@
             <div class="form-group"><label>备注（支持 Markdown）</label><textarea id="connRemark" placeholder="例如：**生产环境**\n`docker ps`"></textarea></div>
             <div class="form-group connection-share-group">
                 <label>共享设置</label>
-                <div style="display:flex;flex-direction:column;gap:6px;padding:8px 0">
-                    <label class="check-line"><input type="checkbox" id="connShareUsers"> 共享给所有用户（可见、可连接）</label>
-                    <label class="check-line"><input type="checkbox" id="connShareAdmins"> 共享给管理员</label>
+                <div class="connection-share-options">
+                    <label class="connection-share-option" for="connShareUsers">
+                        <span class="connection-share-copy"><strong>共享给所有用户</strong><small>所有用户均可查看并连接</small></span>
+                        <span class="connection-share-switch"><input type="checkbox" id="connShareUsers"><span aria-hidden="true"></span></span>
+                    </label>
+                    <label class="connection-share-option" for="connShareAdmins">
+                        <span class="connection-share-copy"><strong>共享给管理员</strong><small>仅管理员可查看并连接</small></span>
+                        <span class="connection-share-switch"><input type="checkbox" id="connShareAdmins"><span aria-hidden="true"></span></span>
+                    </label>
                 </div>
             </div>
             <div class="modal-actions" id="connectionModalActions">
@@ -801,13 +874,52 @@
         </form>
     </div>
 
+    <div class="modal-backdrop" id="proxyModal" aria-hidden="true">
+        <form class="connection-modal proxy-modal" id="proxyForm">
+            <div class="modal-head"><h2 id="proxyModalTitle">新建代理</h2><button type="button" class="icon-btn" id="proxyCloseBtn" aria-label="关闭代理弹窗">✕</button></div>
+            <input type="hidden" id="proxyId">
+            <div class="form-group"><label for="proxyName">名称</label><input id="proxyName" required placeholder="例如：海外 SOCKS5"></div>
+            <div class="form-row"><div class="form-group"><label for="proxyType">类型</label><select id="proxyType"><option value="socks5">SOCKS5</option><option value="http">HTTP CONNECT</option></select></div><div class="form-group"><label for="proxyPort">端口</label><input id="proxyPort" type="number" min="1" max="65535" value="1080" required></div></div>
+            <div class="form-group"><label for="proxyHost">IP / 主机</label><input id="proxyHost" required placeholder="proxy.example.com"></div>
+            <div class="form-row"><div class="form-group"><label for="proxyUsername">用户名</label><input id="proxyUsername" placeholder="可选"></div><div class="form-group"><label for="proxyPassword">密码</label><input id="proxyPassword" type="password" placeholder="可选"></div></div>
+            <p class="field-hint">保存后可在连接的高级选项中选择此代理。编辑时留空密码不会覆盖已保存密码。</p>
+            <div class="modal-actions"><button type="button" class="btn" id="proxyCancelBtn">取消</button><button class="btn btn-primary" type="submit">保存代理</button></div>
+        </form>
+    </div>
+
+    <div class="modal-backdrop" id="sshKeyModal" aria-hidden="true">
+        <form class="connection-modal ssh-key-modal" id="sshKeyForm">
+            <div class="modal-head"><h2 id="sshKeyModalTitle">新增 SSH 密钥</h2><button type="button" class="icon-btn" id="sshKeyCloseBtn" aria-label="关闭 SSH 密钥弹窗">✕</button></div>
+            <input type="hidden" id="sshKeyId">
+            <div class="form-group"><label for="sshKeyName">密钥名称</label><input id="sshKeyName" required placeholder="例如：生产环境 deploy key"></div>
+            <div class="form-group"><label for="sshKeyPrivateKey">SSH 私钥</label><textarea id="sshKeyPrivateKey" required placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"></textarea></div>
+            <div class="form-group"><label for="sshKeyPassphrase">私钥口令</label><input id="sshKeyPassphrase" type="password" placeholder="可选"></div>
+            <div class="form-group"><label for="sshKeyRemark">备注</label><input id="sshKeyRemark" placeholder="可选"></div>
+            <p class="field-hint">编辑时留空或保留 ****** 不会覆盖已保存的私钥与口令。</p>
+            <div class="modal-actions"><button class="btn" type="button" id="sshKeyCancelBtn">取消</button><button class="btn btn-primary" type="submit" id="saveSshKeyBtn">保存 SSH 密钥</button></div>
+        </form>
+    </div>
+
+    <div class="modal-backdrop" id="snippetModal" aria-hidden="true">
+        <form class="connection-modal snippet-modal" id="snippetForm">
+            <div class="modal-head"><h2 id="snippetModalTitle">新增代码片段</h2><button type="button" class="icon-btn" id="snippetCloseBtn" aria-label="关闭代码片段弹窗">✕</button></div>
+            <input id="snippetId" type="hidden">
+            <div class="form-group"><label for="snippetName">名称</label><input id="snippetName" maxlength="60" required placeholder="例如：查看 Docker 状态"></div>
+            <div class="form-group"><label for="snippetCommand">命令内容</label><textarea id="snippetCommand" rows="6" required placeholder="docker ps\n# 支持多行命令"></textarea></div>
+            <div class="form-group"><label for="snippetGroup">分组 / 标签</label><input id="snippetGroup" maxlength="40" placeholder="例如：Docker / Linux / 自定义"></div>
+            <label class="settings-switch-option snippet-auto-run" for="snippetAutoRun"><span class="settings-switch-copy"><strong>点击后直接执行</strong><small>关闭时仅将命令填入终端输入框</small></span><span class="settings-switch-control"><input type="checkbox" id="snippetAutoRun"><span class="settings-switch-track" aria-hidden="true"></span></span></label>
+            <div class="modal-actions"><button class="btn" type="button" id="cancelSnippetEditBtn">取消</button><button class="btn btn-primary" type="submit" id="saveSnippetBtn">保存代码片段</button></div>
+        </form>
+    </div>
+
     <div class="toast" id="toast"></div>
+    <script src="preview-mock.js?v=20260723-activity1" type="module"></script>
     <script src="app.js?v=20260723-permission-workspace1" type="module"></script>
     <script>
         // Paint last shell immediately (before module load) to avoid dashboard flash.
         try {
             var lastView = localStorage.getItem('zephyr.lastView') || '';
-            if (['terminal','remote','notes','settings'].indexOf(lastView) >= 0) {
+            if (['activity','terminal','remote','notes','settings'].indexOf(lastView) >= 0) {
                 document.documentElement.dataset.earlyView = lastView;
                 document.addEventListener('DOMContentLoaded', function () {
                     document.querySelectorAll('.nav-tab').forEach(function (b) {

--- a/public/app.js
+++ b/public/app.js
@@ -18,6 +18,7 @@ installClosestFallback();
 document.documentElement.dataset.appModule = 'loaded';
 
 let connections = [], activities = [], proxies = [], jumpHosts = [], sshKeys = [], settings = {}, personalSettingsOverrides = {};
+let activityRange = '7d';
 let zephyrSharedClipboard = { type: '', text: '', files: [], sourceTabId: '', sourcePage: '', updatedAt: 0 };
 let aiSettingsState = null;
 let aiProviderShareTargetsState = [];
@@ -57,6 +58,12 @@ let transientToken = '';
 let transientHasCredential = false;
 let connectionModalTrigger = null;
 let connectionModalOriginRect = null;
+let proxyModalTrigger = null;
+let proxyModalOriginRect = null;
+let sshKeyModalTrigger = null;
+let sshKeyModalCycle = 0;
+let snippetModalTrigger = null;
+let snippetModalCycle = 0;
 let notesController = null;
 let workspaceClientId = '';
 let workspaceRevision = null;
@@ -1139,10 +1146,75 @@ function renderConnections() {
         <div class="tag-row">${(c.tags || []).map((t) => `<span>${escapeHtml(t)}</span>`).join('')}</div><div class="remark-md">${renderMarkdown(c.remark || '暂无备注')}</div>
         <div class="card-actions">${canEdit ? `<button class="tool-btn" data-edit="${c.id}">编辑</button>` : ''}${canDelete ? `<button class="tool-btn danger" data-delete="${c.id}">删除</button>` : ''}${canUse ? `<button class="btn btn-primary" data-connect="${c.id}">连接</button>` : '<button class="btn btn-primary" disabled title="仅观察">只读</button>'}</div></article>`;
     }).join('') : '<div class="empty-card">暂无连接，点击右上角添加新连接。</div>';
-    $('#activityList').innerHTML = activities.length ? activities.map((a) => `<div class="activity-item"><span>${fmtTime(a.time)}</span><b>${escapeHtml(a.message)}</b></div>`).join('') : '<div class="muted">暂无活动</div>';
     renderRemoteServers(); renderJumpOptions();
 }
-async function loadConnections() { const data = await api('/api/connections'); connections = data.connections || []; activities = data.activities || []; renderConnections(); }
+function activityRangeBounds(range = activityRange) {
+    const end = new Date();
+    if (range === 'all') return { from: 0, to: 0, label: '全部时间' };
+    if (range === 'custom') {
+        const startValue = $('#activityStartDate')?.value || '';
+        const endValue = $('#activityEndDate')?.value || '';
+        const from = startValue ? new Date(`${startValue}T00:00:00`).getTime() : 0;
+        const to = endValue ? new Date(`${endValue}T23:59:59.999`).getTime() : 0;
+        return { from, to, label: startValue || endValue ? `${startValue || '最早'} 至 ${endValue || '现在'}` : '自定义范围' };
+    }
+    const fromDate = new Date(end);
+    if (range === 'today') fromDate.setHours(0, 0, 0, 0);
+    else fromDate.setDate(fromDate.getDate() - (range === '30d' ? 30 : 7));
+    return { from: fromDate.getTime(), to: 0, label: range === 'today' ? '今天' : (range === '30d' ? '近 30 天' : '近 7 天') };
+}
+function activityDetails(activity) {
+    const message = String(activity.message || '未知活动');
+    const connection = connections.find((item) => message.includes(item.name) || activity.connectionId === item.id);
+    const category = activity.category || (/登录|密码|TOTP|Passkey|用户/.test(message) ? '账户' : (/连接|服务器|跳板机|代理|SSH 密钥/.test(message) ? '连接' : (/设置|邮件|导入|日志/.test(message) ? '系统' : '操作')));
+    const outcome = activity.outcome || (/失败|拒绝|错误|超时/.test(message) ? '失败' : '成功');
+    return {
+        category,
+        outcome,
+        actor: activity.actor || (activity.userId === myIdentity.userId ? '当前用户' : (activity.userId || '系统')),
+        protocol: activity.protocol || connection?.protocol || '—',
+        target: activity.target || (connection ? `${connection.host}:${connection.port}` : '—'),
+        sourceIp: activity.sourceIp || '—',
+        duration: Number.isFinite(Number(activity.durationMs)) ? `${Number(activity.durationMs)} ms` : '—',
+    };
+}
+function renderActivities() {
+    const list = $('#activityList');
+    if (!list) return;
+    const bounds = activityRangeBounds();
+    $('#activityResultCount').textContent = `${activities.length} 条记录`;
+    $('#activityRangeLabel').textContent = bounds.label;
+    list.innerHTML = activities.length ? activities.map((activity) => {
+        const detail = activityDetails(activity);
+        const outcomeClass = detail.outcome === '失败' ? 'failed' : 'success';
+        return `<article class="activity-detail-item">
+            <div class="activity-detail-head">
+                <div class="activity-event-mark" data-category="${escapeHtml(detail.category)}" aria-hidden="true"></div>
+                <div class="activity-event-title"><h2>${escapeHtml(activity.message || '未知活动')}</h2><span class="activity-status ${outcomeClass}">${escapeHtml(detail.outcome)}</span></div>
+                <time datetime="${new Date(Number(activity.time || 0)).toISOString()}">${escapeHtml(fmtTime(activity.time))}</time>
+            </div>
+            <dl class="activity-meta-grid">
+                <div><dt>事件类型</dt><dd>${escapeHtml(detail.category)}</dd></div>
+                <div><dt>操作者</dt><dd>${escapeHtml(detail.actor)}</dd></div>
+                <div><dt>协议</dt><dd>${escapeHtml(detail.protocol)}</dd></div>
+                <div><dt>目标地址</dt><dd>${escapeHtml(detail.target)}</dd></div>
+                <div><dt>来源 IP</dt><dd>${escapeHtml(detail.sourceIp)}</dd></div>
+                <div><dt>耗时</dt><dd>${escapeHtml(detail.duration)}</dd></div>
+            </dl>
+            <div class="activity-event-id"><span>事件 ID</span><code>${escapeHtml(activity.id || '—')}</code></div>
+        </article>`;
+    }).join('') : '<div class="activity-empty"><strong>此时间范围内没有活动</strong><span>尝试扩大时间范围查看更早的记录。</span></div>';
+}
+async function loadActivities() {
+    const { from, to } = activityRangeBounds();
+    const params = new URLSearchParams();
+    if (from) params.set('from', String(from));
+    if (to) params.set('to', String(to));
+    const data = await api(`/api/activities${params.size ? `?${params}` : ''}`);
+    activities = data.activities || [];
+    renderActivities();
+}
+async function loadConnections() { const data = await api('/api/connections'); connections = data.connections || []; renderConnections(); }
 function waitForConnectionCardExit(card, connectionId) {
     if (!card) return Promise.resolve();
     card.querySelectorAll('button').forEach((btn) => { btn.disabled = true; });
@@ -1158,6 +1230,22 @@ function waitForConnectionCardExit(card, connectionId) {
             resolve();
         };
         card.addEventListener('animationend', finish, { once: true });
+        window.setTimeout(finish, 380);
+    });
+}
+function waitForMiniItemExit(item, itemId) {
+    if (!item) return Promise.resolve();
+    item.querySelectorAll('button').forEach((btn) => { btn.disabled = true; });
+    item.classList.add('deleting');
+    return new Promise((resolve) => {
+        let done = false;
+        const finish = () => {
+            if (done) return;
+            done = true;
+            item.removeEventListener('animationend', finish);
+            resolve();
+        };
+        item.addEventListener('animationend', finish, { once: true });
         window.setTimeout(finish, 380);
     });
 }
@@ -1448,7 +1536,7 @@ function resetConnectionTransitionLayer(layer) {
     layer.style.whiteSpace = '';
     layer.innerHTML = '';
     layer.removeAttribute('data-has-source-visual');
-    layer.classList.remove('source-visual-hidden');
+    layer.classList.remove('source-visual-hidden', 'expanded-material');
 }
 function setConnectionModalMode(mode = 'create', { source = 'dashboard', draft = null, token = '' } = {}) {
     connectionModalMode = mode === 'transient' ? 'transient' : (mode === 'edit' || draft?.id ? 'edit' : 'create');
@@ -1554,7 +1642,7 @@ function openModal(conn = null, trigger = null, options = {}) {
     requestAnimationFrame(() => {
         document.body.classList.add('connection-home-blur');
         modal.classList.add('app-visible');
-        layer.classList.add('source-visual-hidden');
+        layer.classList.add('source-visual-hidden', 'expanded-material');
         layer.style.transition = `
             top var(--connection-app-duration) var(--connection-ios-spring),
             left var(--connection-app-duration) var(--connection-ios-spring),
@@ -1611,6 +1699,7 @@ function closeModal() {
 
     document.body.classList.add('disable-interaction', 'connection-transition-closing');
     document.body.classList.remove('connection-transition-opening', 'connection-home-blur');
+    layer.classList.remove('expanded-material');
 
     const sourceEl = currentRect.source || connectionModalTrigger;
     const sourceStyle = sourceEl?.isConnected ? getComputedStyle(sourceEl) : null;
@@ -7002,6 +7091,7 @@ function setupAiAssistant() {
     normalizeAiProviderModalLayout();
     setupAiPanelChrome();
     $('#aiSettingsForm')?.addEventListener('submit', saveAiSettings);
+    $('[data-ai-save-settings]')?.addEventListener('click', saveAiSettings);
     $('#aiAddProviderBtn')?.addEventListener('click', () => openAiProviderModal());
     $('#aiProviderForm')?.addEventListener('submit', saveAiProvider);
     $('#aiFetchModelsBtn')?.addEventListener('click', () => fetchAiModelsForProvider());
@@ -7238,7 +7328,7 @@ async function loadSecurityLists() {
     loginEvents = eventData.events || [];
     renderSecurityLists();
 }
-function renderTotp() { $('#totpBox').innerHTML = `<div class="mini-item"><b>TOTP 状态</b><span>${securityStatus.user.totpEnabled ? '已开启' : '未开启'}</span><button id="setupTotpBtn">${securityStatus.user.totpEnabled ? '重新绑定' : '开启 TOTP'}</button></div>`; $('#totpDisableForm').classList.toggle('force-hidden', !securityStatus.user.totpEnabled); }
+function renderTotp() { $('#totpBox').innerHTML = securityStatus.user.totpEnabled ? '<div class="mini-item"><b>TOTP 状态</b><span>已开启</span></div>' : '<p class="muted">暂无 TOTP</p>'; $('#totpAction').innerHTML = `<button class="security-card-action" id="setupTotpBtn" type="button">${securityStatus.user.totpEnabled ? '重新绑定' : '开启 TOTP'}</button>`; $('#totpDisableForm').classList.toggle('force-hidden', !securityStatus.user.totpEnabled); }
 function renderPasskeys() { $('#passkeyList').innerHTML = (securityStatus.passkeys || []).map((p) => `<div class="mini-item"><b>Passkey</b><span>${fmtTime(p.createdAt)}</span><button data-del-passkey="${p.id}">删除</button></div>`).join('') || '<p class="muted">暂无 Passkey</p>'; }
 function renderSecurityLists() { $('#ipBanList').innerHTML = ipBans.map((b) => `<div class="mini-item"><b>${escapeHtml(b.ip)}</b><span>失败 ${b.failedCount} · 解封 ${fmtTime(b.bannedUntil)}</span><button data-unban="${escapeHtml(b.ip)}">解除</button></div>`).join('') || '<p class="muted">暂无封禁 IP</p>'; $('#loginEventList').innerHTML = loginEvents.slice(0, 20).map((e) => `<div class="mini-item"><b>${e.success ? '成功' : '失败'} · ${escapeHtml(e.username || '-')}</b><span>${escapeHtml(e.ip || '')} · ${escapeHtml(e.reason || '')} · ${fmtTime(e.time)}</span></div>`).join('') || '<p class="muted">暂无登录事件</p>'; }
 async function saveSecurityPolicy(e) { e.preventDefault(); settings = await savePlatformSettings('security', { security: { ipWhitelistEnabled: $('#ipWhitelistEnabled').checked, ipWhitelist: $('#ipWhitelist').value, bruteForceEnabled: $('#bruteForceEnabled').checked, bruteForceMaxFailures: Number($('#bruteForceMaxFailures').value) || 5, bruteForceBanMinutes: Number($('#bruteForceBanMinutes').value) || 15 } }); toast('安全策略已保存'); }
@@ -7365,11 +7455,50 @@ function resetSnippetForm() {
     $('#snippetGroup').value = '';
     $('#snippetAutoRun').checked = false;
 }
+function openSnippetModal(item = null, trigger = null) {
+    window.clearTimeout(closeSnippetModal._timer);
+    ++snippetModalCycle;
+    const modal = $('#snippetModal');
+    if (!modal || (modal.classList.contains('show') && !modal.classList.contains('closing'))) return;
+    modal.classList.remove('show', 'closing', 'app-visible');
+    resetSnippetForm();
+    $('#snippetModalTitle').textContent = item ? '编辑代码片段' : '新增代码片段';
+    $('#saveSnippetBtn').textContent = item ? '保存修改' : '保存代码片段';
+    $('#snippetId').value = item?.id || '';
+    $('#snippetName').value = item?.name || '';
+    $('#snippetCommand').value = item?.command || '';
+    $('#snippetGroup').value = item?.group || '';
+    $('#snippetAutoRun').checked = !!item?.autoRun;
+    snippetModalTrigger = trigger || $('#addSnippetBtn');
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('connection-home-blur');
+    void modal.offsetWidth;
+    modal.classList.add('app-visible');
+    $('#snippetName')?.focus({ preventScroll: true });
+}
+function closeSnippetModal() {
+    const modal = $('#snippetModal');
+    if (!modal?.classList.contains('show') || modal.classList.contains('closing')) return;
+    modal.classList.add('closing');
+    modal.classList.remove('app-visible');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('connection-home-blur');
+    window.clearTimeout(closeSnippetModal._timer);
+    const cycle = ++snippetModalCycle;
+    closeSnippetModal._timer = window.setTimeout(() => {
+        if (cycle !== snippetModalCycle) return;
+        modal.classList.remove('show', 'closing');
+        resetSnippetForm();
+        snippetModalTrigger?.focus?.();
+        snippetModalTrigger = null;
+    }, 180);
+}
 function renderSnippetSettings() {
     const list = $('#snippetSettingsList');
     if (!list) return;
     const snippets = getSnippets();
-    list.innerHTML = snippets.length ? snippets.map((item) => `<div class="snippet-settings-item" data-id="${escapeHtml(item.id)}"><div><strong>${escapeHtml(item.name || '未命名片段')}</strong><em>${escapeHtml(item.group || '未分组')} · ${item.autoRun ? '直接执行' : '填入输入框'}</em><code>${escapeHtml(item.command || '')}</code></div><button class="tool-btn" data-edit-snippet="${escapeHtml(item.id)}">编辑</button><button class="tool-btn danger" data-delete-snippet="${escapeHtml(item.id)}">删除</button></div>`).join('') : '<p class="empty-state">暂无代码片段。</p>';
+    list.innerHTML = snippets.length ? snippets.map((item) => `<div class="mini-item snippet-settings-item" data-id="${escapeHtml(item.id)}"><span class="resource-tag resource-tag-name" title="${escapeHtml(item.name || '未命名片段')}">${escapeHtml(item.name || '未命名片段')}</span><div class="resource-meta"><span class="resource-tag resource-tag-protocol">${escapeHtml(item.group || '未分组')}</span><span class="resource-tag ${item.autoRun ? 'resource-tag-host' : 'resource-tag-auth'}">${item.autoRun ? '直接执行' : '填入输入框'}</span></div><button class="tool-btn" data-edit-snippet="${escapeHtml(item.id)}">编辑</button><button class="tool-btn danger" data-delete-snippet="${escapeHtml(item.id)}">删除</button></div>`).join('') : '<p class="empty-state">暂无代码片段。</p>';
 }
 async function saveSnippet(e) {
     e.preventDefault();
@@ -7382,26 +7511,33 @@ async function saveSnippet(e) {
     const idx = snippets.findIndex((x) => x.id === id);
     if (idx >= 0) snippets[idx] = item; else snippets.unshift(item);
     await persistSnippets(snippets);
-    resetSnippetForm();
+    closeSnippetModal();
     renderSnippetSettings();
     toast('代码片段已保存到服务端');
 }
 function setupSnippetSettings() {
     $('#snippetForm')?.addEventListener('submit', saveSnippet);
-    $('#cancelSnippetEditBtn')?.addEventListener('click', resetSnippetForm);
-    $('#snippetSettingsList')?.addEventListener('click', (e) => {
+    $('#addSnippetBtn')?.addEventListener('click', (e) => openSnippetModal(null, e.currentTarget));
+    $('#snippetCloseBtn')?.addEventListener('click', closeSnippetModal);
+    $('#cancelSnippetEditBtn')?.addEventListener('click', closeSnippetModal);
+    $('#snippetModal')?.addEventListener('click', (e) => { if (e.target.id === 'snippetModal') closeSnippetModal(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && $('#snippetModal')?.classList.contains('show')) closeSnippetModal(); });
+    $('#snippetSettingsList')?.addEventListener('click', async (e) => {
         const editId = e.target.closest?.('[data-edit-snippet]')?.dataset.editSnippet;
         const deleteId = e.target.closest?.('[data-delete-snippet]')?.dataset.deleteSnippet;
         const snippets = getSnippets();
         if (editId) {
             const item = snippets.find((x) => x.id === editId); if (!item) return;
-            $('#snippetId').value = item.id; $('#snippetName').value = item.name || ''; $('#snippetCommand').value = item.command || ''; $('#snippetGroup').value = item.group || ''; $('#snippetAutoRun').checked = !!item.autoRun;
+            openSnippetModal(item, e.target.closest('[data-edit-snippet]'));
         }
         if (deleteId) {
-            persistSnippets(snippets.filter((x) => x.id !== deleteId)).then(() => {
+            if (!confirm('删除该代码片段？')) return;
+            await waitForMiniItemExit(e.target.closest('.mini-item'), deleteId);
+            try {
+                await persistSnippets(snippets.filter((x) => x.id !== deleteId));
                 renderSnippetSettings();
                 toast('代码片段已从服务端删除');
-            }).catch((err) => toast(err.message || '删除失败'));
+            } catch (err) { toast(err.message || '删除失败'); }
         }
     });
     renderSnippetSettings();
@@ -7420,12 +7556,155 @@ async function loadNetwork() {
     renderSshKeyOptions($('#connSshKey')?.value || '');
 }
 function renderNetwork() {
-    $('#proxyList').innerHTML = proxies.map((p) => `<div class="mini-item"><b>${escapeHtml(p.name)}</b><span>${escapeHtml((p.type || 'socks5').toUpperCase())} · ${escapeHtml(p.host)}:${p.port}</span><button data-edit-proxy="${p.id}">编辑</button><button data-open-proxy="${p.id}">查看</button><button data-del-proxy="${p.id}">删除</button></div>`).join('') || '<p class="muted">暂无代理</p>';
-    $('#sshKeyList').innerHTML = sshKeys.map((k) => `<div class="mini-item"><b>${escapeHtml(k.name)}</b><span>${k.hasPrivateKey ? '已保存私钥' : '无私钥'}${k.hasPassphrase ? ' · 有口令' : ''}${k.remark ? ` · ${escapeHtml(k.remark)}` : ''}</span><button data-edit-ssh-key="${k.id}">编辑</button><button data-open-ssh-key="${k.id}">查看</button><button data-del-ssh-key="${k.id}">删除</button></div>`).join('') || '<p class="muted">暂无 SSH 密钥</p>';
+    $('#proxyList').innerHTML = proxies.map((p) => `<div class="mini-item proxy-item"><span class="resource-tag resource-tag-name" title="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span><div class="resource-meta"><span class="resource-tag resource-tag-protocol">${escapeHtml((p.type || 'socks5').toUpperCase())}</span><span class="resource-tag resource-tag-host" title="${escapeHtml(p.host)}">${escapeHtml(p.host)}</span><span class="resource-tag resource-tag-port">${Number(p.port) || 1080}</span>${p.username ? `<span class="resource-tag resource-tag-auth">${escapeHtml(p.username)}</span>` : ''}${p.hasPassword ? '<span class="resource-tag resource-tag-secret">有密码</span>' : ''}</div><button data-edit-proxy="${p.id}">编辑</button><button data-open-proxy="${p.id}">查看</button><button data-del-proxy="${p.id}">删除</button></div>`).join('') || '<p class="muted">暂无代理</p>';
+    $('#sshKeyList').innerHTML = sshKeys.map((k) => `<div class="mini-item ssh-key-item"><span class="ssh-key-tag ssh-key-tag-name" title="${escapeHtml(k.name)}">${escapeHtml(k.name)}</span><div class="ssh-key-meta"><span class="ssh-key-tag ssh-key-tag-private">${k.hasPrivateKey ? '已保存私钥' : '无私钥'}</span>${k.hasPassphrase ? '<span class="ssh-key-tag ssh-key-tag-passphrase">有口令</span>' : ''}${k.remark ? `<span class="ssh-key-tag ssh-key-tag-remark" title="${escapeHtml(k.remark)}">${escapeHtml(k.remark)}</span>` : ''}</div><button data-edit-ssh-key="${k.id}">编辑</button><button data-open-ssh-key="${k.id}">查看</button><button data-del-ssh-key="${k.id}">删除</button></div>`).join('') || '<p class="muted">暂无 SSH 密钥</p>';
 }
 function renderJumpOptions() { if ($('#jumpRouteConfig') && $('#connMode')?.value === 'jump') updateRouteOptions('jump', $$('#jumpRouteList [data-jump-route-select]').map((el) => el.value).filter(Boolean)); }
-async function saveProxy(e) { e.preventDefault(); const id = $('#proxyId').value, payload = { name: $('#proxyName').value, type: $('#proxyType').value, host: $('#proxyHost').value, port: Number($('#proxyPort').value), username: $('#proxyUsername').value, password: $('#proxyPassword').value }; console.debug('[route-ui]', 'save proxy payload', { id, ...payload, password: payload.password ? '******' : '' }); await api(id ? `/api/proxies/${id}` : '/api/proxies', { method: id ? 'PUT' : 'POST', body: JSON.stringify(payload) }); e.target.reset(); $('#proxyId').value = ''; $('#proxyType').value = 'socks5'; await loadNetwork(); toast('代理已保存'); }
-async function openProxySecret(id) {
+function resetProxyForm() { $('#proxyForm')?.reset(); $('#proxyId').value = ''; $('#proxyType').value = 'socks5'; $('#proxyPort').value = '1080'; }
+function openProxyModal(proxy = null, trigger = null) {
+    resetProxyForm();
+    $('#proxyModalTitle').textContent = proxy ? '编辑代理' : '新建代理';
+    $('#proxyId').value = proxy?.id || '';
+    $('#proxyName').value = proxy?.name || '';
+    $('#proxyType').value = proxy?.type || 'socks5';
+    $('#proxyHost').value = proxy?.host || '';
+    $('#proxyPort').value = proxy?.port || 1080;
+    $('#proxyUsername').value = proxy?.username || '';
+    $('#proxyPassword').value = proxy?.hasPassword ? '******' : '';
+    const modal = $('#proxyModal');
+    const layer = $('#connectionTransitionLayer');
+    if (!modal || !layer || modal.classList.contains('show')) return;
+    window.clearTimeout(closeProxyModal._timer);
+    window.clearTimeout(openProxyModal._finishTimer);
+    resetConnectionTransitionLayer(layer);
+    modal.classList.remove('closing', 'app-visible');
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+    proxyModalTrigger = trigger || $('#addProxyBtn');
+    const sourceRect = connectionTransitionTargetRect(proxyModalTrigger);
+    const viewport = viewportMetrics();
+    proxyModalOriginRect = { left: sourceRect.left, top: sourceRect.top, width: sourceRect.width, height: sourceRect.height };
+    syncConnectionLayerVisual(layer, sourceRect.source);
+    setConnectionLayerRect(layer, proxyModalOriginRect);
+    layer.style.transition = 'none';
+    layer.style.borderRadius = getComputedStyle(sourceRect.source || proxyModalTrigger || layer).borderRadius || '18px';
+    layer.style.boxShadow = 'none';
+    layer.style.visibility = 'visible';
+    layer.style.pointerEvents = 'auto';
+    proxyModalTrigger?.style?.setProperty('opacity', '0');
+    document.body.classList.add('disable-interaction', 'connection-transition-opening');
+    void layer.offsetHeight;
+    requestAnimationFrame(() => {
+        document.body.classList.add('connection-home-blur');
+        modal.classList.add('app-visible');
+        layer.classList.add('source-visual-hidden', 'expanded-material');
+        layer.style.transition = `
+            top var(--connection-app-duration) var(--connection-ios-spring),
+            left var(--connection-app-duration) var(--connection-ios-spring),
+            width var(--connection-app-duration) var(--connection-ios-spring),
+            height var(--connection-app-duration) var(--connection-ios-spring),
+            border-radius var(--connection-app-duration) var(--connection-ios-spring)
+        `;
+        setConnectionLayerRect(layer, viewport);
+        layer.style.borderRadius = '0px';
+    });
+    openProxyModal._finishTimer = window.setTimeout(() => {
+        document.body.classList.remove('disable-interaction', 'connection-transition-opening');
+        modal.classList.add('app-visible');
+        $('#proxyName')?.focus();
+    }, 520);
+}
+function closeProxyModal() {
+    const modal = $('#proxyModal');
+    const layer = $('#connectionTransitionLayer');
+    if (!modal?.classList.contains('show') || modal.classList.contains('closing')) return;
+    window.clearTimeout(closeProxyModal._timer);
+    window.clearTimeout(openProxyModal._finishTimer);
+    modal.classList.add('closing');
+    modal.classList.remove('app-visible');
+    modal.setAttribute('aria-hidden', 'true');
+    const viewport = viewportMetrics();
+    const sourceRect = proxyModalOriginRect || connectionTransitionTargetRect(proxyModalTrigger);
+    const source = proxyModalTrigger?.isConnected ? proxyModalTrigger : $('#addProxyBtn');
+    const sourceRadius = getComputedStyle(source || layer).borderRadius || '18px';
+    const shadowLayer = getConnectionTransitionShadowLayer();
+    document.body.classList.add('disable-interaction', 'connection-transition-closing');
+    document.body.classList.remove('connection-transition-opening', 'connection-home-blur');
+    layer.classList.remove('expanded-material');
+    applyConnectionLayerSourceChrome(layer, source, { revealVisual: true });
+    layer.style.visibility = 'visible';
+    layer.style.pointerEvents = 'auto';
+    layer.style.transition = 'none';
+    setConnectionLayerRect(layer, viewport);
+    layer.style.borderRadius = '0px';
+    layer.classList.remove('source-visual-hidden');
+    shadowLayer.style.visibility = 'visible';
+    shadowLayer.style.pointerEvents = 'none';
+    shadowLayer.style.transition = 'none';
+    shadowLayer.style.left = `${viewport.left}px`;
+    shadowLayer.style.top = `${viewport.top}px`;
+    shadowLayer.style.width = `${viewport.width}px`;
+    shadowLayer.style.height = `${viewport.height}px`;
+    shadowLayer.style.borderRadius = '0px';
+    shadowLayer.style.boxShadow = 'var(--connection-shadow-active)';
+    shadowLayer.style.opacity = '1';
+    shadowLayer.style.zIndex = '99';
+    void layer.offsetHeight;
+    void shadowLayer.offsetHeight;
+    requestAnimationFrame(() => {
+        layer.style.transition = `
+            top var(--connection-app-duration) var(--connection-ios-spring),
+            left var(--connection-app-duration) var(--connection-ios-spring),
+            width var(--connection-app-duration) var(--connection-ios-spring),
+            height var(--connection-app-duration) var(--connection-ios-spring),
+            border-radius var(--connection-app-duration) var(--connection-ios-spring)
+        `;
+        setConnectionLayerRect(layer, sourceRect);
+        layer.style.borderRadius = sourceRadius;
+        shadowLayer.style.transition = `
+            left var(--connection-app-duration) var(--connection-ios-spring),
+            top var(--connection-app-duration) var(--connection-ios-spring),
+            width var(--connection-app-duration) var(--connection-ios-spring),
+            height var(--connection-app-duration) var(--connection-ios-spring),
+            border-radius var(--connection-app-duration) var(--connection-ios-spring),
+            opacity 0.72s cubic-bezier(.16, 1, .3, 1),
+            box-shadow 0.72s cubic-bezier(.16, 1, .3, 1)
+        `;
+        setConnectionLayerRect(shadowLayer, sourceRect);
+        shadowLayer.style.borderRadius = sourceRadius;
+        shadowLayer.style.boxShadow = '0 6px 18px rgba(0,0,0,0.10)';
+        shadowLayer.style.opacity = '0';
+    });
+
+    const restoreTriggerWithoutTransition = () => {
+        const trigger = proxyModalTrigger;
+        if (!trigger?.style) return;
+        const oldTransition = trigger.style.transition;
+        trigger.style.transition = 'none';
+        trigger.style.removeProperty('opacity');
+        void trigger.offsetHeight;
+        requestAnimationFrame(() => oldTransition ? trigger.style.transition = oldTransition : trigger.style.removeProperty('transition'));
+    };
+    let done = false;
+    const finish = () => {
+        if (done) return;
+        done = true;
+        layer.removeEventListener('transitionend', onEnd);
+        modal.classList.remove('show', 'closing', 'app-visible');
+        resetConnectionTransitionLayer(layer);
+        restoreTriggerWithoutTransition();
+        closeProxyModal._shadowTimer = window.setTimeout(() => resetConnectionTransitionShadow(shadowLayer), 180);
+        document.body.classList.remove('disable-interaction', 'connection-transition-closing', 'connection-home-blur');
+        proxyModalTrigger = null;
+        proxyModalOriginRect = null;
+        resetProxyForm();
+    };
+    const onEnd = (ev) => { if (ev.propertyName === 'top') finish(); };
+    layer.addEventListener('transitionend', onEnd);
+    closeProxyModal._timer = window.setTimeout(finish, 560);
+}
+async function saveProxy(e) { e.preventDefault(); const id = $('#proxyId').value, payload = { name: $('#proxyName').value, type: $('#proxyType').value, host: $('#proxyHost').value, port: Number($('#proxyPort').value), username: $('#proxyUsername').value, password: $('#proxyPassword').value }; console.debug('[route-ui]', 'save proxy payload', { id, ...payload, password: payload.password ? '******' : '' }); await api(id ? `/api/proxies/${id}` : '/api/proxies', { method: id ? 'PUT' : 'POST', body: JSON.stringify(payload) }); closeProxyModal(); await loadNetwork(); toast('代理已保存'); }
+async function openProxySecret(id, trigger = null) {
     const secret = requestSensitiveSecret('查看已保存代理密码');
     const data = await api(`/api/proxies/${id}/open`, { method: 'POST', body: JSON.stringify({ secret }) });
     const p = data.proxy || {};
@@ -7436,24 +7715,66 @@ async function openProxySecret(id) {
     $('#proxyPort').value = p.port || '';
     $('#proxyUsername').value = p.username || '';
     $('#proxyPassword').value = p.password || '';
+    openProxyModal(p, trigger);
+    $('#proxyPassword').value = p.password || '';
     console.debug('[proxy-ui]', 'proxy secret loaded', { id, hasPassword: !!p.password });
     toast('已载入代理密码');
 }
 function resetSshKeyForm() { $('#sshKeyForm').reset(); $('#sshKeyId').value = ''; $('#sshKeyPrivateKey').value = ''; $('#sshKeyPassphrase').value = ''; }
+function openSshKeyModal(sshKey = null, trigger = null) {
+    window.clearTimeout(closeSshKeyModal._timer);
+    ++sshKeyModalCycle;
+    const modal = $('#sshKeyModal');
+    if (!modal || (modal.classList.contains('show') && !modal.classList.contains('closing'))) return;
+    modal.classList.remove('show', 'closing', 'app-visible');
+    resetSshKeyForm();
+    $('#sshKeyModalTitle').textContent = sshKey ? '编辑 SSH 密钥' : '新增 SSH 密钥';
+    $('#saveSshKeyBtn').textContent = sshKey ? '保存修改' : '保存 SSH 密钥';
+    $('#sshKeyId').value = sshKey?.id || '';
+    $('#sshKeyName').value = sshKey?.name || '';
+    $('#sshKeyPrivateKey').value = sshKey?.hasPrivateKey ? '******' : '';
+    $('#sshKeyPassphrase').value = sshKey?.hasPassphrase ? '******' : '';
+    $('#sshKeyRemark').value = sshKey?.remark || '';
+    sshKeyModalTrigger = trigger || $('#addSshKeyBtn');
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('connection-home-blur');
+    void modal.offsetWidth;
+    modal.classList.add('app-visible');
+    $('#sshKeyName')?.focus({ preventScroll: true });
+}
+function closeSshKeyModal() {
+    const modal = $('#sshKeyModal');
+    if (!modal?.classList.contains('show') || modal.classList.contains('closing')) return;
+    modal.classList.add('closing');
+    modal.classList.remove('app-visible');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('connection-home-blur');
+    window.clearTimeout(closeSshKeyModal._timer);
+    const cycle = ++sshKeyModalCycle;
+    closeSshKeyModal._timer = window.setTimeout(() => {
+        if (cycle !== sshKeyModalCycle) return;
+        modal.classList.remove('show', 'closing');
+        resetSshKeyForm();
+        sshKeyModalTrigger?.focus?.();
+        sshKeyModalTrigger = null;
+    }, 180);
+}
 async function saveSshKey(e) {
     e.preventDefault();
     const id = $('#sshKeyId').value;
     const payload = { name: $('#sshKeyName').value.trim(), privateKey: $('#sshKeyPrivateKey').value, passphrase: $('#sshKeyPassphrase').value, remark: $('#sshKeyRemark').value.trim() };
     console.debug('[ssh-key-ui]', 'save ssh key payload', { id, name: payload.name, hasPrivateKey: !!payload.privateKey && payload.privateKey !== '******', hasPassphrase: !!payload.passphrase && payload.passphrase !== '******' });
     await api(id ? `/api/ssh-keys/${id}` : '/api/ssh-keys', { method: id ? 'PUT' : 'POST', body: JSON.stringify(payload) });
-    resetSshKeyForm();
+    closeSshKeyModal();
     await loadNetwork();
     toast('SSH 密钥已保存');
 }
-async function openSshKeySecret(id) {
+async function openSshKeySecret(id, trigger = null) {
     const secret = requestSensitiveSecret('查看已保存 SSH 密钥');
     const data = await api(`/api/ssh-keys/${id}/open`, { method: 'POST', body: JSON.stringify({ secret }) });
     const k = data.sshKey || {};
+    openSshKeyModal(k, trigger);
     $('#sshKeyId').value = k.id || '';
     $('#sshKeyName').value = k.name || '';
     $('#sshKeyPrivateKey').value = k.privateKey || '';
@@ -7486,7 +7807,7 @@ function bindEvents() {
     bindConnectionPressFeedback();
     $$('.nav-tab').forEach((btn) => btn.addEventListener('click', () => switchView(btn.dataset.view)));
     $$('.settings-tab').forEach((btn) => btn.addEventListener('click', () => { $$('.settings-tab').forEach((b) => b.classList.remove('active')); btn.classList.add('active'); $$('.settings-panel').forEach((p) => p.classList.remove('active')); $(`#settings-${btn.dataset.settings}`).classList.add('active'); scheduleWorkspaceSave('settings-tab'); }));
-    ['view-settings', 'view-dashboard'].forEach((id) => document.getElementById(id)?.addEventListener('scroll', () => scheduleWorkspaceSave(`${id}-scroll`), { passive: true }));
+    ['view-settings', 'view-dashboard', 'view-activity'].forEach((id) => document.getElementById(id)?.addEventListener('scroll', () => scheduleWorkspaceSave(`${id}-scroll`), { passive: true }));
     $('#appThemeToggle').addEventListener('click', () => toggleTheme().catch((err) => toast(err.message))); $('#settingsThemeToggle').addEventListener('click', () => toggleTheme().catch((err) => toast(err.message))); $('#logoutBtn').addEventListener('click', async () => { await api('/api/auth/logout', { method: 'POST' }); location.href = '/'; });
     $('#notesSettingsForm')?.addEventListener('submit', saveNotesSettings);
     $('#notifyLoginPersonal')?.addEventListener('change', () => savePersonalLoginNotification().catch((err) => toast(err.message || '保存通知设置失败')));
@@ -7501,6 +7822,17 @@ function bindEvents() {
     $('#rdpTouchMode')?.addEventListener('change', updateRdpTouchSettingsUi);
     $('#rdpTouchSensitivity')?.addEventListener('input', updateRdpTouchSettingsUi);
     $('#connectionForm').addEventListener('submit', saveConnection); restoreConnectionFilters(); ['searchInput', 'protocolFilter', 'tagFilter', 'sortSelect'].forEach((id) => { const el = $(`#${id}`); const handler = () => { saveConnectionFilters(); renderConnections(); }; el.addEventListener('input', handler); el.addEventListener('change', handler); });
+    $$('[data-activity-range]').forEach((button) => button.addEventListener('click', async () => {
+        activityRange = button.dataset.activityRange || '7d';
+        $$('[data-activity-range]').forEach((item) => item.classList.toggle('active', item === button));
+        $('#activityCustomRange').classList.toggle('force-hidden', activityRange !== 'custom');
+        if (activityRange !== 'custom') await loadActivities();
+    }));
+    $('#applyActivityRange')?.addEventListener('click', async () => {
+        const bounds = activityRangeBounds('custom');
+        if (bounds.from && bounds.to && bounds.from > bounds.to) return toast('开始日期不能晚于结束日期');
+        await loadActivities();
+    });
     $('#connectionGrid').addEventListener('click', async (e) => {
         const edit = e.target.closest?.('[data-edit]')?.dataset.edit, del = e.target.closest?.('[data-delete]')?.dataset.delete, connect = e.target.closest?.('[data-connect]')?.dataset.connect;
         if (edit) openModal(connections.find((c) => c.id === edit), e.target.closest?.('[data-edit]'));
@@ -7848,17 +8180,17 @@ function bindEvents() {
         enforceTerminalWorkspaceLimit(activeTerminalTab);
         renderTerminalTabs();
     });
-    $('#remoteExecForm').addEventListener('submit', remoteExecute); $('#beianForm').addEventListener('submit', saveBeian); $('#proxyForm').addEventListener('submit', saveProxy); $('#sshKeyForm').addEventListener('submit', saveSshKey); $('#resetSshKeyForm').addEventListener('click', resetSshKeyForm);
+    $('#remoteExecForm').addEventListener('submit', remoteExecute); $('#beianForm').addEventListener('submit', saveBeian); $('#proxyForm').addEventListener('submit', saveProxy); $('#addProxyBtn')?.addEventListener('click', (e) => openProxyModal(null, e.currentTarget)); $('#proxyCloseBtn')?.addEventListener('click', closeProxyModal); $('#proxyCancelBtn')?.addEventListener('click', closeProxyModal); $('#proxyModal')?.addEventListener('click', (e) => { if (e.target.id === 'proxyModal') closeProxyModal(); }); $('#sshKeyForm').addEventListener('submit', saveSshKey); $('#addSshKeyBtn')?.addEventListener('click', (e) => openSshKeyModal(null, e.currentTarget)); $('#sshKeyCloseBtn')?.addEventListener('click', closeSshKeyModal); $('#sshKeyCancelBtn')?.addEventListener('click', closeSshKeyModal); $('#sshKeyModal')?.addEventListener('click', (e) => { if (e.target.id === 'sshKeyModal') closeSshKeyModal(); }); document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && $('#sshKeyModal')?.classList.contains('show')) closeSshKeyModal(); });
     setupAiAssistant();
     $('#brandIconFile').addEventListener('change', async (e) => { try { const dataUrl = await readImageAsDataUrl(e.target.files?.[0]); if (!dataUrl) return; pendingBrandIcon = dataUrl; $('#brandIconPreview').innerHTML = iconHtml(dataUrl); console.debug('[appearance-client]', 'brand icon file loaded', { size: e.target.files?.[0]?.size || 0, type: e.target.files?.[0]?.type || '' }); } catch (err) { e.target.value = ''; toast(err.message); } });
     setupAppearanceControls();
     $('#resetAppearanceBtn').addEventListener('click', () => resetAppearance().catch((err) => toast(err.message)));
-    $('#proxyList').addEventListener('click', async (e) => { const id = e.target.dataset.editProxy || e.target.dataset.openProxy || e.target.dataset.delProxy; if (!id) return; const p = proxies.find((x) => x.id === id); if (e.target.dataset.editProxy) { $('#proxyId').value = p.id; $('#proxyName').value = p.name; $('#proxyType').value = p.type || 'socks5'; $('#proxyHost').value = p.host; $('#proxyPort').value = p.port; $('#proxyUsername').value = p.username || ''; $('#proxyPassword').value = p.hasPassword ? '******' : ''; } else if (e.target.dataset.openProxy) { await openProxySecret(id); } else if (confirm('删除代理？')) { await api(`/api/proxies/${id}`, { method: 'DELETE' }); await loadNetwork(); } });
-    $('#sshKeyList').addEventListener('click', async (e) => { const editId = e.target.dataset.editSshKey, openId = e.target.dataset.openSshKey, delId = e.target.dataset.delSshKey; if (editId) { const k = sshKeys.find((x) => x.id === editId); if (!k) return; $('#sshKeyId').value = k.id; $('#sshKeyName').value = k.name || ''; $('#sshKeyPrivateKey').value = k.hasPrivateKey ? '******' : ''; $('#sshKeyPassphrase').value = k.hasPassphrase ? '******' : ''; $('#sshKeyRemark').value = k.remark || ''; return; } if (openId) { await openSshKeySecret(openId); return; } if (delId && confirm('删除该 SSH 密钥？已选择它的连接将无法再使用该密钥。')) { await api(`/api/ssh-keys/${delId}`, { method: 'DELETE' }); await loadNetwork(); toast('SSH 密钥已删除'); } });
+    $('#proxyList').addEventListener('click', async (e) => { const id = e.target.dataset.editProxy || e.target.dataset.openProxy || e.target.dataset.delProxy; if (!id) return; const p = proxies.find((x) => x.id === id); if (e.target.dataset.editProxy) openProxyModal(p, e.target); else if (e.target.dataset.openProxy) { await openProxySecret(id, e.target); } else if (confirm('删除代理？')) { await waitForMiniItemExit(e.target.closest('.mini-item'), id); await api(`/api/proxies/${id}`, { method: 'DELETE' }); await loadNetwork(); toast('代理已删除'); } });
+    $('#sshKeyList').addEventListener('click', async (e) => { const editId = e.target.dataset.editSshKey, openId = e.target.dataset.openSshKey, delId = e.target.dataset.delSshKey; if (editId) { const k = sshKeys.find((x) => x.id === editId); if (k) openSshKeyModal(k, e.target); return; } if (openId) { await openSshKeySecret(openId, e.target); return; } if (delId && confirm('删除该 SSH 密钥？已选择它的连接将无法再使用该密钥。')) { await waitForMiniItemExit(e.target.closest('.mini-item'), delId); await api(`/api/ssh-keys/${delId}`, { method: 'DELETE' }); await loadNetwork(); toast('SSH 密钥已删除'); } });
     $('#passwordForm').addEventListener('submit', async (e) => { e.preventDefault(); const currentPassword = $('#settingsCurrentPassword').value, newPassword = $('#settingsNewPassword').value, confirmPassword = $('#settingsConfirmPassword').value; if (newPassword !== confirmPassword) return toast('两次输入的新密码不一致'); await api('/api/auth/change-password', { method: 'POST', body: JSON.stringify({ currentPassword, newPassword }) }); e.target.reset(); toast('密码已更新'); });
     $('#profileForm').addEventListener('submit', async (e) => { e.preventDefault(); await api('/api/security/profile', { method: 'PUT', body: JSON.stringify({ username: $('#profileUsername').value.trim(), email: $('#profileEmail').value }) }); toast('资料已保存'); await loadSecurityStatus(); });
     $('#securityPolicyForm').addEventListener('submit', saveSecurityPolicy); $('#captchaForm').addEventListener('submit', saveCaptcha); $('#mailForm').addEventListener('submit', saveMail); $('#appearanceForm').addEventListener('submit', saveAppearance); $('#terminalLayoutForm').addEventListener('submit', saveTerminalLayout); setupSnippetSettings(); setupAgentTokenSettings();
-    $('#totpBox').addEventListener('click', (e) => { if (e.target.id === 'setupTotpBtn') setupTotp().catch((err) => toast(err.message)); });
+    $('#totpAction').addEventListener('click', (e) => { if (e.target.id === 'setupTotpBtn') setupTotp().catch((err) => toast(err.message)); });
     $('#totpEnableForm').addEventListener('submit', async (e) => { e.preventDefault(); await api('/api/security/totp/enable', { method: 'POST', body: JSON.stringify({ code: $('#totpEnableCode').value }) }); toast('TOTP 已开启'); $('#totpEnableForm').classList.add('force-hidden'); await loadSecurityStatus(); });
     $('#totpDisableForm').addEventListener('submit', async (e) => { e.preventDefault(); if (!confirm('确定关闭 TOTP？')) return; await api('/api/security/totp/disable', { method: 'POST', body: JSON.stringify({ currentPassword: $('#totpDisablePassword').value, code: $('#totpDisableCode').value }) }); e.target.reset(); toast('TOTP 已关闭'); await loadSecurityStatus(); });
     $('#addPasskeyBtn').addEventListener('click', () => registerPasskey().catch((err) => toast(err.message)));
@@ -7870,7 +8202,7 @@ function bindEvents() {
     $('#revealMailPass').addEventListener('click', () => revealMailPass().catch((err) => toast(err.message || '读取 SMTP 密码失败')));
     $('#testMailBtn').addEventListener('click', () => testMail());
     $('#exportDataBtn').addEventListener('click', () => { location.href = '/api/data/export'; });
-    $('#clearActivityBtn').addEventListener('click', async () => { if (!confirm('确定清理最近活动日志？')) return; await api('/api/activities', { method: 'DELETE' }); await loadConnections(); toast('活动日志已清理'); });
+    $('#clearActivityBtn').addEventListener('click', async () => { if (!confirm('确定清理活动日志？')) return; await api('/api/activities', { method: 'DELETE' }); await loadActivities(); toast('活动日志已清理'); });
     $('#clearLoginEventsBtn').addEventListener('click', async () => { if (!confirm('确定清理登录事件日志？')) return; await api('/api/security/login-events', { method: 'DELETE' }); await loadSecurityLists(); toast('登录事件已清理'); });
     $('#importDataForm').addEventListener('submit', async (e) => { e.preventDefault(); if (!confirm('导入会覆盖当前数据库，系统会先生成本地备份。继续？')) return; const fd = new FormData(); fd.append('backup', $('#backupFile').files[0]); fd.append('loginPassword', $('#importLoginPassword').value); fd.append('backupPassword', $('#backupPassword').value); const res = await fetch('/api/data/import', { method: 'POST', body: fd, credentials: 'same-origin' }); const data = await res.json().catch(() => ({})); if (!res.ok) throw new Error(data.error || '导入失败'); toast(data.message || '导入完成'); });
 }
@@ -8045,7 +8377,7 @@ async function restoreLastWorkspace() {
                 .sort((a, b) => Number(a.order || 0) - Number(b.order || 0))
             : [];
         const view = String(state.ui?.activeView || 'dashboard');
-        const allowedView = ['dashboard', 'terminal', 'remote', 'notes', 'settings'].includes(view) ? view : 'dashboard';
+        const allowedView = ['dashboard', 'activity', 'terminal', 'remote', 'notes', 'settings'].includes(view) ? view : 'dashboard';
         // Switch view first so the user lands on the terminal shell immediately,
         // then re-attach sessions underneath (with history replay).
         if (savedTabs.length && (allowedView === 'terminal' || savedTabs.some((t) => t.active))) {
@@ -8385,6 +8717,7 @@ async function handleAdminAction(action, userId) {
 }
 
 function registerStaticAssetWorker() {
+    if (window.__zephyrPreviewMode) return;
     if (!('serviceWorker' in navigator)) return;
     navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch((err) => {
         console.warn('[service-worker] registration failed', err);
@@ -8408,7 +8741,7 @@ async function init() {
         // network restore so refresh does not flash the dashboard first.
         try {
             const lastView = localStorage.getItem('zephyr.lastView') || '';
-            if (['terminal', 'remote', 'notes', 'settings', 'dashboard'].includes(lastView) && lastView !== 'dashboard') {
+            if (['activity', 'terminal', 'remote', 'notes', 'settings', 'dashboard'].includes(lastView) && lastView !== 'dashboard') {
                 currentAppView = lastView;
                 $$('.nav-tab').forEach((b) => b.classList.toggle('active', b.dataset.view === lastView));
                 $$('.view').forEach((v) => v.classList.toggle('active', v.id === `view-${lastView}`));
@@ -8436,6 +8769,7 @@ async function init() {
         renderSnippetSettings();
         await loadConnections();
         document.documentElement.dataset.appLoadConnections = 'ok';
+        await loadActivities();
         await restoreLastWorkspace();
         await backgroundLoads;
         // Deep Link hand-off from /open (token only — never the raw URI).

--- a/public/client.js
+++ b/public/client.js
@@ -279,8 +279,9 @@ async function loadBeian() {
         captchaConfig = publicSettings.captcha || { enabled: false, provider: 'turnstile', siteKey: '' };
         defaultUsername = s.defaultUsername || 'admin';
         const usernameInput = $('#username');
-        if (usernameInput) usernameInput.removeAttribute('placeholder');
-        $('#password')?.removeAttribute('placeholder');
+        if (usernameInput) usernameInput.placeholder = ' ';
+        const passwordInput = $('#password');
+        if (passwordInput) passwordInput.placeholder = ' ';
         const hint = $('.auth-hint');
         if (hint) hint.textContent = '';
         initRememberMe();

--- a/public/index.html
+++ b/public/index.html
@@ -18,11 +18,11 @@
         <form id="loginForm" autocomplete="off">
             <div class="form-group">
                 <label for="username">账号</label>
-                <input type="text" id="username" autocomplete="username" required>
+                <input type="text" id="username" autocomplete="username" placeholder=" " required>
             </div>
             <div class="form-group">
                 <label for="password">密码</label>
-                <input type="password" id="password" autocomplete="current-password" required>
+                <input type="password" id="password" autocomplete="current-password" placeholder=" " required>
             </div>
             <div class="auth-options">
                 <label class="remember-me"><input type="checkbox" id="rememberMe"> 记住我</label>
@@ -44,8 +44,8 @@
         <button class="theme-btn-login" id="themeToggleForgot" title="切换主题">🌓</button>
         <div class="logo">🌬️</div><h1>重置密码</h1><p class="auth-subtitle">通过管理员邮箱验证码重置</p>
         <div id="forgotErrorBanner" class="error-banner"></div>
-        <form id="forgotRequestForm"><div class="form-group"><label>管理员邮箱</label><input type="email" id="forgotEmail" required></div><button class="btn btn-primary" type="submit">发送验证码</button></form>
-        <form id="forgotResetForm" class="force-hidden"><div class="form-group"><label>验证码</label><input id="resetCode" inputmode="numeric" maxlength="6" required></div><div class="form-group"><label>新密码</label><input type="password" id="resetPassword" minlength="4" required></div><button class="btn btn-primary" type="submit">重置密码</button></form>
+        <form id="forgotRequestForm"><div class="form-group"><label for="forgotEmail">管理员邮箱</label><input type="email" id="forgotEmail" autocomplete="email" placeholder=" " required></div><button class="btn btn-primary" type="submit">发送验证码</button></form>
+        <form id="forgotResetForm" class="force-hidden"><div class="form-group"><label for="resetCode">验证码</label><input id="resetCode" inputmode="numeric" autocomplete="one-time-code" maxlength="6" placeholder=" " required></div><div class="form-group"><label for="resetPassword">新密码</label><input type="password" id="resetPassword" minlength="4" autocomplete="new-password" placeholder=" " required></div><button class="btn btn-primary" type="submit">重置密码</button></form>
         <p class="auth-link"><a href="#" id="backLoginLink">返回登录</a></p>
     </div>
 
@@ -72,6 +72,7 @@
         </form>
     </div>
     <div class="beian-footer" id="beianFooter"></div>
+    <script src="preview-mock.js?v=20260723-activity1" type="module"></script>
     <script src="client.js?v=20260615-visual-color-picker" type="module"></script>
 </body>
 </html>

--- a/public/preview-mock.js
+++ b/public/preview-mock.js
@@ -1,0 +1,228 @@
+const previewEnabled = location.protocol === 'http:' && location.hostname === 'localhost' && location.port === '5173';
+
+const now = Date.now();
+const previewConnections = [
+    {
+        id: 'preview-ssh-prod',
+        name: '生产 Web 节点',
+        host: '10.24.8.12',
+        port: 22,
+        protocol: 'SSH',
+        username: 'deploy',
+        remark: '**Nginx + Node.js**\n\n华东区生产环境，只读示例数据。',
+        tags: ['生产', 'Web'],
+        connectionMode: 'direct',
+        createdAt: now - 1000 * 60 * 60 * 24 * 45,
+        updatedAt: now - 1000 * 60 * 60 * 24 * 2,
+        lastConnectedAt: now - 1000 * 60 * 18,
+        owner: 'own',
+        capabilities: ['view', 'use', 'edit', 'delete'],
+    },
+    {
+        id: 'preview-rdp-office',
+        name: '设计工作站',
+        host: '192.168.10.36',
+        port: 3389,
+        protocol: 'RDP',
+        username: 'designer',
+        remark: 'Windows 11 工作站\n\n用于 UI 与浏览器兼容性测试。',
+        tags: ['办公', 'Windows'],
+        connectionMode: 'direct',
+        createdAt: now - 1000 * 60 * 60 * 24 * 24,
+        updatedAt: now - 1000 * 60 * 60 * 9,
+        lastConnectedAt: now - 1000 * 60 * 60 * 3,
+        owner: 'own',
+        capabilities: ['view', 'use', 'edit', 'delete'],
+    },
+    {
+        id: 'preview-telnet-lab',
+        name: '实验室交换机',
+        host: '172.16.4.8',
+        port: 23,
+        protocol: 'TELNET',
+        username: 'observer',
+        remark: '网络实验设备，共享观察权限。',
+        tags: ['实验室', '网络'],
+        connectionMode: 'jump',
+        createdAt: now - 1000 * 60 * 60 * 24 * 12,
+        updatedAt: now - 1000 * 60 * 60 * 24,
+        lastConnectedAt: now - 1000 * 60 * 60 * 26,
+        owner: 'shared',
+        capabilities: ['view', 'observe'],
+    },
+];
+
+const previewActivities = [
+    { id: 'evt_01JZ7N5F9P', time: now - 1000 * 60 * 18, message: '连接到生产 Web 节点', type: 'info', userId: 'preview-user', actor: 'demo', category: '连接', outcome: '成功', connectionId: 'preview-ssh-prod', protocol: 'SSH', target: '10.24.8.12:22', sourceIp: '192.168.1.28', durationMs: 428 },
+    { id: 'evt_01JZ7MBC2K', time: now - 1000 * 60 * 60 * 3, message: '断开设计工作站', type: 'info', userId: 'preview-user', actor: 'demo', category: '连接', outcome: '成功', connectionId: 'preview-rdp-office', protocol: 'RDP', target: '192.168.10.36:3389', sourceIp: '192.168.1.28', durationMs: 96 },
+    { id: 'evt_01JZ6QB8RE', time: now - 1000 * 60 * 60 * 26, message: '查看实验室交换机', type: 'info', userId: 'preview-user', actor: 'demo', category: '连接', outcome: '成功', connectionId: 'preview-telnet-lab', protocol: 'TELNET', target: '172.16.4.8:23', sourceIp: '192.168.1.28', durationMs: 214 },
+    { id: 'evt_01JYY8N44W', time: now - 1000 * 60 * 60 * 24 * 5, message: '用户登录：demo', type: 'info', userId: 'preview-user', actor: 'demo', category: '账户', outcome: '成功', sourceIp: '192.168.1.28', durationMs: 182 },
+    { id: 'evt_01JXPQ2G7A', time: now - 1000 * 60 * 60 * 24 * 16, message: '测试连接：生产 Web 节点 - 连接超时', type: 'error', userId: 'preview-user', actor: 'demo', category: '连接', outcome: '失败', connectionId: 'preview-ssh-prod', protocol: 'SSH', target: '10.24.8.12:22', sourceIp: '192.168.1.28', durationMs: 30000 },
+    { id: 'evt_01JW1CV19S', time: now - 1000 * 60 * 60 * 24 * 42, message: '更新系统设置：appearance', type: 'info', userId: 'preview-user', actor: 'demo', category: '系统', outcome: '成功', sourceIp: '192.168.1.28', durationMs: 74 },
+];
+
+let previewSshKeys = [
+    { id: 'preview-key-prod', name: '生产环境 Deploy Key', privateKey: '-----BEGIN OPENSSH PRIVATE KEY-----\npreview-production-key\n-----END OPENSSH PRIVATE KEY-----', passphrase: '******', remark: '华东生产 Web 节点', createdAt: now - 1000 * 60 * 60 * 24 * 38, updatedAt: now - 1000 * 60 * 60 * 24 * 4 },
+    { id: 'preview-key-github', name: 'GitHub CI Key', privateKey: '-----BEGIN OPENSSH PRIVATE KEY-----\npreview-github-ci-key\n-----END OPENSSH PRIVATE KEY-----', passphrase: '', remark: 'Actions 部署专用，只读仓库', createdAt: now - 1000 * 60 * 60 * 24 * 19, updatedAt: now - 1000 * 60 * 60 * 24 * 2 },
+    { id: 'preview-key-lab', name: '实验室运维密钥', privateKey: '-----BEGIN OPENSSH PRIVATE KEY-----\npreview-lab-key\n-----END OPENSSH PRIVATE KEY-----', passphrase: '******', remark: '交换机与测试服务器', createdAt: now - 1000 * 60 * 60 * 24 * 8, updatedAt: now - 1000 * 60 * 60 * 9 },
+];
+
+let previewProxies = [
+    { id: 'preview-proxy-prod', name: '生产出口代理', type: 'socks5', host: '10.24.0.18', port: 1080, username: 'deploy', password: '******', createdAt: now - 1000 * 60 * 60 * 24 * 31, updatedAt: now - 1000 * 60 * 60 * 7 },
+    { id: 'preview-proxy-office', name: '办公网络代理', type: 'http', host: '192.168.10.15', port: 8080, username: '', password: '', createdAt: now - 1000 * 60 * 60 * 24 * 18, updatedAt: now - 1000 * 60 * 60 * 24 * 2 },
+    { id: 'preview-proxy-lab', name: '实验室链路', type: 'socks5', host: '172.16.4.20', port: 1081, username: 'observer', password: '******', createdAt: now - 1000 * 60 * 60 * 24 * 9, updatedAt: now - 1000 * 60 * 60 * 15 },
+];
+
+function previewProxySummary(proxy) {
+    return { ...proxy, password: proxy.password ? '******' : '', hasPassword: !!proxy.password };
+}
+
+function previewSshKeySummary(key) {
+    return { ...key, privateKey: key.privateKey ? '******' : '', passphrase: key.passphrase ? '******' : '', hasPrivateKey: !!key.privateKey, hasPassphrase: !!key.passphrase };
+}
+
+let previewSettings = {
+    version: '3.0.0 Preview',
+    appearance: {
+        brandName: 'Zephyr',
+        brandIcon: '🌬️',
+        theme: 'light',
+        autoThemeEnabled: false,
+        colorScheme: 'frost',
+    },
+    terminal: {
+        maxWindows: 3,
+        minimizedKeepAlive: 0,
+        smartbarOrder: 'old-first',
+        shortcutPlatform: 'auto',
+        allowLigatures: false,
+    },
+    notes: { enabled: false },
+    ai: { enabled: false, providers: [] },
+    security: {},
+    captcha: {},
+    mail: {},
+    beian: { show: false },
+    snippets: [
+        { id: 'preview-snippet-docker', name: '查看 Docker 状态', command: 'docker ps --format "table {{.Names}}\\t{{.Status}}\\t{{.Ports}}"', group: 'Docker', autoRun: true, updatedAt: now - 1000 * 60 * 60 * 5 },
+        { id: 'preview-snippet-system', name: '系统资源概览', command: 'uptime\nfree -h\ndf -h', group: 'Linux', autoRun: false, updatedAt: now - 1000 * 60 * 60 * 24 },
+        { id: 'preview-snippet-logs', name: '查看服务日志', command: 'journalctl -u nginx -n 100 --no-pager', group: '运维', autoRun: true, updatedAt: now - 1000 * 60 * 60 * 24 * 3 },
+    ],
+};
+
+function jsonResponse(data, status = 200) {
+    return Promise.resolve(new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    }));
+}
+
+function requestPath(input) {
+    const value = input instanceof Request ? input.url : input;
+    return new URL(String(value), location.origin).pathname;
+}
+
+function requestMethod(input, init = {}) {
+    return String(init.method || (input instanceof Request ? input.method : 'GET')).toUpperCase();
+}
+
+function requestBody(init = {}) {
+    if (typeof init.body !== 'string') return {};
+    try { return JSON.parse(init.body); } catch { return {}; }
+}
+
+if (previewEnabled && !globalThis.__zephyrPreviewMockInstalled) {
+    globalThis.__zephyrPreviewMockInstalled = true;
+    globalThis.__zephyrPreviewMode = true;
+    const nativeFetch = globalThis.fetch.bind(globalThis);
+
+    globalThis.fetch = (input, init = {}) => {
+        const path = requestPath(input);
+        const method = requestMethod(input, init);
+        const body = requestBody(init);
+        if (!path.startsWith('/api/')) return nativeFetch(input, init);
+
+        if (path === '/api/public/settings') return jsonResponse({
+            defaultUsername: 'demo',
+            appearance: previewSettings.appearance,
+            captcha: { enabled: false },
+            showBeian: false,
+        });
+        if (path === '/api/auth/me') return jsonResponse({
+            user: { userId: 'preview-user', username: 'demo', role: 'user', isSuperAdmin: false },
+            mustChangePassword: false,
+            instanceId: 'preview',
+        });
+        if (path === '/api/auth/login' && method === 'POST') return jsonResponse({ ok: true });
+        if (path === '/api/auth/logout' && method === 'POST') return jsonResponse({ ok: true });
+        if (path === '/api/connections' && method === 'GET') return jsonResponse({ connections: previewConnections, activities: previewActivities });
+        if (path === '/api/activities' && method === 'GET') {
+            const url = new URL(input instanceof Request ? input.url : String(input), location.origin);
+            const from = Number(url.searchParams.get('from')) || 0;
+            const to = Number(url.searchParams.get('to')) || 0;
+            return jsonResponse({ activities: previewActivities.filter((activity) => (!from || activity.time >= from) && (!to || activity.time <= to)) });
+        }
+        if (path === '/api/activities' && method === 'DELETE') return jsonResponse({ ok: true });
+        if (path === '/api/me/settings' && method === 'GET') return jsonResponse({ settings: previewSettings, overrides: { mail: { notifyLogin: true } } });
+        if (path === '/api/me/settings' && method === 'PUT') {
+            previewSettings = { ...previewSettings, ...body };
+            return jsonResponse({ ok: true, settings: previewSettings, overrides: body });
+        }
+        if (path === '/api/ai/providers') return jsonResponse({ providers: [] });
+        if (path === '/api/security/status') return jsonResponse({ user: { username: '', email: '', totpEnabled: false }, passkeys: [] });
+        if (path === '/api/security/login-events/mine') return jsonResponse({ events: [] });
+        if (path === '/api/proxies' && method === 'GET') return jsonResponse({ proxies: previewProxies.map(previewProxySummary) });
+        if (path === '/api/proxies' && method === 'POST') {
+            const proxy = { id: `preview-proxy-${Date.now()}`, name: body.name || '未命名代理', type: body.type || 'socks5', host: body.host || '', port: Number(body.port) || 1080, username: body.username || '', password: body.password || '', createdAt: Date.now(), updatedAt: Date.now() };
+            previewProxies.unshift(proxy);
+            return jsonResponse({ proxy: previewProxySummary(proxy) });
+        }
+        const proxyMatch = path.match(/^\/api\/proxies\/([^/]+)$/);
+        if (proxyMatch && method === 'PUT') {
+            const index = previewProxies.findIndex((proxy) => proxy.id === proxyMatch[1]);
+            if (index < 0) return jsonResponse({ error: '代理不存在' }, 404);
+            const previous = previewProxies[index];
+            previewProxies[index] = { ...previous, ...body, port: Number(body.port) || previous.port, password: body.password === '******' ? previous.password : body.password, updatedAt: Date.now() };
+            return jsonResponse({ proxy: previewProxySummary(previewProxies[index]) });
+        }
+        if (proxyMatch && method === 'DELETE') {
+            previewProxies = previewProxies.filter((proxy) => proxy.id !== proxyMatch[1]);
+            return jsonResponse({ ok: true });
+        }
+        const proxyOpenMatch = path.match(/^\/api\/proxies\/([^/]+)\/open$/);
+        if (proxyOpenMatch && method === 'POST') {
+            const proxy = previewProxies.find((item) => item.id === proxyOpenMatch[1]);
+            return proxy ? jsonResponse({ proxy: { ...proxy, hasPassword: !!proxy.password } }) : jsonResponse({ error: '代理不存在' }, 404);
+        }
+        if (path === '/api/ssh-keys' && method === 'GET') return jsonResponse({ sshKeys: previewSshKeys.map(previewSshKeySummary) });
+        if (path === '/api/ssh-keys' && method === 'POST') {
+            const sshKey = { id: `preview-key-${Date.now()}`, name: body.name || '未命名密钥', privateKey: body.privateKey || '', passphrase: body.passphrase || '', remark: body.remark || '', createdAt: Date.now(), updatedAt: Date.now() };
+            previewSshKeys.unshift(sshKey);
+            return jsonResponse({ sshKey: previewSshKeySummary(sshKey) });
+        }
+        const sshKeyMatch = path.match(/^\/api\/ssh-keys\/([^/]+)$/);
+        if (sshKeyMatch && method === 'PUT') {
+            const index = previewSshKeys.findIndex((key) => key.id === sshKeyMatch[1]);
+            if (index < 0) return jsonResponse({ error: 'SSH 密钥不存在' }, 404);
+            const previous = previewSshKeys[index];
+            previewSshKeys[index] = { ...previous, ...body, privateKey: body.privateKey === '******' ? previous.privateKey : body.privateKey, passphrase: body.passphrase === '******' ? previous.passphrase : body.passphrase, updatedAt: Date.now() };
+            return jsonResponse({ sshKey: previewSshKeySummary(previewSshKeys[index]) });
+        }
+        if (sshKeyMatch && method === 'DELETE') {
+            previewSshKeys = previewSshKeys.filter((key) => key.id !== sshKeyMatch[1]);
+            return jsonResponse({ ok: true });
+        }
+        const sshKeyOpenMatch = path.match(/^\/api\/ssh-keys\/([^/]+)\/open$/);
+        if (sshKeyOpenMatch && method === 'POST') {
+            const sshKey = previewSshKeys.find((key) => key.id === sshKeyOpenMatch[1]);
+            return sshKey ? jsonResponse({ sshKey: { ...sshKey, hasPrivateKey: !!sshKey.privateKey, hasPassphrase: !!sshKey.passphrase } }) : jsonResponse({ error: 'SSH 密钥不存在' }, 404);
+        }
+        if (/^\/api\/me\/workspaces\/[^/]+\/restore$/.test(path) && method === 'POST') return jsonResponse({ workspace: null, inaccessible: 0, autoReplay: false });
+        if (/^\/api\/me\/workspaces\/[^/]+$/.test(path) && method === 'PUT') return jsonResponse({
+            workspace: { workspaceId: path.split('/').pop(), revision: Number(body.revision || 0) + 1, state: body.state || {} },
+        });
+
+        console.info('[preview-mock] Unhandled API request', method, path);
+        return jsonResponse({ error: `预览模式暂未模拟 ${method} ${path}` }, 404);
+    };
+}

--- a/public/style.css
+++ b/public/style.css
@@ -397,7 +397,7 @@ body.app-body.terminal-mode {
 .login-card .logo img { width: 52px; height: 52px; object-fit: contain; display: inline-block; border-radius: 14px; }
 .login-card h1 { text-align: center; font-size: 22px; font-weight: 700; margin-bottom: 20px; }
 .auth-subtitle { text-align: center; color: var(--text-secondary); margin: -12px 0 18px; font-size: 13px; }
-.auth-options { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 4px 0 14px; font-size: 13px; color: var(--text-secondary); }
+.auth-options { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 6px 0 18px; color: var(--text-secondary); }
 .captcha-box {
     display: grid;
     place-items: center;
@@ -421,10 +421,97 @@ body.app-body.terminal-mode {
     font-size: 12px;
     text-align: center;
 }
-.remember-me { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; user-select: none; }
-.remember-me input { width: 14px; height: 14px; accent-color: var(--accent); }
-.auth-options a { color: var(--text-secondary); font-size: 12px; text-decoration: none; }
-.auth-options a:hover { color: var(--accent-hover); text-decoration: underline; }
+.remember-me { display: inline-flex; align-items: center; gap: 8px; min-height: 32px; color: var(--text-secondary); font-size: 13px; font-weight: 500; cursor: pointer; user-select: none; }
+.remember-me input {
+    appearance: none;
+    display: grid;
+    place-content: center;
+    width: 18px;
+    height: 18px;
+    flex: 0 0 18px;
+    border: 1px solid color-mix(in srgb, var(--text-secondary) 42%, var(--border));
+    border-radius: 5px;
+    background: color-mix(in srgb, var(--surface) 88%, var(--bg));
+    cursor: pointer;
+}
+.remember-me input::before {
+    content: '';
+    width: 8px;
+    height: 4px;
+    border: solid #fff;
+    border-width: 0 0 2px 2px;
+    opacity: 0;
+    transform: translateY(-1px) rotate(-45deg) scale(.7);
+    transition: opacity 120ms var(--ease-smooth), transform 120ms var(--ease-smooth);
+}
+.remember-me input:checked { border-color: var(--accent); background: var(--accent); }
+.remember-me input:checked::before { opacity: 1; transform: translateY(-1px) rotate(-45deg) scale(1); }
+.remember-me input:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.remember-me:hover { color: var(--text); }
+.auth-options a { display: inline-flex; align-items: center; min-height: 32px; padding: 0; color: #06c; font-size: 14px; font-weight: 400; line-height: 1.5; text-decoration: none; text-underline-offset: 3px; white-space: nowrap; }
+.auth-options a::after { content: '\2197'; margin-left: .3em; font-size: .9em; line-height: 1; }
+.auth-options a:hover { color: #004f9e; text-decoration: underline; }
+.auth-options a:focus-visible { outline: 2px solid #0071e3; outline-offset: 2px; border-radius: 2px; }
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group,
+.security-input-stack > .form-group { position: relative; margin-bottom: 14px; }
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group label,
+.security-input-stack > .form-group label {
+    position: absolute;
+    z-index: 1;
+    top: 50%;
+    left: 16px;
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 17px;
+    font-weight: 400;
+    line-height: 1;
+    pointer-events: none;
+    transform: translateY(-50%);
+    transform-origin: left top;
+    transition: color 160ms var(--ease-smooth), font-size 160ms var(--ease-smooth), transform 160ms var(--ease-smooth);
+    text-transform: none;
+}
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group input,
+.security-input-stack > .form-group input {
+    height: 56px;
+    min-height: 56px;
+    padding: 20px 15px 5px;
+    border-color: color-mix(in srgb, var(--text-secondary) 72%, var(--border));
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--surface) 92%, transparent);
+    font-family: var(--font-sans);
+    font-size: 17px;
+    line-height: 1.35;
+}
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group input:hover,
+.security-input-stack > .form-group input:hover { border-color: color-mix(in srgb, var(--text-secondary) 88%, var(--border)); }
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group input:focus,
+.security-input-stack > .form-group input:focus {
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--surface) 96%, transparent);
+    box-shadow: inset 0 0 0 1px var(--accent);
+}
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group:has(input:focus) label,
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group:has(input:not(:placeholder-shown)) label,
+:is(#loginForm, #forgotRequestForm, #forgotResetForm) > .form-group:has(input:-webkit-autofill) label,
+.security-input-stack > .form-group:has(input:focus) label,
+.security-input-stack > .form-group:has(input:not(:placeholder-shown)) label,
+.security-input-stack > .form-group:has(input:-webkit-autofill) label {
+    color: var(--text-secondary);
+    font-size: 12px;
+    transform: translateY(-18px);
+}
+#loginBtn { margin-top: 0; }
+#passkeyLoginBtn { margin-top: 12px; }
+#passkeyLoginBtn,
+.auth-link a { border-color: color-mix(in srgb, var(--text-secondary) 10%, transparent); background: color-mix(in srgb, var(--surface) 72%, var(--bg)); color: var(--text); }
+#passkeyLoginBtn:hover,
+.auth-link a:hover { border-color: color-mix(in srgb, var(--text-secondary) 18%, transparent); background: color-mix(in srgb, var(--surface) 58%, var(--bg)); color: var(--text); box-shadow: none; }
+.auth-link { margin-top: 16px; text-align: center; }
+.auth-link a { display: inline-flex; align-items: center; justify-content: center; width: 100%; min-height: 46px; padding: 12px 20px; border-width: 1px; border-style: solid; border-radius: var(--radius-control); font-size: 14px; font-weight: 500; line-height: normal; text-decoration: none; transition: transform .16s var(--ease-smooth), background .20s var(--ease-smooth), border-color .20s var(--ease-smooth), color .20s var(--ease-smooth); }
+.auth-link a:hover { text-decoration: none; transform: translateY(-1px); }
+.auth-link a:active { transform: scale(.985); }
+.auth-link a:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 .auth-hint { margin-top: 14px; color: var(--text-secondary); font-size: 12px; text-align: center; line-height: 1.6; }
 .force-hidden { display: none !important; }
 .beian-footer {
@@ -571,9 +658,78 @@ body.terminal-mode .terminal-view.active { animation: none; }
 .card-actions .btn { width: auto; flex: 1; padding: 8px 12px; margin-top: 0; }
 .activity-panel { margin-top: 18px; padding: 16px; }
 .activity-panel h2, .settings-panel h2 { font-size: 18px; margin-bottom: 12px; }
+.activity-view { max-width: 1060px; margin: 0 auto; }
+.activity-section-head { align-items: center; }
+.activity-intro { margin-top: 7px; color: var(--text-secondary); font-size: 14px; }
+.activity-filter-bar {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 18px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: var(--shadow-soft);
+}
+.activity-range-tabs { display: flex; align-items: center; gap: 4px; overflow-x: auto; }
+.activity-range-btn {
+    min-height: 36px;
+    padding: 7px 13px;
+    border: 0;
+    border-radius: 7px;
+    background: transparent;
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 700;
+    white-space: nowrap;
+    cursor: pointer;
+}
+.activity-range-btn:hover { color: var(--text); background: color-mix(in srgb, var(--text) 5%, transparent); }
+.activity-range-btn.active { color: var(--accent-hover); background: var(--accent-soft-bg); }
+.activity-custom-range { display: flex; align-items: flex-end; gap: 10px; padding-top: 12px; border-top: 1px solid var(--border); }
+.activity-custom-range label { display: grid; flex: 1; gap: 6px; color: var(--text-secondary); font-size: 12px; font-weight: 700; }
+.activity-custom-range input {
+    width: 100%;
+    min-height: 40px;
+    padding: 8px 11px;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    background: var(--bg);
+    color: var(--text);
+    font: inherit;
+    color-scheme: light dark;
+}
+.activity-custom-range .btn { width: auto; min-height: 40px; margin: 0; padding: 8px 18px; }
+.activity-summary { display: flex; justify-content: space-between; gap: 12px; margin: 0 2px 10px; color: var(--text-secondary); font-size: 13px; }
+.activity-summary strong { color: var(--text); }
 .activity-list { display: grid; gap: 8px; }
-.activity-item { display: flex; justify-content: space-between; gap: 10px; padding: 10px 12px; border-radius: var(--radius); background: var(--bg); font-size: 13px; }
-.activity-item span { color: var(--text-secondary); }
+.activity-detail-item {
+    padding: 16px 18px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: 0 5px 18px -16px rgba(0,0,0,.35);
+    animation: fadeIn .28s ease-out both;
+}
+.activity-detail-head { display: grid; grid-template-columns: 10px minmax(0, 1fr) auto; align-items: center; gap: 12px; }
+.activity-event-mark { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft-bg); }
+.activity-event-mark[data-category="账户"] { background: #af52de; box-shadow: 0 0 0 4px color-mix(in srgb, #af52de 14%, transparent); }
+.activity-event-mark[data-category="系统"] { background: #ff9f0a; box-shadow: 0 0 0 4px color-mix(in srgb, #ff9f0a 15%, transparent); }
+.activity-event-title { display: flex; align-items: center; min-width: 0; gap: 9px; }
+.activity-event-title h2 { overflow: hidden; color: var(--text); font-size: 15px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
+.activity-status { padding: 3px 7px; border-radius: 5px; font-size: 11px; font-weight: 800; }
+.activity-status.success { color: var(--success); background: color-mix(in srgb, var(--success) 12%, transparent); }
+.activity-status.failed { color: var(--danger); background: color-mix(in srgb, var(--danger) 12%, transparent); }
+.activity-detail-head time { color: var(--text-secondary); font-family: var(--font-mono); font-size: 12px; white-space: nowrap; }
+.activity-meta-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px 20px; margin: 16px 0 12px 22px; }
+.activity-meta-grid div { min-width: 0; }
+.activity-meta-grid dt { margin-bottom: 4px; color: var(--text-secondary); font-size: 11px; }
+.activity-meta-grid dd { overflow: hidden; color: var(--text); font-family: var(--font-mono); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.activity-event-id { display: flex; align-items: center; gap: 9px; margin-left: 22px; padding-top: 11px; border-top: 1px solid color-mix(in srgb, var(--border) 75%, transparent); color: var(--text-secondary); font-size: 11px; }
+.activity-event-id code { overflow: hidden; color: var(--text-secondary); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.activity-empty { display: grid; place-items: center; gap: 6px; min-height: 220px; border: 1px dashed var(--border); border-radius: 8px; color: var(--text-secondary); text-align: center; }
+.activity-empty strong { color: var(--text); font-size: 15px; }
 .empty-card, .terminal-placeholder { padding: 28px; text-align: center; color: var(--text-secondary); }
 .browser-tabs { min-height: 50px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); padding: 10px; margin-bottom: 14px; overflow-x: auto; }
 
@@ -1974,6 +2130,9 @@ body.terminal-custom-fullscreen-open .main-nav {
 }
 .panel-title-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .panel-title-row h2 { margin: 0; }
+.proxy-panel-title { align-items: center; }
+.proxy-add-btn { width: auto !important; min-width: 0; margin: 0; padding: 7px 12px; font-size: 12px; line-height: 1.2; white-space: nowrap; }
+#aiAddProviderBtn { margin: 0; padding: 7px 12px; font-size: 12px; line-height: 1.2; }
 .empty-state { color: var(--text-secondary); font-size: 14px; padding: 6px; }
 .settings-layout { display: grid; grid-template-columns: 220px 1fr; gap: 14px; align-items: start; }
 .settings-menu {
@@ -1988,11 +2147,39 @@ body.terminal-custom-fullscreen-open .main-nav {
 .settings-panel { display: none; }
 .settings-panel.active { display: block; animation: fadeIn .24s ease-out; }
 .settings-form { display: grid; gap: 10px; max-width: 420px; margin-bottom: 14px; }
+#settings-security { display: none; gap: 14px; }
+#settings-security.active { display: grid; }
+.security-card {
+    padding: 16px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+}
+.security-card-row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.security-card-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-width: 0; margin-bottom: 12px; }
+.security-card-head h2 { min-width: 0; margin: 0; }
+.security-card-action { flex: 0 0 auto; width: auto; min-width: 0; max-width: 140px; min-height: 32px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); font: 500 12px/1.2 var(--font-sans); white-space: nowrap; cursor: pointer; }
+.security-card-action:hover { border-color: color-mix(in srgb, var(--accent) 32%, var(--border)); background: color-mix(in srgb, var(--accent) 7%, var(--surface)); }
+.security-card-action:active { transform: scale(.98); }
+.security-card .settings-form { max-width: none; margin-bottom: 0; }
+.security-input-stack { display: grid; gap: 0; }
+.security-input-stack > .form-group { position: relative; margin: 0; }
+.security-input-stack > .form-group:not(:first-child) { margin-top: -1px; }
+.security-input-stack > .form-group:focus-within { z-index: 2; }
+.security-input-stack > .form-group input { border-radius: 0; }
+.security-input-stack > .form-group:first-child input { border-radius: 12px 12px 0 0; }
+.security-input-stack > .form-group:last-child input { border-radius: 0 0 12px 12px; }
+.security-input-stack > .form-group:only-child input { border-radius: 12px; }
+.security-card .mini-list { margin-bottom: 0; }
+.security-card > .settings-switch-option { margin: 0; }
 .settings-form .form-actions {
     display: grid;
     grid-template-columns: 1fr;
     gap: 14px;
     margin-top: 12px;
+}
+@media (max-width: 760px) {
+    .security-card-row { grid-template-columns: 1fr; gap: 14px; }
 }
 .settings-form .form-actions .btn {
     width: 100%;
@@ -2005,9 +2192,120 @@ body.terminal-custom-fullscreen-open .main-nav {
 .inline-form { max-width: none; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); align-items: end; }
 .check-line { color: var(--text-secondary); font-size: 13px; display: flex; align-items: center; gap: 8px; }
 .check-line input { width: auto; }
+.connection-share-group { margin-top: 2px; }
+.connection-share-options {
+    display: grid;
+    gap: 8px;
+    padding-top: 8px;
+}
+.connection-share-group .connection-share-option {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 16px;
+    min-height: 64px;
+    padding: 11px 13px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    cursor: pointer;
+    transition: background-color 160ms ease, border-color 160ms ease, transform 120ms ease-out, box-shadow 160ms ease;
+}
+.connection-share-option:hover {
+    border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+    background: color-mix(in srgb, var(--accent) 5%, var(--bg));
+}
+.connection-share-option:active { transform: scale(.992); }
+.connection-share-option:has(input:checked) {
+    border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.connection-share-option:has(input:focus-visible) { box-shadow: var(--focus-ring); }
+.connection-share-copy { display: grid; min-width: 0; gap: 3px; }
+.connection-share-copy strong { color: var(--text); font-size: 13px; line-height: 1.35; }
+.connection-share-copy small { color: var(--text-secondary); font-size: 12px; line-height: 1.4; }
+.connection-share-switch { position: relative; display: block; width: 42px; height: 24px; flex: 0 0 auto; }
+.connection-share-switch input { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+.connection-share-switch > span {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--text-secondary) 30%, var(--surface));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-secondary) 18%, transparent);
+    transition: background-color 160ms ease, box-shadow 160ms ease;
+}
+.connection-share-switch > span::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(0,0,0,.24);
+    transition: transform 180ms cubic-bezier(.23,1,.32,1);
+}
+.connection-share-switch input:checked + span { background: var(--accent); box-shadow: none; }
+.connection-share-switch input:checked + span::after { transform: translateX(18px); }
+.settings-switch-option {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+    min-height: 62px;
+    margin: 8px 0 18px;
+    padding: 10px 13px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    color: var(--text);
+    cursor: pointer;
+    transition: background-color 160ms ease, border-color 160ms ease, transform 120ms ease-out, box-shadow 160ms ease;
+}
+.settings-switch-option:hover {
+    border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+    background: color-mix(in srgb, var(--accent) 5%, var(--bg));
+}
+.settings-switch-option:active { transform: scale(.995); }
+.settings-switch-option:has(input:checked) {
+    border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+}
+.settings-switch-option:has(input:focus-visible) { box-shadow: var(--focus-ring); }
+.settings-switch-copy { display: grid; min-width: 0; gap: 3px; }
+.settings-switch-copy strong { color: var(--text); font-size: 13px; line-height: 1.35; }
+.settings-switch-copy small { color: var(--text-secondary); font-size: 12px; line-height: 1.4; }
 .mini-list { display: grid; gap: 8px; margin: 10px 0 20px; }
-.mini-item { display: grid; grid-template-columns: 1fr 1.5fr auto auto; gap: 8px; align-items: center; padding: 10px; border-radius: var(--radius); background: var(--bg); font-size: 13px; }
+.mini-list > .muted:only-child {
+    display: grid;
+    place-items: center;
+    min-height: 72px;
+    padding: 16px;
+    border: 1px dashed color-mix(in srgb, var(--border) 86%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--bg) 72%, transparent);
+    color: var(--text-secondary);
+    font-size: 12px;
+    text-align: center;
+}
+.mini-item { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr) auto auto auto; gap: 8px; align-items: center; padding: 10px; border-radius: var(--radius); background: var(--bg); font-size: 13px; animation: connectionCardIn .34s cubic-bezier(.16,1,.3,1) both; }
+.mini-item.deleting { opacity: 0; transform: translate3d(0, -14px, 0) scale(.90); filter: blur(10px) saturate(.72); pointer-events: none; animation: connectionCardDelete .30s cubic-bezier(.2,.8,.2,1) both; }
 .mini-item span { color: var(--text-secondary); }
+.ssh-key-tag, .resource-tag { display: inline-flex; align-items: center; justify-self: start; width: max-content; max-width: 100%; min-height: 24px; padding: 3px 8px; border-radius: var(--radius-control); font-size: 12px; font-weight: 500; line-height: 18px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ssh-key-tag-name { color: var(--accent-hover) !important; background: var(--accent-soft-bg); }
+.ssh-key-tag-private { color: var(--success) !important; background: color-mix(in srgb, var(--success) 13%, transparent); }
+.ssh-key-tag-passphrase { color: var(--warning) !important; background: color-mix(in srgb, var(--warning) 14%, transparent); }
+.ssh-key-tag-remark { color: #8e5bb7 !important; background: rgba(142,91,183,.12); }
+.ssh-key-meta, .resource-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; min-width: 0; }
+.resource-tag-name { color: var(--accent-hover) !important; background: var(--accent-soft-bg); }
+.resource-tag-protocol { color: #8e5bb7 !important; background: rgba(142,91,183,.12); }
+.resource-tag-host { color: var(--success) !important; background: color-mix(in srgb, var(--success) 13%, transparent); }
+.resource-tag-port { color: var(--warning) !important; background: color-mix(in srgb, var(--warning) 14%, transparent); }
+.resource-tag-auth { color: var(--text-secondary) !important; background: color-mix(in srgb, var(--text-secondary) 12%, transparent); }
+.resource-tag-secret { color: var(--danger) !important; background: color-mix(in srgb, var(--danger) 11%, transparent); }
 .mini-item button { border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); padding: 6px 9px; cursor: pointer; }
 .remote-layout { display: grid; grid-template-columns: minmax(260px, 320px) 1fr; gap: 14px; align-items: start; }
 .remote-servers, .remote-command, .result-card { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); padding: 14px; }
@@ -2042,14 +2340,24 @@ body.app-body::after {
 }
 body.connection-home-blur .app-shell {
     transform: scale(.92) translateZ(0);
-    filter: blur(12px) brightness(.5);
+}
+body.connection-home-blur::after {
+    content: '';
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 99;
+    pointer-events: none;
+    background: rgba(0, 0, 0, .24);
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
 }
 body.connection-transition-opening .app-shell,
 body.connection-transition-closing .app-shell {
     transition:
         transform var(--connection-app-duration) var(--connection-ios-spring),
         filter var(--connection-app-duration) ease-out;
-    will-change: transform, filter;
+    will-change: transform;
 }
 .connection-transition-layer {
     position: fixed;
@@ -2068,6 +2376,10 @@ body.connection-transition-closing .app-shell {
     backface-visibility: hidden;
     will-change: top, left, width, height, border-radius, box-shadow;
     contain: layout paint style;
+}
+.connection-transition-layer.expanded-material {
+    background: color-mix(in srgb, var(--surface) 58%, transparent) !important;
+    border-color: transparent !important;
 }
 .connection-transition-layer::before,
 .connection-transition-layer::after {
@@ -2132,7 +2444,35 @@ body.connection-transition-closing .app-shell {
     filter: none;
     transition: opacity 0.15s cubic-bezier(0.4, 0, 1, 1);
     will-change: opacity;
+    scrollbar-width: none;
 }
+.connection-modal::-webkit-scrollbar,
+.modal-backdrop::-webkit-scrollbar,
+.modal-backdrop *::-webkit-scrollbar,
+.notes-modal-backdrop::-webkit-scrollbar,
+.notes-modal-backdrop *::-webkit-scrollbar { width: 0; height: 0; display: none; }
+.modal-backdrop,
+.modal-backdrop *,
+.notes-modal-backdrop,
+.notes-modal-backdrop * { scrollbar-width: none; }
+#connectionForm {
+    background: color-mix(in srgb, var(--surface) 94%, transparent);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+}
+.proxy-modal { width: min(520px, 100%); }
+.proxy-modal .form-group { margin-bottom: 12px; }
+.proxy-modal .form-row { gap: 12px; }
+.proxy-modal .field-hint { margin: 2px 0 14px; }
+.proxy-modal .modal-actions { margin-top: 4px; }
+.ssh-key-modal { width: min(560px, 100%); }
+.ssh-key-modal .form-group { margin-bottom: 12px; }
+.ssh-key-modal textarea { min-height: 132px; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; resize: vertical; }
+.ssh-key-modal .field-hint { margin: 2px 0 14px; }
+.ssh-key-modal .modal-actions { margin-top: 4px; }
+#sshKeyModal .connection-modal { transform: scale(.97); transition: opacity .16s ease-out, transform .22s cubic-bezier(.23,1,.32,1); }
+#sshKeyModal.show.app-visible .connection-modal { transform: scale(1); }
+#sshKeyModal.closing .connection-modal { transform: scale(.985); transition: opacity .14s ease-in, transform .14s ease-in; }
 .modal-backdrop.show.app-visible .connection-modal {
     opacity: 1;
     transition: opacity 0.3s ease-out 0.1s;
@@ -2140,6 +2480,11 @@ body.connection-transition-closing .app-shell {
 .modal-backdrop.closing .connection-modal {
     opacity: 0;
     transition: opacity 0.15s cubic-bezier(0.4, 0, 1, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+    .modal-backdrop .connection-modal,
+    .modal-backdrop.show.app-visible .connection-modal,
+    .modal-backdrop.closing .connection-modal { transition: opacity .01ms linear; }
 }
 .modal-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
 .icon-btn { width: 34px; height: 34px; border-radius: 50%; border: 1px solid var(--border); background: var(--bg); color: var(--text); cursor: pointer; }
@@ -2529,6 +2874,17 @@ body.app-body > .toast.show { opacity: 1; transform: translate3d(0,0,0) scale(1)
     .section-head { align-items: stretch; flex-direction: column; }
     .add-btn { width: 100%; }
     .action-bar { grid-template-columns: 1fr; }
+    .activity-section-head { align-items: stretch; }
+    .activity-section-head .tool-btn { width: 100%; }
+    .activity-custom-range { align-items: stretch; flex-direction: column; }
+    .activity-custom-range > span { display: none; }
+    .activity-custom-range .btn { width: 100%; }
+    .activity-detail-item { padding: 14px; }
+    .activity-detail-head { grid-template-columns: 10px minmax(0, 1fr); }
+    .activity-detail-head time { grid-column: 2; }
+    .activity-event-title { align-items: flex-start; flex-direction: column; gap: 5px; }
+    .activity-event-title h2 { overflow: visible; white-space: normal; }
+    .activity-meta-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); margin-left: 22px; }
     .settings-layout { grid-template-columns: 1fr; }
     .settings-menu {
         grid-auto-flow: column;
@@ -2543,8 +2899,11 @@ body.app-body > .toast.show { opacity: 1; transform: translate3d(0,0,0) scale(1)
     }
     .settings-content {
         padding: 14px;
+        width: 100%;
+        min-width: 0;
         overflow-wrap: anywhere;
     }
+    #settings-security { width: 100%; min-width: 0; }
     .jump-route-row {
         grid-template-columns: 1fr auto;
         gap: 8px;
@@ -2557,6 +2916,14 @@ body.app-body > .toast.show { opacity: 1; transform: translate3d(0,0,0) scale(1)
     .inline-form {
         max-width: none;
         grid-template-columns: 1fr;
+    }
+    #settings-appearance .form-row:has(#terminalBgFit) {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+    #settings-appearance .form-row:has(#terminalBgFit) .form-group {
+        min-width: 0;
     }
     .mini-item {
         grid-template-columns: minmax(0, 1fr);
@@ -2580,6 +2947,7 @@ body.app-body > .toast.show { opacity: 1; transform: translate3d(0,0,0) scale(1)
     .activity-item { flex-direction: column; }
     .modal-backdrop { align-items: start; place-items: start center; overflow-y: auto; padding: 10px; -webkit-overflow-scrolling: touch; }
     .connection-modal { max-height: none; margin: 10px 0 calc(24px + env(safe-area-inset-bottom)); overflow: visible; border-radius: var(--radius-lg); }
+    .proxy-modal .form-row { flex-direction: column; gap: 0; }
     .terminal-view.active { min-height: calc(100dvh - 2px); }
     .terminal-workspace { min-height: calc(100dvh - 2px); }
     .terminal-frame { height: 100%; min-height: 0; }
@@ -5518,10 +5886,13 @@ body.smartbar-trash-hover .smartbar-trash-target {
 .shortcut-grid .tool-btn { min-width: 0; width: 100%; min-height: 36px; padding-inline: 6px; font-size: 11px; }
 .shortcut-grid .fn-key,
 .rdp-shortcut-grid .tool-btn[data-keyseq^="f"] { order: 20; }
-.snippet-form { max-width: min(760px, 100%); }
-.snippet-form .form-actions { gap: 16px; margin-top: 14px; }
-.snippet-settings-list { display: grid; gap: 10px; margin-top: 12px; }
-.snippet-settings-item { display: grid; grid-template-columns: 1fr auto auto; gap: 8px; align-items: center; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); }
+.snippet-modal { width: min(600px, 100%); }
+.snippet-modal .form-group { margin-bottom: 12px; }
+.snippet-modal textarea { min-height: 168px; font-family: var(--font-mono); font-size: 12px; line-height: 1.55; resize: vertical; }
+.snippet-modal .modal-actions { margin-top: 14px; }
+.snippet-auto-run { margin: 2px 0 14px; }
+.snippet-settings-list { display: grid; gap: 8px; margin: 10px 0 20px; }
+.snippet-settings-item { grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr) auto auto; }
 @media (max-width: 480px) and (pointer: coarse) {
     .snippet-settings-item { grid-template-columns: 1fr; }
     .shortcut-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -7760,9 +8131,51 @@ html[data-theme="dark"] .rdp-joystick-icon.active { fill: #ffb14f; filter: brigh
     padding: 22px;
     box-shadow: var(--shadow-soft);
 }
+.ai-settings-title { margin-bottom: 14px; }
+.ai-settings-form {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+    max-width: none;
+    margin-bottom: 14px;
+}
+.ai-settings-card { display: grid; align-content: start; gap: 10px; min-width: 0; }
+.ai-settings-card h2, .ai-resource-card h2 { margin: 0 0 2px; }
+.ai-settings-card-wide, .ai-resource-card-wide { grid-column: 1 / -1; }
+.ai-settings-card .ai-card-actions { align-self: end; justify-items: end; margin-top: 4px; }
+#settings-ai .ai-card-actions .btn { width: 100%; min-width: 0; min-height: 46px; margin: 0 !important; padding: 12px 20px; font-size: 14px; }
+.ai-runtime-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; margin-bottom: 14px; align-items: stretch; }
+.ai-runtime-card { min-width: 0; }
+.ai-runtime-card.settings-form { max-width: none; margin-bottom: 0; }
+.ai-runtime-card .settings-form { max-width: none; }
+.ai-runtime-card.settings-form > textarea {
+    min-height: 80px;
+    padding: 10px 12px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.5;
+    resize: vertical;
+}
+.ai-resource-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.ai-resource-card { min-width: 0; }
+.ai-resource-card .settings-form { max-width: none; margin: 12px 0 0; }
+.ai-resource-card > :last-child { margin-bottom: 0; }
 .ai-settings-form h3 { margin: 12px 0 0; color: var(--text); }
 .ai-permission-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 8px 14px; }
 .ai-provider-list, .ai-skill-list, .ai-env-list, .ai-memory-list, .ai-plan-list { display: grid; gap: 10px; margin: 12px 0 20px; }
+#aiProviderList > .empty-state:only-child,
+#aiPlanList > .empty-state:only-child {
+    display: grid;
+    place-items: center;
+    min-height: 72px;
+    padding: 16px;
+    border: 1px dashed color-mix(in srgb, var(--border) 86%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--bg) 72%, transparent);
+    color: var(--text-secondary);
+    font-size: 12px;
+    text-align: center;
+}
 .ai-provider-item, .ai-skill-item, .ai-env-item, .ai-memory-item, .ai-plan-item {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto auto;
@@ -7778,6 +8191,10 @@ html[data-theme="dark"] .rdp-joystick-icon.active { fill: #ffb14f; filter: brigh
 .ai-provider-item code, .ai-skill-item code, .ai-memory-item code { display: block; margin-top: 6px; max-height: 58px; overflow: hidden; color: var(--text-secondary); white-space: pre-wrap; }
 .ai-plan-item ol { margin: 8px 0 0 20px; color: var(--text-secondary); }
 .ai-plan-item li em { color: var(--accent-hover); font-style: normal; margin-right: 6px; }
+@media (max-width: 900px) {
+    .ai-settings-form, .ai-runtime-grid, .ai-resource-grid { grid-template-columns: 1fr; }
+    .ai-settings-card-wide, .ai-resource-card-wide { grid-column: auto; }
+}
 .ai-agent-panel.file-manager {
     position: fixed;
     z-index: var(--panel-z, 10080);
@@ -10281,6 +10698,151 @@ textarea,
 :root[data-theme="light"] .ai-provider-modal select,
 :root[data-theme="light"] .ai-provider-modal textarea,
 :root[data-theme="light"] .color-hex-input { background: #fff; }
+
+/* Native select, visually normalized while preserving keyboard and screen-reader behavior. */
+select:not([multiple]) {
+    min-height: 40px;
+    padding: 9px 42px 9px 12px !important;
+    border: 1px solid color-mix(in srgb, var(--border) 88%, transparent) !important;
+    border-radius: var(--radius-control) !important;
+    color: var(--text);
+    background-color: color-mix(in srgb, var(--surface) 92%, var(--bg)) !important;
+    background-image:
+        linear-gradient(to bottom, transparent 18%, color-mix(in srgb, var(--border) 72%, transparent) 18%, color-mix(in srgb, var(--border) 72%, transparent) 82%, transparent 82%),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14' fill='none'%3E%3Cpath d='M3.25 5.25L7 9l3.75-3.75' stroke='%2377777d' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat, no-repeat !important;
+    background-position: right 34px center, right 11px center !important;
+    background-size: 1px 100%, 14px 14px !important;
+    box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 24%, transparent), 0 1px 2px rgba(0,0,0,.035);
+    font-family: var(--font-sans) !important;
+    font-size: 14px;
+    font-weight: 500 !important;
+    line-height: 20px;
+    cursor: pointer;
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    transition: border-color 180ms ease, background-color 180ms ease, box-shadow 180ms cubic-bezier(.23,1,.32,1), transform 120ms ease-out !important;
+}
+select:not([multiple]):hover {
+    border-color: color-mix(in srgb, var(--text-secondary) 34%, var(--border)) !important;
+    background-color: color-mix(in srgb, var(--surface) 96%, var(--bg)) !important;
+    box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 30%, transparent), 0 3px 9px rgba(0,0,0,.065);
+}
+select:not([multiple]):focus,
+select:not([multiple]):focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--accent) 54%, var(--border)) !important;
+    box-shadow: var(--focus-ring), inset 0 1px 0 color-mix(in srgb, #fff 28%, transparent) !important;
+}
+select:not([multiple]):active { transform: scale(.992); }
+select:not([multiple]):disabled {
+    cursor: not-allowed;
+    opacity: .52;
+    box-shadow: none;
+}
+select option,
+select optgroup {
+    color: var(--text);
+    background: var(--surface);
+    font-family: var(--font-sans);
+    font-weight: 500;
+}
+:root[data-theme="light"] select:not([multiple]) { background-color: #fff !important; }
+:root[data-theme="dark"] select:not([multiple]) {
+    background-image:
+        linear-gradient(to bottom, transparent 18%, color-mix(in srgb, var(--border) 72%, transparent) 18%, color-mix(in srgb, var(--border) 72%, transparent) 82%, transparent 82%),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14' fill='none'%3E%3Cpath d='M3.25 5.25L7 9l3.75-3.75' stroke='%23b8b8bd' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") !important;
+}
+@supports (appearance: base-select) {
+    select:not([multiple]),
+    ::picker(select) {
+        appearance: base-select !important;
+        -webkit-appearance: base-select !important;
+    }
+    select:not([multiple]) {
+        padding: 9px 11px 9px 12px !important;
+        background-image: none !important;
+        gap: 10px;
+    }
+    select:not([multiple])::picker-icon {
+        width: 16px;
+        height: 16px;
+        margin-left: auto;
+        color: var(--text-secondary);
+        transition: transform 180ms cubic-bezier(.23,1,.32,1), color 180ms ease;
+    }
+    select:not([multiple]):open::picker-icon {
+        color: var(--accent-hover);
+        transform: rotate(180deg);
+    }
+    ::picker(select) {
+        min-width: max(var(--select-picker-width, 180px), anchor-size(width));
+        max-height: min(320px, calc(100vh - 32px));
+        margin-block-start: 6px;
+        padding: 6px;
+        border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+        border-radius: 12px;
+        color: var(--text);
+        background: color-mix(in srgb, var(--surface) 96%, transparent);
+        box-shadow: 0 18px 44px rgba(0,0,0,.16), 0 2px 10px rgba(0,0,0,.08), inset 0 1px 0 color-mix(in srgb, #fff 34%, transparent);
+        -webkit-backdrop-filter: blur(18px) saturate(150%);
+        backdrop-filter: blur(18px) saturate(150%);
+        opacity: 0;
+        transform: translateY(-6px) scale(.98);
+        transform-origin: top center;
+        transition: opacity 160ms ease-out, transform 180ms cubic-bezier(.23,1,.32,1), display 180ms allow-discrete, overlay 180ms allow-discrete;
+        scrollbar-width: thin;
+    }
+    ::picker(select):popover-open {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+    @starting-style {
+        ::picker(select):popover-open {
+            opacity: 0;
+            transform: translateY(-6px) scale(.98);
+        }
+    }
+    select:not([multiple]) option {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-height: 36px;
+        margin: 0;
+        padding: 8px 9px;
+        border: 0;
+        border-radius: 8px;
+        color: var(--text);
+        background: transparent;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: color 140ms ease, background-color 140ms ease, transform 100ms ease-out;
+    }
+    select:not([multiple]) option + option { margin-top: 2px; }
+    select:not([multiple]) option:hover,
+    select:not([multiple]) option:focus-visible {
+        outline: none;
+        background: color-mix(in srgb, var(--text) 6%, transparent);
+    }
+    select:not([multiple]) option:active { transform: scale(.985); }
+    select:not([multiple]) option:checked {
+        color: var(--accent-hover);
+        background: var(--accent-soft-bg);
+        font-weight: 600;
+    }
+    select:not([multiple]) option::checkmark {
+        order: 2;
+        margin-left: auto;
+        color: var(--accent-hover);
+        font-size: 13px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+        ::picker(select) { transform: none; transition: opacity 120ms ease, display 120ms allow-discrete, overlay 120ms allow-discrete; }
+        select:not([multiple])::picker-icon { transition: color 120ms ease; }
+        select:not([multiple]):open::picker-icon { transform: none; }
+    }
+}
 .btn-sm,
 .tool-btn,
 .icon-btn,

--- a/server.js
+++ b/server.js
@@ -2720,6 +2720,13 @@ app.get('/api/connections', requireUser, (req, res) => {
     }
 });
 
+app.get('/api/activities', requireUser, (req, res) => {
+    const from = Number(req.query.from) || 0;
+    const to = Number(req.query.to) || 0;
+    const userId = req.user.role === 'admin' ? '' : req.user.userId;
+    res.json({ activities: storage.queryActivities({ userId, from, to, limit: 500 }) });
+});
+
 app.post('/api/connections', requireUser, (req, res) => {
     const body = req.body || {};
     const protocol = String(body.protocol || 'SSH').toUpperCase();

--- a/storage.js
+++ b/storage.js
@@ -763,6 +763,15 @@ function listAllConnectionRows() { return db.prepare('SELECT * FROM connections 
 
 function getActivities(limit = 50) { return db.prepare('SELECT * FROM activities ORDER BY time DESC LIMIT ?').all(limit); }
 function getActivitiesForUser(userId, limit = 50) { return db.prepare('SELECT * FROM activities WHERE userId = ? ORDER BY time DESC LIMIT ?').all(String(userId), limit); }
+function queryActivities({ userId = '', from = 0, to = 0, limit = 500 } = {}) {
+    const conditions = [];
+    const params = { limit: Math.max(1, Math.min(500, Number(limit) || 500)) };
+    if (userId) { conditions.push('userId = @userId'); params.userId = String(userId); }
+    if (from > 0) { conditions.push('time >= @from'); params.from = Number(from); }
+    if (to > 0) { conditions.push('time <= @to'); params.to = Number(to); }
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    return db.prepare(`SELECT * FROM activities ${where} ORDER BY time DESC LIMIT @limit`).all(params);
+}
 function addActivity(activity) { db.prepare('INSERT INTO activities (id,time,message,type,userId) VALUES (@id,@time,@message,@type,@userId)').run({ ...activity, userId: activity.userId || null }); }
 function clearActivities() { db.prepare('DELETE FROM activities').run(); }
 
@@ -817,4 +826,4 @@ function deletePasskey(username, id) { db.prepare('DELETE FROM passkeys WHERE us
 function rawDb() { return db; }
 function close() { if (db) { db.close(); db = null; } }
 
-module.exports = { init, getUsersStore, saveUsersStore, getUser, getUserById, getUserBrief, getFirstUser, listUsers, createUser, updateUser, updateUserById, renameUser, getConnectionsStore, saveConnectionsStore, getConnectionById, insertConnection, updateConnectionRow, deleteConnectionRow, listAllConnectionRows, getSettings, updateSettings, addActivity, getActivities, getActivitiesForUser, clearActivities, listProxies, getProxyRaw, saveProxy, deleteProxy, listSshKeys, getSshKeyRaw, saveSshKey, deleteSshKey, listJumpHosts, saveJumpHost, deleteJumpHost, addLoginEvent, listLoginEvents, clearLoginEvents, getIpBan, saveIpBan, clearIpBan, listIpBans, createResetCode, findResetCode, markResetCodeUsed, listPasskeys, savePasskey, getPasskeyByCredentialId, updatePasskeyCounter, deletePasskey, rawDb, close };
+module.exports = { init, getUsersStore, saveUsersStore, getUser, getUserById, getUserBrief, getFirstUser, listUsers, createUser, updateUser, updateUserById, renameUser, getConnectionsStore, saveConnectionsStore, getConnectionById, insertConnection, updateConnectionRow, deleteConnectionRow, listAllConnectionRows, getSettings, updateSettings, addActivity, getActivities, getActivitiesForUser, queryActivities, clearActivities, listProxies, getProxyRaw, saveProxy, deleteProxy, listSshKeys, getSshKeyRaw, saveSshKey, deleteSshKey, listJumpHosts, saveJumpHost, deleteJumpHost, addLoginEvent, listLoginEvents, clearLoginEvents, getIpBan, saveIpBan, clearIpBan, listIpBans, createResetCode, findResetCode, markResetCodeUsed, listPasskeys, savePasskey, getPasskeyByCredentialId, updatePasskeyCounter, deletePasskey, rawDb, close };


### PR DESCRIPTION
## Summary
- move activity history into a dedicated, filterable view
- refine security, AI, proxy, SSH key, and snippet settings workflows
- improve connection window transitions and add a localhost preview mock

## Validation
- JavaScript syntax check: 45 files passed
- permission/workspace hardening tests: 5 passed