### PR TITLE
feat(telnet): support proxy and SSH jump routes

### DIFF
--- a/ai-connection-tools.js
+++ b/ai-connection-tools.js
@@ -103,17 +103,12 @@ function applyProtocolRules(connection) {
     connection.connectionMode = CONNECTION_MODES.includes(connection.connectionMode) ? connection.connectionMode : 'direct';
     connection.sshKeyId = String(connection.sshKeyId || '');
     connection.encoding = String(connection.encoding || 'utf-8').slice(0, 80);
+    connection.proxyId = connection.connectionMode === 'proxy' ? (connection.proxyId || null) : null;
+    connection.jumpHostIds = connection.connectionMode === 'jump' ? strings(connection.jumpHostIds, 12) : [];
+    connection.jumpHostId = connection.jumpHostIds[0] || null;
     if (protocol === 'TELNET') {
-        connection.connectionMode = 'direct';
-        connection.proxyId = null;
-        connection.jumpHostId = null;
-        connection.jumpHostIds = [];
         connection.sshKeyId = '';
         connection.privateKey = '';
-    } else {
-        connection.proxyId = connection.connectionMode === 'proxy' ? (connection.proxyId || null) : null;
-        connection.jumpHostIds = connection.connectionMode === 'jump' ? strings(connection.jumpHostIds, 12) : [];
-        connection.jumpHostId = connection.jumpHostIds[0] || null;
     }
     if (!String(connection.name || '').trim() || !String(connection.host || '').trim() || (protocol === 'SSH' && !String(connection.username || '').trim())) {
         throw new HttpError(400, 'invalid_connection', protocol === 'SSH' ? '名称、主机、用户名不能为空' : '名称、主机不能为空');

--- a/public/activity-i18n.js
+++ b/public/activity-i18n.js
@@ -1,4 +1,4 @@
-import { t } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 const exact = new Set([
     '修改登录密码', '通过邮箱重置令牌重置密码', '开启 TOTP 两步验证', '关闭 TOTP 两步验证',

--- a/public/app.html
+++ b/public/app.html
@@ -6,10 +6,10 @@
     <title>Zephyr</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌬️</text></svg>">
     <link rel="modulepreload" href="vendor/zephyr-motion/index.js?v=20260725-ai-picker3">
-    <link rel="modulepreload" href="app.js?v=20260726-password-code-layout1">
+    <link rel="modulepreload" href="app.js?v=20260726-telnet-routes1">
     <link rel="modulepreload" href="theme-runtime.js?v=20260725-ai-picker3">
-    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-password-code-layout1">
-    <link rel="stylesheet" href="style.css?v=20260726-password-code-layout1">
+    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-telnet-routes1">
+    <link rel="stylesheet" href="style.css?v=20260726-telnet-routes1">
 </head>
 <body class="app-body">
     <div class="app-shell">
@@ -1025,7 +1025,7 @@
 
     <div class="toast" id="toast"></div>
     <script src="preview-mock.js?v=20260723-sync2" type="module"></script>
-    <script src="app.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="app.js?v=20260726-telnet-routes1" type="module"></script>
     <script>
         // Paint last shell immediately (before module load) to avoid dashboard flash.
         try {

--- a/public/app.js
+++ b/public/app.js
@@ -2,8 +2,8 @@ import { reduceParentKeyboardMessage } from './ssh-keyboard/bridge.js?v=20260723
 import { applyZephyrColorScheme, DEFAULT_CUSTOM_THEME_COLORS, normalizeCustomThemeColors, zephyrBrandIconHtml, zephyrFaviconHref } from './theme-runtime.js?v=20260723-term-colors1';
 import { createNotesController } from './notes.js?v=20260720-notes-select1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
-import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260726-password-code-layout1';
-import { localizeActivityMessage } from './activity-i18n.js?v=20260726-password-code-layout1';
+import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260726-telnet-routes1';
+import { localizeActivityMessage } from './activity-i18n.js?v=20260726-telnet-routes1';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));
@@ -1728,7 +1728,8 @@ function updateProtocolFields({ preservePort = true } = {}) {
     }
     $('#connSshKey')?.closest('.form-group')?.classList.toggle('force-hidden', protocol !== 'SSH');
     $('#connPrivateKey')?.closest('.form-group')?.classList.toggle('force-hidden', protocol !== 'SSH');
-    // Telnet is cleartext and has no SSH jump/proxy chain support.
+    // Telnet remains cleartext end-to-end, but its TCP transport can use the
+    // same proxy or SSH jump route selector as SSH/RDP/VNC.
     // Password is kept visible for in-band auto-login (still plaintext on wire).
     $('#connPassword')?.closest('.form-group')?.classList.toggle('force-hidden', false);
     $('#connEncodingGroup')?.classList.toggle('force-hidden', protocol !== 'TELNET');
@@ -1736,8 +1737,7 @@ function updateProtocolFields({ preservePort = true } = {}) {
     $('#telnetUsernameHint')?.classList.toggle('force-hidden', protocol !== 'TELNET');
     $('#rdpSettingsPanel')?.classList.toggle('force-hidden', protocol !== 'RDP');
     $('#rdpDomainGroup')?.classList.toggle('force-hidden', protocol !== 'RDP');
-    $('.advanced-route-panel')?.classList.toggle('force-hidden', protocol === 'TELNET');
-    if (protocol === 'TELNET') setRouteMode?.('direct');
+    $('.advanced-route-panel')?.classList.remove('force-hidden');
     updateConnectionSecretRevealChrome(protocol);
     console.debug('[conn-protocol]', 'protocol fields updated', { protocol, defaultPort, usernameRequired: protocol === 'SSH' });
 }
@@ -2295,8 +2295,7 @@ function updateRdpTouchSettingsUi() {
 
 function connectionPayload({ forTest = false } = {}) {
     const protocol = String($('#connProtocol').value || 'SSH').toUpperCase();
-    // Telnet has no jump/proxy chain yet — force direct.
-    const mode = protocol === 'TELNET' ? 'direct' : ($('#connMode').value || 'direct');
+    const mode = $('#connMode').value || 'direct';
     const proxyId = mode === 'proxy' ? ($('#connRoute')?.value || '') : '';
     const jumpHostIds = mode === 'jump' ? [...new Set($$('#jumpRouteList [data-jump-route-select]').map((el) => el.value).filter(Boolean))] : [];
     const defaultPort = protocol === 'RDP' ? 3389 : protocol === 'VNC' ? 5900 : protocol === 'TELNET' ? 23 : 22;

--- a/public/client.js
+++ b/public/client.js
@@ -1,5 +1,5 @@
 import { applyZephyrColorScheme, zephyrBrandIconHtml, zephyrFaviconHref } from './theme-runtime.js?v=20260615-visual-color-picker';
-import { t, initI18n, setLocale, getLocale, applyDomI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n, setLocale, getLocale, applyDomI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 const $ = (sel) => document.querySelector(sel);
 const errorBanner = $('#errorBanner');
@@ -306,7 +306,7 @@ const loginSelectMotion = {
     failed: false,
     _ensure() {
         if (this.engine || this.failed) return Promise.resolve(this.engine);
-        return import('./vendor/zephyr-motion/index.js?v=20260726-password-code-layout1')
+        return import('./vendor/zephyr-motion/index.js?v=20260726-telnet-routes1')
             .then(async (mod) => {
                 const Motion = mod?.Motion || window.Motion;
                 if (!Motion) throw new Error('Motion missing from zephyr-motion module');

--- a/public/floating-panel.js
+++ b/public/floating-panel.js
@@ -9,7 +9,7 @@ let panelLayoutMenu = null;
 let panelLayoutButton = null;
 let suppressNextLayoutClick = false;
 
-import { t } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 export function detectInteractionEnvironment() {
     const ua = String(navigator.userAgent || '').toLowerCase();

--- a/public/i18n/runtime.js
+++ b/public/i18n/runtime.js
@@ -112,7 +112,7 @@ async function fetchCatalog(locale) {
     const loc = normalizeLocale(locale);
     if (catalogs[loc] && Object.keys(catalogs[loc]).length) return catalogs[loc];
     const url = new URL(`./locales/${loc}.json`, import.meta.url);
-    url.searchParams.set('v', '20260726-password-code-layout1');
+    url.searchParams.set('v', '20260726-telnet-routes1');
     const res = await fetch(url.href, { credentials: 'same-origin' });
     if (!res.ok) throw new Error(`i18n catalog ${loc} HTTP ${res.status}`);
     const dict = await res.json();

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="Zephyr - 登录">Zephyr - 登录</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌬️</text></svg>">
-    <link rel="stylesheet" href="style.css?v=20260726-password-code-layout1">
+    <link rel="stylesheet" href="style.css?v=20260726-telnet-routes1">
 </head>
 <body>
     <div class="login-card auth-card" id="loginCard">
@@ -135,6 +135,6 @@
     </div>
     <div class="beian-footer" id="beianFooter"></div>
     <script src="preview-mock.js?v=20260723-activity1" type="module"></script>
-    <script src="client.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="client.js?v=20260726-telnet-routes1" type="module"></script>
 </body>
 </html>

--- a/public/notes.js
+++ b/public/notes.js
@@ -5,7 +5,7 @@
  */
 
 import { renderMarkdown as renderMarkdownFull, escapeHtml as mdEscapeHtml } from './markdown.js?v=20260720-notes-md1';
-import { t } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 const NOTES_DEBOUNCE_MS = 800;
 const NOTES_SEARCH_MS = 180;

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -117,6 +117,6 @@
             </div>
         </main>
     </div>
-    <script src="novnc.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="novnc.js?v=20260726-telnet-routes1" type="module"></script>
 </body>
 </html>

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -1,5 +1,5 @@
 import RFB from '/vendor/novnc/core/rfb.js';
-import { t, initI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 import KeyTable from '/vendor/novnc/core/input/keysym.js';
 import { applyZephyrColorScheme } from './theme-runtime.js?v=20260615-visual-color-picker';
 

--- a/public/open.html
+++ b/public/open.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="color-scheme" content="dark light">
     <title data-i18n="临时连接 · Zephyr">临时连接 · Zephyr</title>
-    <link rel="stylesheet" href="/style.css?v=20260726-password-code-layout1">
-    <link rel="modulepreload" href="/i18n/runtime.js?v=20260726-password-code-layout1">
+    <link rel="stylesheet" href="/style.css?v=20260726-telnet-routes1">
+    <link rel="modulepreload" href="/i18n/runtime.js?v=20260726-telnet-routes1">
     <style>
         /* /open is a thin hand-off page: parse fragment, prepare token, then
          * either open the in-app transient modal or show a self-contained
@@ -132,6 +132,6 @@
             </div>
         </section>
     </main>
-    <script src="/open.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="/open.js?v=20260726-telnet-routes1" type="module"></script>
 </body>
 </html>

--- a/public/open.js
+++ b/public/open.js
@@ -10,7 +10,7 @@
  * Never writes passwords into localStorage, draft DOM values, or logs.
  */
 
-import { t, initI18n, applyDomI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n, applyDomI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 const STORAGE_KEY = 'zephyr:deeplink:pending';
 const channel = ('BroadcastChannel' in window) ? new BroadcastChannel('zephyr-deeplink') : null;

--- a/public/password-rollback.html
+++ b/public/password-rollback.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="color-scheme" content="dark light">
     <title data-i18n="恢复之前的密码 · Zephyr">恢复之前的密码 · Zephyr</title>
-    <link rel="stylesheet" href="/style.css?v=20260726-password-code-layout1">
-    <link rel="modulepreload" href="/i18n/runtime.js?v=20260726-password-code-layout1">
+    <link rel="stylesheet" href="/style.css?v=20260726-telnet-routes1">
+    <link rel="modulepreload" href="/i18n/runtime.js?v=20260726-telnet-routes1">
     <style>
         /* Standalone password-rollback landing page (reachable while logged
          * out). Reuses the same design tokens as /open. */
@@ -131,6 +131,6 @@
             </div>
         </section>
     </main>
-    <script src="/password-rollback.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="/password-rollback.js?v=20260726-telnet-routes1" type="module"></script>
 </body>
 </html>

--- a/public/password-rollback.js
+++ b/public/password-rollback.js
@@ -7,7 +7,7 @@
  * States: confirm → working → done | error (invalid/expired/missing token).
  */
 
-import { t, initI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 const el = {
     warning: document.getElementById('rollbackWarning'),

--- a/public/preview-mock.js
+++ b/public/preview-mock.js
@@ -1,4 +1,4 @@
-import { t } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t } from './i18n/runtime.js?v=20260726-telnet-routes1';
 
 const previewEnabled = location.protocol === 'http:' && location.hostname === 'localhost' && location.port === '5173';
 

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -11,7 +11,7 @@
  */
 
 import { applyZephyrColorScheme } from './theme-runtime.js?v=20260630-rdp-engine';
-import { t, initI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 import { createRdpDiagnostics } from './rdp-diagnostics.js?v=20260720-zft2';
 import { RdpWorkerBridge } from './rdp-worker-bridge.js?v=20260720-zft2';
 import { RdpTouchController, rdpHaptic } from './rdp-touch.js?v=20260720-zft2';

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=overlays-content">
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌬️</text></svg>">
-    <link rel="stylesheet" href="style.css?v=20260726-password-code-layout1">
-    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-password-code-layout1">
+    <link rel="stylesheet" href="style.css?v=20260726-telnet-routes1">
+    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-telnet-routes1">
 </head>
 <body>
     <div class="novnc-page rdp-page">
@@ -216,7 +216,7 @@
             </div>
         </div>
     </div>
-    <script src="rdp-wasm-client.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="rdp-wasm-client.js?v=20260726-telnet-routes1" type="module"></script>
     <script>
     /* Auto-report H264 debug logs to server after 8 seconds */
     setTimeout(async () => {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = 'zephyr-static-20260726-password-code-layout1';
+const CACHE_NAME = 'zephyr-static-20260726-telnet-routes1';
 const PRECACHE = [
-    '/app.js?v=20260726-password-code-layout1',
-    '/style.css?v=20260726-password-code-layout1',
+    '/app.js?v=20260726-telnet-routes1',
+    '/style.css?v=20260726-telnet-routes1',
     '/theme-runtime.js?v=20260615-visual-color-picker',
-    '/terminal.js?v=20260726-password-code-layout1',
+    '/terminal.js?v=20260726-telnet-routes1',
     '/notes.js',
     '/markdown.js',
 ];

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=overlays-content">
     <title data-i18n="Zephyr - Telnet 终端">Zephyr - Telnet 终端</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌬️</text></svg>">
-    <link rel="modulepreload" href="telnet-terminal.js?v=20260726-password-code-layout1">
+    <link rel="modulepreload" href="telnet-terminal.js?v=20260726-telnet-routes1">
     <link rel="modulepreload" href="theme-runtime.js?v=20260725-telnet-page-split1">
-    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-password-code-layout1">
+    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-telnet-routes1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260725-telnet-page-split1">
-    <link rel="stylesheet" href="style.css?v=20260726-password-code-layout1">
+    <link rel="stylesheet" href="style.css?v=20260726-telnet-routes1">
     <script type="importmap">
         {
             "imports": {
@@ -165,6 +165,6 @@
             </div>
         </div>
     </div>
-    <script src="telnet-terminal.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="telnet-terminal.js?v=20260726-telnet-routes1" type="module"></script>
 </body>
 </html>

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -1,6 +1,6 @@
 /* Telnet terminal page — no SFTP / Docker / remote stats. Fork of terminal.js. */
 import { applyZephyrColorScheme } from './theme-runtime.js?v=20260615-visual-color-picker';
-import { t, initI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 window.__zephyrT = t;
 import {
     createSshKeyboard,

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=overlays-content">
     <title data-i18n="Zephyr - 终端">Zephyr - 终端</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌬️</text></svg>">
-    <link rel="modulepreload" href="terminal.js?v=20260726-password-code-layout1">
+    <link rel="modulepreload" href="terminal.js?v=20260726-telnet-routes1">
     <link rel="modulepreload" href="theme-runtime.js?v=20260725-telnet-page-split1">
-    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-password-code-layout1">
+    <link rel="modulepreload" href="i18n/runtime.js?v=20260726-telnet-routes1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260725-telnet-page-split1">
-    <link rel="stylesheet" href="style.css?v=20260726-password-code-layout1">
+    <link rel="stylesheet" href="style.css?v=20260726-telnet-routes1">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">
@@ -364,6 +364,6 @@
     <script src="preview/image/image-preview.js?v=20260725-telnet-page-split1"></script>
     <script src="preview/media/media-preview.js?v=20260725-telnet-page-split1"></script>
     <script src="editor/zephyr-editor.bundle.js?v=20260725-telnet-page-split1" type="module"></script>
-    <script src="terminal.js?v=20260726-password-code-layout1" type="module"></script>
+    <script src="terminal.js?v=20260726-telnet-routes1" type="module"></script>
 </body>
 </html>

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -1,5 +1,5 @@
 import { applyZephyrColorScheme } from './theme-runtime.js?v=20260615-visual-color-picker';
-import { t, initI18n } from './i18n/runtime.js?v=20260726-password-code-layout1';
+import { t, initI18n } from './i18n/runtime.js?v=20260726-telnet-routes1';
 window.__zephyrT = t;
 import {
     createSshKeyboard,

--- a/server.js
+++ b/server.js
@@ -408,6 +408,10 @@ function destroySshTerminalSession(sessionOrId, reason = 'session-destroy') {
         try { session.telnetSocket.destroy?.(); } catch {}
         session.telnetSocket = null;
     }
+    if (session.routedTcpForward) {
+        try { session.routedTcpForward.close?.(); } catch {}
+        session.routedTcpForward = null;
+    }
 }
 
 
@@ -988,8 +992,7 @@ function forwardOut(client, host, port) {
 }
 
 function resolveRoutePlan(conn) {
-    const store = readJSON(CONNECTIONS_FILE, { connections: [] });
-    const connections = store.connections || [];
+    const connections = storage.listAllConnectionRows();
     const mode = conn.connectionMode || 'direct';
     if (mode === 'proxy') {
         const proxy = storage.getProxyRaw(conn.proxyId);
@@ -1430,36 +1433,35 @@ function classifySSHError(err) {
     return { code: 'unknown', message: msg };
 }
 
-/* Telnet connectivity test (FREEZE plan §5.6): TCP connect to host:port and
- * send a minimal IAC DO TERMINAL-TYPE to confirm a Telnet server is listening.
- * Full IAC negotiation happens on the live /ssh session; this just verifies
- * reachability. */
-function testTelnetConnection(conn, timeout = 10000) {
-    return new Promise((resolve) => {
-        const started = Date.now();
-        const socket = new net.Socket();
-        let done = false;
-        const finish = (result) => {
-            if (done) return;
-            done = true;
-            socket.destroy();
-            resolve({ ...result, durationMs: Date.now() - started });
+/* Telnet connectivity test (FREEZE plan §5.6): open the configured direct,
+ * proxy, or SSH-jump TCP route and perform the normal initial IAC negotiation.
+ * The probe closes immediately after reachability is confirmed. */
+async function testTelnetConnection(conn, timeout = 10000) {
+    const started = Date.now();
+    let routedForward = null;
+    let socket = null;
+    try {
+        routedForward = await createRoutedTcpForward(conn, Number(conn.port) || 23, timeout);
+        const effectiveHost = routedForward?.host || String(conn.host || '');
+        const effectivePort = routedForward?.port || Number(conn.port) || 23;
+        socket = await dialTelnet({ host: effectiveHost, port: effectivePort }, { timeout });
+        return {
+            ok: true,
+            code: 'success',
+            message: routedForward?.route ? `Telnet 端口可达（${routedForward.route}）` : 'Telnet 端口可达',
+            durationMs: Date.now() - started,
         };
-        const timer = setTimeout(() => finish({ ok: false, code: 'timeout', message: 'Telnet 连接超时', durationMs: 0 }), timeout + 1000);
-        socket.setTimeout(timeout);
-        socket.once('connect', () => {
-            clearTimeout(timer);
-            // Send IAC DO TERMINAL-TYPE (255 253 24) to probe for a Telnet server
-            try { socket.write(Buffer.from([255, 253, 24])); } catch {}
-            finish({ ok: true, code: 'success', message: 'Telnet 端口可达' });
-        });
-        socket.once('timeout', () => finish({ ok: false, code: 'timeout', message: 'Telnet 连接超时' }));
-        socket.once('error', (err) => {
-            clearTimeout(timer);
-            finish({ ok: false, code: 'connect_failed', message: err.message || 'Telnet 连接失败' });
-        });
-        socket.connect(Number(conn.port) || 23, String(conn.host || ''));
-    });
+    } catch (err) {
+        return {
+            ok: false,
+            code: /timeout|超时/i.test(String(err?.message || '')) ? 'timeout' : 'connect_failed',
+            message: err?.message || 'Telnet 连接失败',
+            durationMs: Date.now() - started,
+        };
+    } finally {
+        try { socket?.destroy?.(); } catch {}
+        try { routedForward?.close?.(); } catch {}
+    }
 }
 
 function testSSHConnection(conn, timeout = 10000) {    return new Promise((resolve) => {
@@ -3279,22 +3281,16 @@ app.post('/api/connections', requireUser, (req, res) => {
         conn.rdpTouchSensitivity = Math.max(0.5, Math.min(3, Number(body.rdpTouchSensitivity) || 1.5));
         conn.rdpDomain = String(body.rdpDomain || '').trim();
     }
+    applyConnectionRouteFields(conn, body);
     if (protocol === 'TELNET') {
-        // Telnet is direct-only: no jump/proxy/SSH key. Username/password are
-        // still stored (encrypted) for in-band auto-login after TCP connect.
-        conn.connectionMode = 'direct';
-        conn.proxyId = null;
-        conn.jumpHostId = null;
-        conn.jumpHostIds = [];
+        // Telnet cannot use SSH target credentials, but its raw TCP connection
+        // may travel through a proxy or an SSH jump chain. Username/password
+        // remain encrypted at rest and are used only for in-band auto-login.
         conn.sshKeyId = '';
         conn.privateKey = '';
-        // keep conn.password / conn.username
-        if (body.encoding !== undefined) conn.encoding = String(body.encoding || 'utf-8');
-        else if (!conn.encoding) conn.encoding = 'utf-8';
-    } else {
-        applyConnectionRouteFields(conn, body);
-        if (body.encoding !== undefined) conn.encoding = String(body.encoding || 'utf-8');
     }
+    if (body.encoding !== undefined) conn.encoding = String(body.encoding || 'utf-8');
+    else if (protocol === 'TELNET' && !conn.encoding) conn.encoding = 'utf-8';
     try {
         const saved = resourceService.createConnection(req.user, conn);
         addActivity(`新增连接：${conn.name}`, req.user.userId);
@@ -3315,19 +3311,14 @@ app.put('/api/connections/:id', requireUser, (req, res) => {
             if (body.sshKeyId !== undefined) conn.sshKeyId = String(body.sshKeyId || '');
             if (body.shareWithUsers !== undefined) conn.shareWithUsers = !!body.shareWithUsers;
             if (body.shareWithAdmins !== undefined) conn.shareWithAdmins = !!body.shareWithAdmins;
+            applyConnectionRouteFields(conn, body);
+            if (body.password !== undefined && body.password !== '******') conn.password = String(body.password || '');
             if (String(conn.protocol || '').toUpperCase() === 'TELNET') {
-                conn.connectionMode = 'direct';
-                conn.proxyId = null;
-                conn.jumpHostId = null;
-                conn.jumpHostIds = [];
                 conn.sshKeyId = '';
                 conn.privateKey = '';
                 // Telnet password is in-band auto-login material — allow update.
-                if (body.password !== undefined && body.password !== '******') conn.password = String(body.password || '');
                 if (body.encoding !== undefined) conn.encoding = String(body.encoding || 'utf-8');
             } else {
-                applyConnectionRouteFields(conn, body);
-                if (body.password !== undefined && body.password !== '******') conn.password = String(body.password || '');
                 if (body.privateKey !== undefined && body.privateKey !== '******') conn.privateKey = String(body.privateKey || '');
                 if (body.encoding !== undefined) conn.encoding = String(body.encoding || 'utf-8');
             }
@@ -4163,13 +4154,6 @@ app.post('/api/connections/test', requireUser, async (req, res) => {
     }
     const protocol = String(conn.protocol || 'SSH').toUpperCase();
     if (!conn.host || (protocol === 'SSH' && !conn.username)) return res.status(400).json({ error: protocol === 'SSH' ? '主机和用户名不能为空' : '主机不能为空' });
-    // Telnet is direct-only; ignore proxy/jump for connectivity tests.
-    if (protocol === 'TELNET') {
-        conn.connectionMode = 'direct';
-        conn.proxyId = null;
-        conn.jumpHostId = null;
-        conn.jumpHostIds = [];
-    }
     const timeoutMs = Math.max(1000, Math.min(Number(body.timeoutSeconds || 10) * 1000, 30000));
     const result = protocol === 'SSH'
         ? await testSSHConnection(conn, timeoutMs)
@@ -7206,13 +7190,10 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
                         jumpHostIds: msg.jumpHostIds,
                     });
                     if (fallbackProtocol === 'TELNET') {
-                        conn.connectionMode = 'direct';
-                        conn.proxyId = null;
-                        conn.jumpHostId = null;
-                        conn.jumpHostIds = [];
                         conn.sshKeyId = '';
                         conn.privateKey = '';
-                        // keep password for in-band auto-login
+                        // keep password for in-band auto-login; proxy/jump routes
+                        // are resolved above with the same dependency ACLs.
                     }
                     if (conn.sshKeyId || conn.connectionMode === 'proxy' || conn.connectionMode === 'jump') {
                         // Reuse dependency ACL checks against the caller's owned/shared deps.
@@ -7226,12 +7207,6 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
                 // Telnet: host is enough; username is display-only / in-band.
                 if (!conn.host) throw new Error('主机不能为空');
                 if (protocol !== 'TELNET' && !conn.username) throw new Error('主机和用户名不能为空');
-                if (protocol === 'TELNET') {
-                    conn.connectionMode = 'direct';
-                    conn.proxyId = null;
-                    conn.jumpHostId = null;
-                    conn.jumpHostIds = [];
-                }
                 console.info('[SSH-DIAG] resolved connection config', {
                     connectionId: conn.id || connectionId || '',
                     requestedConnectionId: connectionId || '',
@@ -7262,11 +7237,21 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
                     // the socket in the same session object SSH uses so attach /
                     // detach / history / detached-TTL all work unchanged.
                     if (connectionId) console.log(`[TELNET] 使用已保存连接 ${conn.name || conn.host}`);
-                    const socket = await dialTelnet(conn, { timeout: 10000, cols: initialCols, rows: initialRows });
+                    const routedForward = await createRoutedTcpForward(conn, Number(conn.port) || 23, 10000);
+                    let socket;
+                    try {
+                        socket = await dialTelnet({
+                            host: routedForward?.host || conn.host,
+                            port: routedForward?.port || Number(conn.port) || 23,
+                        }, { timeout: 10000, cols: initialCols, rows: initialRows });
+                    } catch (err) {
+                        try { routedForward?.close?.(); } catch {}
+                        throw err;
+                    }
                     telnetSocket = socket;
                     telnetProtocol = true;
                     socket.setTimeout(0); // live session — no idle timeout kill
-                    console.log(`[TELNET] 已连接: ${conn.host}:${Number(conn.port) || 23}`);
+                    console.log(`[TELNET] 已连接: ${conn.host}:${Number(conn.port) || 23}${routedForward?.route ? ` (${routedForward.route})` : ''}`);
                     const telnetIac = attachIacEngine(socket, {
                         termType: 'xterm-256color',
                         keepaliveMs: 60000,
@@ -7298,6 +7283,7 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
                         protocol: 'TELNET',
                         encoding: telnetDecoder.encoding,
                         telnetSocket: socket,
+                        routedTcpForward: routedForward,
                         telnetIac,
                         telnetDecoder,
                         telnetAutoLogin: autoLogin,

--- a/tests/ai-connection-lifecycle-v1.test.mjs
+++ b/tests/ai-connection-lifecycle-v1.test.mjs
@@ -35,7 +35,7 @@ test('canonical connection lifecycle supports TELNET without credential leaks', 
         args: {
             name: 'ai-telnet-lifecycle', protocol: 'TELNET', host: '127.0.0.1', port: 1,
             username: 'ops', encoding: 'gbk',
-            connectionMode: 'jump', jumpHostIds: ['must-be-cleared-for-telnet'],
+            connectionMode: 'direct',
         },
     });
     assert.equal(pendingCreate.status, 200);

--- a/tests/i18n-app-batch2-contract.test.mjs
+++ b/tests/i18n-app-batch2-contract.test.mjs
@@ -24,7 +24,7 @@ test('app.html marks navigation, dashboard, settings tabs with data-i18n', () =>
 
 test('app.js imports i18n runtime and bootstraps in init()', () => {
     const js = read('public/app.js');
-    assert.match(js, /from '\.\/i18n\/runtime\.js\?v=20260726-password-code-layout1'/);
+    assert.match(js, /from '\.\/i18n\/runtime\.js\?v=20260726-telnet-routes1'/);
     assert.match(js, /await initI18n\(\{ applyDom: true \}\);/);
     assert.match(js, /onLocaleChange\(/);
     assert.match(js, /function bindLocaleSelects\(\)/);
@@ -73,9 +73,9 @@ test('catalogs include batch 2 keys with en translations', () => {
 
 test('app.html cache busts include current i18n fix revision', () => {
     const html = read('public/app.html');
-    assert.match(html, /app\.js\?v=20260726-password-code-layout1/);
-    assert.match(html, /style\.css\?v=20260726-password-code-layout1/);
-    assert.match(html, /i18n\/runtime\.js\?v=20260726-password-code-layout1/);
+    assert.match(html, /app\.js\?v=20260726-telnet-routes1/);
+    assert.match(html, /style\.css\?v=20260726-telnet-routes1/);
+    assert.match(html, /i18n\/runtime\.js\?v=20260726-telnet-routes1/);
 });
 
 test('app.html marks security settings panel with data-i18n', () => {

--- a/tests/i18n-global-audit.test.mjs
+++ b/tests/i18n-global-audit.test.mjs
@@ -56,7 +56,7 @@ test('frontend user-visible calls contain no untranslated Chinese literals', () 
 });
 
 test('every frontend module that imports i18n uses the current cache revision', () => {
-    const current = '20260726-password-code-layout1';
+    const current = '20260726-telnet-routes1';
     const publicDir = path.join(root, 'public');
     const files = [];
     const walk = (dir) => {

--- a/tests/i18n-locale-rerender-browser.test.mjs
+++ b/tests/i18n-locale-rerender-browser.test.mjs
@@ -18,12 +18,12 @@ after(async () => {
 test('app HTML ships the current i18n cache-busting revision', async () => {
     const response = await fetch(server.url('/app.html'), { headers: { cookie } });
     const html = await response.text();
-    assert.match(html, /app\.js\?v=20260726-password-code-layout1/);
-    assert.match(html, /i18n\/runtime\.js\?v=20260726-password-code-layout1/);
+    assert.match(html, /app\.js\?v=20260726-telnet-routes1/);
+    assert.match(html, /i18n\/runtime\.js\?v=20260726-telnet-routes1/);
 });
 
 test('locale switch hook repaints state-derived security fragments', async () => {
-    const source = await (await fetch(server.url('/app.js?v=20260726-password-code-layout1'))).text();
+    const source = await (await fetch(server.url('/app.js?v=20260726-telnet-routes1'))).text();
     for (const renderer of ['renderTotp', 'renderPasskeys', 'renderSecurityLists', 'renderAiProviderList']) {
         assert.match(source, new RegExp(`rerenderLocaleSensitiveContent[\\s\\S]{0,1800}${renderer}`));
     }

--- a/tests/i18n-login-contract.test.mjs
+++ b/tests/i18n-login-contract.test.mjs
@@ -38,12 +38,12 @@ test('index.html marks login strings with data-i18n and locale switch', () => {
     assert.match(html, /data-i18n="登录"/);
     assert.match(html, /data-i18n="使用 Passkey 登录"/);
     assert.match(html, /id="localeSelectLogin"/);
-    assert.match(html, /client\.js\?v=20260726-password-code-layout1/);
+    assert.match(html, /client\.js\?v=20260726-telnet-routes1/);
 });
 
 test('client.js uses i18n runtime for user-facing strings', () => {
     const js = read('public/client.js');
-    assert.match(js, /from '\.\/i18n\/runtime\.js\?v=20260726-password-code-layout1'/);
+    assert.match(js, /from '\.\/i18n\/runtime\.js\?v=20260726-telnet-routes1'/);
     assert.match(js, /t\('请求失败'\)/);
     assert.match(js, /t\('请先完成人机验证'\)/);
     assert.match(js, /t\('\{brand\} - 登录'/);

--- a/tests/login-locale-toggle-select-contract.test.mjs
+++ b/tests/login-locale-toggle-select-contract.test.mjs
@@ -13,7 +13,7 @@ test('login locale selects become toggle-selects with motion open/close', () => 
     assert.match(js, /function openLoginToggleMenu\(shell\)/);
     assert.match(js, /function closeLoginToggleMenu\(shell\)/);
     assert.match(js, /function syncLoginToggleFace\(select\)/);
-    assert.match(js, /import\('\.\/vendor\/zephyr-motion\/index\.js\?v=20260726-password-code-layout1'\)/);
+    assert.match(js, /import\('\.\/vendor\/zephyr-motion\/index\.js\?v=20260726-telnet-routes1'\)/);
     assert.match(js, /preset: 'mac',/);
     assert.match(js, /\{ preset: 'macClose' \}/);
     assert.match(js, /Motion\.setOriginFromAnchor\?\.\(menu, trigger\)/);
@@ -64,5 +64,5 @@ test('settings language select and proxy type select join the motion open/close 
 
 test('rollback page contract test revision stays in sync', () => {
     const js = read('public/password-rollback.js');
-    assert.match(js, /i18n\/runtime\.js\?v=20260726-password-code-layout1/);
+    assert.match(js, /i18n\/runtime\.js\?v=20260726-telnet-routes1/);
 });

--- a/tests/password-rollback-contract.test.mjs
+++ b/tests/password-rollback-contract.test.mjs
@@ -72,9 +72,9 @@ test('rollback landing page markup and client follow i18n and post the token', (
     assert.match(html, /id="rollbackConfirmBtn" data-i18n="恢复密码"/);
     assert.match(html, /href="\/" data-i18n="返回登录"/);
     assert.match(html, /id="rollbackError" role="alert"/);
-    assert.match(html, /src="\/password-rollback\.js\?v=20260726-password-code-layout1" type="module"/);
+    assert.match(html, /src="\/password-rollback\.js\?v=20260726-telnet-routes1" type="module"/);
     const js = read('public/password-rollback.js');
-    assert.match(js, /import \{ t, initI18n \} from '\.\/i18n\/runtime\.js\?v=20260726-password-code-layout1';/);
+    assert.match(js, /import \{ t, initI18n \} from '\.\/i18n\/runtime\.js\?v=20260726-telnet-routes1';/);
     assert.match(js, /new URLSearchParams\(location\.search\)\.get\('token'\)/);
     assert.match(js, /fetch\('\/api\/auth\/password-rollback'/);
     assert.match(js, /JSON\.stringify\(\{ token \}\)/);

--- a/tests/telnet-api.test.mjs
+++ b/tests/telnet-api.test.mjs
@@ -71,7 +71,7 @@ test('deeplink prepare + test for telnet:// works', async () => {
     assert.equal(testRes.body.ok, true);
 });
 
-test('PUT forces TELNET connections back to direct; keeps password, clears privateKey/route', async () => {
+test('PUT keeps TELNET proxy route and password while clearing SSH target credentials', async () => {
     const created = await server.api(adminCookie, 'POST', '/api/connections', {
         name: 'telnet-edit',
         host: '10.1.1.1',
@@ -82,6 +82,10 @@ test('PUT forces TELNET connections back to direct; keeps password, clears priva
     });
     assert.equal(created.status, 200);
     const id = created.body.connection.id;
+    const proxy = await server.api(adminCookie, 'POST', '/api/proxies', {
+        name: 'telnet-test-proxy', type: 'socks5', host: '127.0.0.1', port: 1080,
+    });
+    assert.equal(proxy.status, 200, JSON.stringify(proxy.body));
     const updated = await server.api(adminCookie, 'PUT', `/api/connections/${id}`, {
         protocol: 'TELNET',
         host: '10.1.1.1',
@@ -90,12 +94,13 @@ test('PUT forces TELNET connections back to direct; keeps password, clears priva
         password: 'inband-secret',
         privateKey: '-----BEGIN FAKE-----',
         connectionMode: 'proxy',
-        proxyId: 'whatever',
+        proxyId: proxy.body.proxy.id,
         encoding: 'gbk',
     });
     assert.equal(updated.status, 200, JSON.stringify(updated.body));
     assert.equal(updated.body.connection.protocol, 'TELNET');
-    assert.equal(updated.body.connection.connectionMode, 'direct');
+    assert.equal(updated.body.connection.connectionMode, 'proxy');
+    assert.equal(updated.body.connection.proxyId, proxy.body.proxy.id);
     // Password is stored (masked in API response as ****** or hasPassword).
     assert.ok(
         updated.body.connection.hasPassword === true

--- a/tests/telnet-route.test.mjs
+++ b/tests/telnet-route.test.mjs
@@ -1,0 +1,203 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import WebSocket from 'ws';
+import ssh2 from 'ssh2';
+import { TestServer } from './test-server.mjs';
+
+const { Server: SshServer, utils: sshUtils } = ssh2;
+
+let server;
+let cookie;
+let telnetServer;
+let telnetPort;
+let proxyServer;
+let proxyPort;
+let sshServer;
+let sshPort;
+let sshPrivateKey;
+
+function listen(server, host = '127.0.0.1') {
+    return new Promise((resolve) => server.listen(0, host, () => resolve(server.address().port)));
+}
+
+function openWs(cookieValue) {
+    return new WebSocket(server.url('/ssh').replace(/^http/, 'ws'), { headers: { Cookie: cookieValue } });
+}
+
+function waitFor(ws, type, timeoutMs = 5000) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timeout waiting for ${type}`)), timeoutMs);
+        const onMessage = (raw) => {
+            let msg;
+            try { msg = JSON.parse(String(raw)); } catch { return; }
+            if (msg.type === 'error' && type !== 'error') {
+                clearTimeout(timer);
+                ws.off('message', onMessage);
+                reject(new Error(msg.message || 'websocket error'));
+                return;
+            }
+            if (msg.type !== type) return;
+            clearTimeout(timer);
+            ws.off('message', onMessage);
+            resolve(msg);
+        };
+        ws.on('message', onMessage);
+    });
+}
+
+before(async () => {
+    telnetServer = net.createServer((socket) => {
+        socket.on('error', () => {});
+        socket.write('proxy-login: ');
+        socket.on('data', (chunk) => {
+            const printable = [...chunk].filter((byte) => byte !== 255).map((byte) => String.fromCharCode(byte)).join('');
+            if (printable.trim()) socket.write(printable);
+        });
+    });
+    telnetPort = await listen(telnetServer);
+
+    proxyServer = net.createServer((client) => {
+        client.on('error', () => {});
+        let buffer = Buffer.alloc(0);
+        client.once('data', (hello) => {
+            if (hello[0] !== 0x05) return client.destroy();
+            client.write(Buffer.from([0x05, 0x00]));
+            client.once('data', (request) => {
+                buffer = Buffer.concat([buffer, request]);
+                if (buffer[0] !== 0x05 || buffer[1] !== 0x01) return client.destroy();
+                let offset = 4;
+                let host = '';
+                if (buffer[3] === 0x01) {
+                    host = [...buffer.subarray(offset, offset + 4)].join('.');
+                    offset += 4;
+                } else if (buffer[3] === 0x03) {
+                    const length = buffer[offset++];
+                    host = buffer.subarray(offset, offset + length).toString();
+                    offset += length;
+                } else return client.destroy();
+                const port = buffer.readUInt16BE(offset);
+                const upstream = net.createConnection(port, host, () => {
+                    client.write(Buffer.from([0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 0]));
+                    client.pipe(upstream);
+                    upstream.pipe(client);
+                });
+                upstream.on('error', () => client.destroy());
+            });
+            if (hello.length > 3) client.unshift(hello.subarray(3));
+        });
+    });
+    proxyPort = await listen(proxyServer);
+
+    sshPrivateKey = sshUtils.generateKeyPairSync('ed25519').private;
+    sshServer = new SshServer({ hostKeys: [sshPrivateKey] }, (client) => {
+        client.on('authentication', (ctx) => {
+            if (ctx.method === 'password' && ctx.username === 'jump' && ctx.password === 'jump-pass') ctx.accept();
+            else ctx.reject();
+        });
+        client.on('ready', () => {
+            client.on('tcpip', (accept, reject, info) => {
+                const upstream = net.createConnection(info.destPort, info.destIP, () => {
+                    const channel = accept();
+                    channel.on('error', () => {});
+                    upstream.on('error', () => {});
+                    channel.pipe(upstream);
+                    upstream.pipe(channel);
+                });
+                upstream.on('error', () => reject());
+            });
+        });
+    });
+    sshPort = await listen(sshServer);
+
+    server = new TestServer();
+    await server.start();
+    cookie = (await server.bootstrapAdmin('admin-pass-telnet-route')).cookie;
+});
+
+after(async () => {
+    await server.cleanup();
+    await new Promise((resolve) => sshServer.close(resolve));
+    await new Promise((resolve) => proxyServer.close(resolve));
+    await new Promise((resolve) => telnetServer.close(resolve));
+});
+
+test('saved TELNET connection tests and opens through SOCKS5 proxy', async () => {
+    const proxy = await server.api(cookie, 'POST', '/api/proxies', {
+        name: 'local-socks', type: 'socks5', host: '127.0.0.1', port: proxyPort,
+    });
+    assert.equal(proxy.status, 200, JSON.stringify(proxy.body));
+
+    const created = await server.api(cookie, 'POST', '/api/connections', {
+        name: 'proxied-telnet', protocol: 'TELNET', host: '127.0.0.1', port: telnetPort,
+        connectionMode: 'proxy', proxyId: proxy.body.proxy.id,
+    });
+    assert.equal(created.status, 200, JSON.stringify(created.body));
+    assert.equal(created.body.connection.connectionMode, 'proxy');
+    assert.equal(created.body.connection.proxyId, proxy.body.proxy.id);
+
+    const tested = await server.api(cookie, 'POST', '/api/connections/test', {
+        connectionId: created.body.connection.id, timeoutSeconds: 3,
+    });
+    assert.equal(tested.status, 200, JSON.stringify(tested.body));
+    assert.equal(tested.body.ok, true);
+    assert.match(tested.body.message, /代理|local-socks/);
+
+    const ws = openWs(cookie);
+    await new Promise((resolve, reject) => { ws.once('open', resolve); ws.once('error', reject); });
+    const readyPromise = waitFor(ws, 'ready');
+    const dataPromise = waitFor(ws, 'data');
+    ws.send(JSON.stringify({
+        type: 'connect', connectionId: created.body.connection.id,
+        sessionId: `telnet-proxy-${Date.now()}`, cols: 80, rows: 24,
+    }));
+    const ready = await readyPromise;
+    assert.equal(ready.protocol, 'TELNET');
+    const data = await dataPromise;
+    assert.match(data.data, /proxy-login:/);
+    ws.close();
+});
+
+
+test('saved TELNET connection tests and opens through SSH jump host', async () => {
+    const jumpConnection = await server.api(cookie, 'POST', '/api/connections', {
+        name: 'local-ssh-jump', protocol: 'SSH', host: '127.0.0.1', port: sshPort,
+        username: 'jump', password: 'jump-pass', connectionMode: 'direct',
+    });
+    assert.equal(jumpConnection.status, 200, JSON.stringify(jumpConnection.body));
+
+    const jumpHost = await server.api(cookie, 'POST', '/api/jump-hosts', {
+        name: 'local-jump', connectionId: jumpConnection.body.connection.id,
+    });
+    assert.equal(jumpHost.status, 200, JSON.stringify(jumpHost.body));
+
+    const created = await server.api(cookie, 'POST', '/api/connections', {
+        name: 'jumped-telnet', protocol: 'TELNET', host: '127.0.0.1', port: telnetPort,
+        connectionMode: 'jump', jumpHostId: jumpHost.body.jumpHost.id,
+        jumpHostIds: [jumpHost.body.jumpHost.id],
+    });
+    assert.equal(created.status, 200, JSON.stringify(created.body));
+    assert.equal(created.body.connection.connectionMode, 'jump');
+    assert.deepEqual(created.body.connection.jumpHostIds, [jumpHost.body.jumpHost.id]);
+
+    const tested = await server.api(cookie, 'POST', '/api/connections/test', {
+        connectionId: created.body.connection.id, timeoutSeconds: 3,
+    });
+    assert.equal(tested.status, 200, JSON.stringify(tested.body));
+    assert.equal(tested.body.ok, true);
+    assert.match(tested.body.message, /local-jump/);
+
+    const ws = openWs(cookie);
+    await new Promise((resolve, reject) => { ws.once('open', resolve); ws.once('error', reject); });
+    const readyPromise = waitFor(ws, 'ready');
+    const dataPromise = waitFor(ws, 'data');
+    ws.send(JSON.stringify({
+        type: 'connect', connectionId: created.body.connection.id,
+        sessionId: `telnet-jump-${Date.now()}`, cols: 80, rows: 24,
+    }));
+    const ready = await readyPromise;
+    assert.equal(ready.protocol, 'TELNET');
+    const data = await dataPromise;
+    assert.match(data.data, /proxy-login:/);
+    ws.close();
+});

--- a/tests/telnet-ui-contract.test.mjs
+++ b/tests/telnet-ui-contract.test.mjs
@@ -30,11 +30,14 @@ test('frontend keeps password field for TELNET auto-login and submits encoding',
     assert.match(terminalJs, /encoding: params\.encoding/);
 });
 
-test('frontend no longer hard-blocks Telnet connect', () => {
+test('frontend no longer hard-blocks Telnet connect and keeps route UI available', () => {
     assert.doesNotMatch(appJs, /当前版本尚未启用 Telnet transport/);
     assert.doesNotMatch(appJs, /telnetBlocked\s*=\s*String\(\$\('#connProtocol'\)/);
     assert.match(appJs, /protocol === 'TELNET'/);
     assert.match(appJs, /telnetPlaintextBanner/);
+    assert.match(appHtml, /data-route-mode="proxy"[\s\S]*?data-route-mode="jump"/);
+    assert.doesNotMatch(appJs, /protocol === 'TELNET' \? 'direct' : \(\$\('#connMode'\)/);
+    assert.doesNotMatch(appJs, /advanced-route-panel[^\n]*force-hidden[^\n]*protocol === 'TELNET'/);
 });
 
 test('style defines plaintext Telnet banner', () => {
@@ -45,6 +48,8 @@ test('server wires TELNET on create/test/ws and no longer rejects transient Teln
     assert.match(serverJs, /require\('\.\/telnet-transport'\)/);
     assert.match(serverJs, /protocol === 'TELNET'/);
     assert.match(serverJs, /dialTelnet\(/);
+    assert.match(serverJs, /createRoutedTcpForward\(conn, Number\(conn\.port\) \|\| 23/);
+    assert.match(serverJs, /routedTcpForward: routedForward/);
     assert.match(serverJs, /filterIac\(/);
     assert.match(serverJs, /sendNaws\(/);
     assert.doesNotMatch(serverJs, /Telnet 临时连接请使用 worker ticket 路径/);


### PR DESCRIPTION
为 TELNET 复用现有连接弹窗的代理服务器/SSH 跳板机 UI，并打通保存、测试、临时连接和 WebSocket 会话路由。支持 SOCKS5、HTTP CONNECT、多级 SSH 跳板；保留 Telnet 编码和终端内自动登录。路由依赖继续走现有 ACL 校验，目标 Telnet 不接收 SSH 私钥。新增真实 SOCKS5 与 SSH forwardOut 端到端测试。验证：Telnet+路由电池 69/69；缓存/i18n 35/35；服务端关键回归 27/27；JS syntax 49 files；移动端 UI 实测代理/跳板控件可见并可选择。全量 Node：806 tests / 774 pass / 32 fail；失败含并行启动超时和主线既有契约，新增 Telnet 路由测试单独重复 3 次均通过。