### PR TITLE
docs(mobile): port Zephyr contracts into native One spec

### DIFF
--- a/FREEZE/zephyr one for mobile/AI_FLOATING_WORKSPACE.md
+++ b/FREEZE/zephyr one for mobile/AI_FLOATING_WORKSPACE.md
@@ -1,0 +1,141 @@
+# Zephyr AI 移动浮窗与能力对齐合同
+
+> [KNOWN] Zephyr AI 在 Zephyr 能做什么，在 Zephyr One 就必须能做什么；移动端只改变呈现、上下文桥接和确认交互，不删 tool、capability、risk、confirmation、playbook 或闭环验证。
+>
+> [KNOWN] 手机上 Zephyr AI 默认不是替换当前内容的独立全屏页，而是覆盖在当前页面/终端/远程桌面之上的原生浮动 workspace，使用户持续看见 AI 正在观察和操作的对象。
+
+## 1. 单一能力真源
+
+- [KNOWN] 服务端 `ai-capabilities.js`、`ai-extended-capabilities.js` 与模型可见 tool catalog 是唯一能力真源；One 不维护容易过期的手写工具子集。
+- [KNOWN] 当前全权限 catalog 在基线 `8dd5b98` 有 116 个模型可见 tool；数量会随 Zephyr 演进，不能被硬编码成永久上限。
+- [KNOWN] 每次连接主端后获取 `capabilityId/toolId/risk/confirmation/playbook/schema/state`；One UI 根据 registry 生成能力说明、trace、确认和失败恢复。
+- [KNOWN] `humanOnly` 保持 human-only：Token enrollment、私钥导入/生成/查看、账号密码、秘密 reveal 不进入模型上下文；“能力一致”不等于放松安全边界。
+- [KNOWN] Zephyr 新增 implemented AI capability 后，若 One 没有 host bridge 或原生观察面，compatibility CI 失败；不得静默隐藏。
+
+## 2. 浮窗形态
+
+### 2.1 手机 portrait
+
+- [KNOWN] AI launcher 是页面级浮动 action；打开后先出现低 detent composer，不离开底层页面。
+- [KNOWN] 面板有 `peek / half / expanded` 三态：peek 显示状态、输入和 stop；half 显示当前 conversation/trace；expanded 显示完整历史、附件、计划和设置。
+- [KNOWN] 即使 expanded 也保留可见的底层 context strip/缩略 live surface 和“一键回到对象”；不能把用户锁进孤立聊天页。
+- [INFERRED] 拖动只从 handle 开始；chat scroll、code block、terminal 和 remote gesture 不抢 panel drag。
+- [INFERRED] 下拉关闭遵循系统 sheet 阈值与速度；run 活跃时关闭只隐藏 UI，不默认取消任务，状态进入 launcher badge/通知。
+
+### 2.2 landscape / tablet
+
+- [KNOWN] 横屏优先右侧浮动 rail/panel，让 terminal/RDP/VNC 保持主要宽度；用户可切左右。
+- [INFERRED] iPad/Android expanded 可停靠为 320–480pt/dp side inspector，并可取消停靠恢复浮窗。
+- [INFERRED] panel 尺寸/位置按 scene/window 保存，不跨不兼容尺寸照搬坐标。
+
+### 2.3 IME 与沉浸 surface
+
+- [KNOWN] AI composer 获取输入时，panel 随 IME resize；不得同时显示根浮岛、terminal context dock、AI composer 三层输入 chrome。
+- [KNOWN] terminal/RDP/VNC 仍在 panel 后 live 渲染；AI 面板不能暂停 session、清空 selection 或改变 PTY/remote resolution，除非用户明确操作。
+- [INFERRED] terminal 可用 compact overlay，RDP/VNC 默认 half/side；面板不覆盖 remote pointer 的最后位置和确认目标标记。
+
+## 3. 用户必须看见 AI 在做什么
+
+[KNOWN] 浮窗不能只是聊天文字，必须把 observation → proposed action → confirmation → execution → verification 做成可观察闭环：
+
+1. **Context header**：当前 page、connection/session/resource、owner/capability 和 freshness。
+2. **Live trace**：tool、risk、参数摘要、目标、开始/完成时间、结果；secret 永不展示。
+3. **Target highlight**：原生页面高亮将操作的 row/field/action；terminal 高亮 session/range；RDP/VNC 显示 capture id 和 action marker。
+4. **Confirmation card**：动作、影响、对象、revision、rollback、风险；R1–R4 遵守服务器 metadata。
+5. **Verification**：执行后重新读取 authoritative state；远程桌面 before/after capture；写文件显示 snapshot/rollback id。
+6. **Take over**：用户随时暂停 AI、收起 panel 并手工操作；恢复时重新观察，不沿用陈旧 targetRef。
+
+[KNOWN] 底层页面发生导航、revision、session、frame 或 semantics version 变化时，旧引用失效；AI 必须重新 inspect/capture，不能点击旧坐标或旧 row。
+
+## 4. 原生上下文桥接
+
+- [KNOWN] Web `ui_action`/browser DOM 不能直接搬到原生 App；One 提供版本化 `NativeSurfaceBridge`，实现等价能力而不是删除 UI 操作。
+- [INFERRED] 每个屏暴露脱敏 semantic tree：`surfaceId/version/nodeId/role/label/value/state/capabilities/bounds/actionIds`。
+- [INFERRED] AI action 必须引用 `surfaceId + version + nodeId + actionId`；版本不匹配返回 stale reference 并强制重新 inspect。
+- [KNOWN] password/privateKey/token/API key/Env value 的 node 不向模型暴露值；只能暴露 `hasValue` 或受限 human-only action。
+- [INFERRED] Compose 语义与 SwiftUI/UIKit accessibility bridge 同时服务自动化和无障碍，但 AI action 仍经过业务 capability gate，不能把 accessibility action 当授权。
+
+### 4.1 Terminal bridge
+
+- [KNOWN] 完整支持 `terminal_read_v1 / terminal_send_v1 / terminal_wait_v1`；read 来源是 authoritative terminal model/scrollback，不是 OCR。
+- [KNOWN] send 前显示目标 session、文本摘要和 R2 confirmation；输出等待/验证显示匹配位置与 freshness。
+- [KNOWN] 用户手工输入、切 session 或进入 copy mode 后，待确认的 terminal target 重新验证。
+
+### 4.2 RDP/VNC bridge
+
+- [KNOWN] 完整支持 capture/action/verify/cert status/cert decide；captureId 与 surface generation 绑定。
+- [KNOWN] AI 浮窗与 remote live surface 同时可见；操作 marker 显示 click/type/key 目标，用户可以在确认前检查。
+- [KNOWN] orientation、resolution、zoom 或 viewport 改变使旧 captureId 失效；action 后必须取得 after capture 验证。
+
+### 4.3 Files 与业务页面
+
+- [KNOWN] SFTP/Agent 文件、Connection、Proxy、Key metadata、JumpHost、Snippet、Note、ACL、Docker、Workspace 直接调用 Zephyr canonical tool/service；原生页面同步显示结果和 revision。
+- [KNOWN] AI 写文件前创建 snapshot，支持 rollback；Docker mutation、ACL、delete 等显示具体影响，不用统一“允许 AI 操作吗”空洞弹窗。
+
+## 5. Zephyr AI 能力对齐分组
+
+以下全部是 One 的必需能力面，不是可选 roadmap：
+
+| 分组 | Zephyr capability/tool 行为 | One 原生表现 |
+| --- | --- | --- |
+| Discovery | capability search/playbook | 能力搜索、用途/risk/confirmation 说明 |
+| Connection | list/get/create/update/rename/delete/test/open | 底层连接页实时高亮，revision/confirm 与 Zephyr 一致 |
+| Proxy/Key/Jump/Snippet | 完整 metadata lifecycle；secretRef | 原生编辑 sheet；秘密仍 human-only/opaque ref |
+| Terminal | read/send/wait | 浮窗 trace + 底层 terminal live output |
+| Remote desktop | capture/action/verify/cert | live surface + capture/action marker + before/after |
+| Agent/phone files | list/stat/read/write/mkdir/rename/delete | “文件同步”命名；目标 profile 与 readOnly 明示 |
+| Notes | read/write/delete/groups/trash/bulk | 笔记页 live 更新、revision 与回收站行为一致 |
+| SFTP/remote file | list/stat/read/write/snapshot/rollback/chmod | 文件页、diff/影响与 rollback id |
+| Docker | status/ps/images/logs/action/pull/mirrors | Docker 页 live 状态；mutation confirmation |
+| ACL/share | list/put/delete/shared-with-me | capability 与 expiry 明示，不泄漏 secret |
+| Web/browser | search/fetch/navigate/inspect/click/type/scroll/key/wait/close | 外部浏览 session 的原生 preview；不是 App WebView UI |
+| Memory/Env | search/save/list/get/set/delete | metadata/hasValue；R4 Env get 强确认且不持久显示 |
+| Plan | create/update/delete | plan timeline，状态和取消可见 |
+| Workspace/attachment | list/read/write/view | attachment preview、session workspace 与导出 |
+| Subagent | profiles/task/parallel/fleet | task tree、锁冲突、子任务状态/取消 |
+| Sandbox | status/whitelist exec | 隔离状态、命令与输出 trace |
+| UI action | 当前原生界面语义操作 | `NativeSurfaceBridge` versioned node/action |
+
+[KNOWN] AI Provider/模型、协作模式、run profile、permission mode、思考强度、用量、附件、消息编辑/取消、压缩摘要、对话历史、Memory/Skills/Env 入口和 provider sharing 都必须保留；手机用 picker/sheet/overflow 组织，不以顶部放不下为由删除。
+
+- [KNOWN] One 的 AI run 始终请求 Zephyr 主端 runtime；shared Provider API Key、Env secret、Client Token 和 shared resource resolved credential 永不下发。One 只呈现脱敏 stream/trace/confirmation/result。
+- [KNOWN] AI 读取/操作 shared-to-me Note、Connection、File、Docker 等时，每个 tool 调用由主端实时重验 ACL 与 note allowAiRead/Write；shared 内容不进 One conversation mirror、Memory、index 或 attachment cache，规则见 [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)。
+
+## 6. 浮窗导航与返回
+
+- [KNOWN] AI panel 是 overlay state，不向根 `NavigationStack` 推入普通 destination；打开/收起不破坏底层 navigation path。
+- [KNOWN] Android back 顺序：关闭 panel 内 picker/menu/selection → 降一个 detent → 从 peek 收起 AI → 才交给底层 predictive back。每步都由可观察 state 决定，不在 gesture 完成后临时猜。
+- [KNOWN] Android panel 的 detent/back motion 使用 back progress/drag progress 1:1；取消时回到当前 presentation state，完成时收起。不得让系统丑陋的默认跨页动画套在 panel 上。
+- [KNOWN] iOS panel 内进入 conversation detail/settings 时也必须支持 interactive swipe-back；收起 panel 使用 system interactive sheet gesture，不能把左边缘全屏返回手势据为 panel drag。
+- [INFERRED] 用户从底层页右滑/返回时，如果 AI 在 peek 且无 modal state，可先收起 AI 并保留底层页；再次返回才 pop page，防止一次手势造成两个层级变化。
+
+## 7. Motion 与手势
+
+- [KNOWN] AI 浮窗遵循项目 motion skill：响应快、直接操控、可中断、从 presentation state 开始、交接 release velocity、默认临界阻尼、只在物理 flick 中允许轻微 overshoot。
+- [INFERRED] panel drag 每帧直接跟手；释放根据位置 + 速度投影选择 detent，不使用固定 300ms keyframe。
+- [INFERRED] detent 变化不让底层 surface resize；只改变 overlay clipping/position，避免 terminal PTY 和 remote resolution 抖动。
+- [INFERRED] confirmation card 从对应 trace/target anchor 出现；不要从屏幕中央随机放大。
+- [KNOWN] Reduce Motion 下 detent 仍随手势 1:1，程序性开关改为短 fade/snap；live trace 不逐条飞入。
+- [INFERRED] haptic 只用于 detent snap、要求确认、成功/错误；stream token、每个 tool event 不振动。
+
+## 8. 性能与生命周期
+
+- [KNOWN] AI stream、tool trace、terminal output、remote frame 分离状态流；AI token 更新不能让 terminal/RDP/VNC surface 重组或重绘。
+- [INFERRED] chat 使用虚拟化列表；长 tool output 默认 summary，可展开/导出，不一次 layout 全文。
+- [KNOWN] App 后台后按 Zephyr runId 恢复；浮窗隐藏不取消 run，显式 Stop 才取消。
+- [INFERRED] 系统允许时用 live activity/notification 展示等待确认/完成，但通知不能越过敏感确认执行动作。
+- [KNOWN] 旋转、fold、scene resize 后保留 conversation/run/context identity，重新计算 panel geometry；旧 surface/capture reference 作废。
+
+## 9. 测试与发布门
+
+1. [KNOWN] 从服务端真实 catalog 派生测试：每个 model-visible tool 恰有 One bridge 或标记为 server-only external browser，但不能缺失。
+2. [KNOWN] risk、confirmation、playbook 与参数 schema 逐项相同；未知 tool 默认不可执行并提示升级。
+3. [KNOWN] 浮窗打开时底层 connection/terminal/RDP/VNC 可见且继续更新。
+4. [KNOWN] AI 操作的 target、trace、confirmation、result、verification 均可见；旧 reference 必须失败。
+5. [KNOWN] Android panel back chain、custom progress animation、取消/反向；iOS 每个 panel 子层 interactive swipe-back 真机通过。
+6. [KNOWN] TalkBack/VoiceOver 能在 panel 与底层 context 间有序切换；modal confirmation 正确 trap focus，panel 收起后焦点返回 launcher。
+7. [KNOWN] 116-tool 基线只作为当前 fixture；CI 与 Zephyr catalog 动态 diff，新增能力必须先补 One adapter 才允许发版。
+8. [KNOWN] shared Provider/Note/Connection/File canary 经 AI tool 执行后，One DB/Memory mirror/attachment cache/log/trace 中不得出现 Provider Key、Env value、Client Token、resolved credential 或 shared 正文持久副本。
+9. [KNOWN] ACL/allowAiRead/allowAiWrite 在 run 中途撤销时，下一 tool call 立即失败并清当前 shared content page；不能靠 run 开始时授权继续到底。
+
+任一情况下 Zephyr AI 必须打开独立全屏页才能操作、用户看不到目标 surface、One tool catalog 少于同版本 Zephyr、或 UI stream 使 terminal/remote 输入掉帧，均为发布阻断。

--- a/FREEZE/zephyr one for mobile/DATA_AND_MIGRATION.md
+++ b/FREEZE/zephyr one for mobile/DATA_AND_MIGRATION.md
@@ -1,0 +1,398 @@
+# Zephyr One 原生数据、服务端扩展与迁移合同
+
+> [KNOWN] Zephyr 事实源：`storage.js`、`secret-crypto.js`、`session-store.js`、`one-client-manager.js`、`file-agent-manager.js`、`ai-provider-service.js`。
+>
+> [INFERRED] 本文冻结新增表、事务和迁移门；具体 Room/GRDB migration 文件必须与本文逐版本一致。
+
+## 1. 三类数据
+
+| 类别 | 权威位置 | 示例 |
+| --- | --- | --- |
+| 账号镜像 | [INFERRED] Zephyr service + mobile change log；One 是 local-first replica | connection/note/snippet/AI settings/token/workspace |
+| 设备本地 | [KNOWN] One 本机 | SAF URI、security-scoped bookmark、设备密钥、active socket、scroll position |
+| opaque preservation | [INFERRED] 服务端 canonical snapshot/One 原样保存 | 新版本未知字段、customCssJs、无移动用途后台字段 |
+
+[KNOWN] 不可把设备身份私钥、refresh credential、数据库 master key、SID、系统授权句柄同步给其他设备。
+
+## 2. 服务端新增 DDL
+
+```sql
+CREATE TABLE mobile_devices (
+  device_id TEXT PRIMARY KEY,
+  owner_user_id TEXT NOT NULL,
+  owner_username_compat TEXT NOT NULL,
+  token_id TEXT NOT NULL,
+  device_name TEXT NOT NULL,
+  platform TEXT NOT NULL CHECK(platform IN ('android','ios')),
+  app_version TEXT NOT NULL,
+  encryption_public_key BLOB NOT NULL,
+  signing_public_jwk TEXT NOT NULL,
+  refresh_token_hash TEXT,
+  refresh_generation INTEGER NOT NULL DEFAULT 1,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  automatic_enabled INTEGER NOT NULL DEFAULT 1,
+  sync_interval_sec INTEGER NOT NULL DEFAULT 300,
+  registry_hash TEXT NOT NULL,
+  last_acked_cursor INTEGER NOT NULL DEFAULT 0,
+  last_sync_at INTEGER,
+  last_seen_at INTEGER,
+  created_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  revoke_reason TEXT
+);
+CREATE INDEX idx_mobile_devices_owner
+  ON mobile_devices(owner_user_id, created_at DESC);
+CREATE INDEX idx_mobile_devices_token
+  ON mobile_devices(token_id, revoked_at);
+
+CREATE TABLE mobile_entity_versions (
+  owner_user_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  deleted_at INTEGER,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY(owner_user_id, entity_type, entity_id)
+);
+
+CREATE TABLE mobile_entity_field_revisions (
+  owner_user_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  field_path TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  PRIMARY KEY(owner_user_id, entity_type, entity_id, field_path)
+);
+CREATE INDEX idx_mobile_field_revision_entity
+  ON mobile_entity_field_revisions(owner_user_id, entity_type, entity_id, revision);
+
+CREATE TABLE mobile_sync_changes (
+  change_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  owner_user_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  action TEXT NOT NULL CHECK(action IN ('upsert','delete')),
+  revision INTEGER NOT NULL,
+  field_mask_json TEXT NOT NULL DEFAULT '[]',
+  actor_device_id TEXT,
+  changed_at INTEGER NOT NULL,
+  tombstone_json TEXT
+);
+CREATE INDEX idx_mobile_changes_owner_seq
+  ON mobile_sync_changes(owner_user_id, change_seq);
+CREATE INDEX idx_mobile_changes_entity
+  ON mobile_sync_changes(owner_user_id, entity_type, entity_id, revision);
+
+CREATE TABLE mobile_applied_ops (
+  owner_user_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  op_id TEXT NOT NULL,
+  batch_id TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  applied_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  PRIMARY KEY(owner_user_id, device_id, op_id)
+);
+CREATE INDEX idx_mobile_applied_ops_expiry ON mobile_applied_ops(expires_at);
+
+CREATE TABLE mobile_sync_runs (
+  run_id TEXT PRIMARY KEY,
+  owner_user_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  trigger TEXT NOT NULL,
+  state TEXT NOT NULL,
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  from_cursor INTEGER NOT NULL,
+  to_cursor INTEGER,
+  pushed INTEGER NOT NULL DEFAULT 0,
+  pulled INTEGER NOT NULL DEFAULT 0,
+  conflicts INTEGER NOT NULL DEFAULT 0,
+  error_code TEXT,
+  request_id TEXT
+);
+CREATE INDEX idx_mobile_sync_runs_device
+  ON mobile_sync_runs(device_id, started_at DESC);
+
+CREATE TABLE client_tokens (
+  token_id TEXT PRIMARY KEY,
+  owner_user_id TEXT NOT NULL,
+  owner_username_compat TEXT NOT NULL,
+  name TEXT NOT NULL,
+  token_secret_enc TEXT NOT NULL,
+  revision INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  last_used_at INTEGER,
+  deleted_at INTEGER
+);
+CREATE INDEX idx_client_tokens_owner
+  ON client_tokens(owner_user_id, deleted_at, created_at DESC);
+
+CREATE TABLE mobile_sensitive_grants (
+  grant_hash TEXT PRIMARY KEY,
+  owner_user_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  target_hash TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  request_id TEXT NOT NULL
+);
+CREATE INDEX idx_mobile_sensitive_grants_expiry
+  ON mobile_sensitive_grants(expires_at, consumed_at);
+```
+
+- [INFERRED] 所有表由版本化 migration 建立；生产启动逻辑不得继续无限堆叠未编号 `addColumnIfMissing`。
+- [INFERRED] 每次业务 service 写入与 `mobile_entity_versions/field_revisions/sync_changes` 在同一个 SQLite transaction。
+- [INFERRED] `mobile_sync_changes` 不存 secret 明文或完整 secret ciphertext；响应时按目标设备生成 envelope。
+
+## 3. Token 明文 JSON 迁移
+
+### 3.1 输入事实
+
+- [KNOWN] 当前 `data/agent-tokens.json` v2 是 `{version:2,tokens:[{id,ownerId,name,token,...}]}`，`ownerId` 使用 username，token 是明文。
+- [KNOWN] `storage.js` 已有 immutable userId；`secret-crypto.js` 已有 ML-KEM-768 + AES-256-GCM 字段加密。
+
+### 3.2 单次事务
+
+```text
+1 acquire exclusive token migration lock
+2 read and strictly validate agent-tokens.json v2 / legacy map
+3 resolve ownerId username → immutable users.userId
+4 for each token:
+    preserve token_id/name/timestamps
+    encrypt token with AAD clientToken:<tokenId>:token
+    insert client_tokens revision=1
+5 compare counts and decrypt every inserted token in memory
+6 write meta.clientTokensMigratedAt + source sha256
+7 COMMIT
+8 rename source to agent-tokens.pre-sqlite.<timestamp>.json
+9 chmod 0600; do not continue dual-write
+```
+
+- [INFERRED] 任一 owner 无法解析、重复 tokenId、重复 secret 或解密回验失败时整个事务回滚，原 JSON 保持原位。
+- [INFERRED] 迁移后旧 Agent 验证从 SQLite 读取并只在内存构建 hash/index；不得把明文重新写回磁盘。
+- [KNOWN] username 改名后归属继续跟随 userId；`owner_username_compat` 仅用于旧协议展示。
+
+## 4. One 本地 SQLite 逻辑表
+
+[INFERRED] Android Room 和 iOS GRDB 使用相同逻辑 schema；列名可平台化，但 migration fixture 必须映射一致。
+
+```sql
+CREATE TABLE bindings (
+  binding_id TEXT PRIMARY KEY,
+  server_id TEXT NOT NULL,
+  base_url TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  username TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  token_id TEXT NOT NULL,
+  sid_secret_ref TEXT,
+  access_secret_ref TEXT,
+  refresh_secret_ref TEXT,
+  registry_hash TEXT NOT NULL,
+  state TEXT NOT NULL,
+  applied_cursor INTEGER NOT NULL DEFAULT 0,
+  acknowledged_cursor INTEGER NOT NULL DEFAULT 0,
+  bootstrap_id TEXT,
+  bootstrap_page_token TEXT,
+  bootstrap_snapshot_cursor INTEGER,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  automatic_enabled INTEGER NOT NULL DEFAULT 1,
+  interval_sec INTEGER NOT NULL DEFAULT 300,
+  last_attempt_at INTEGER,
+  last_success_at INTEGER,
+  last_error_code TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE(server_id,user_id,device_id)
+);
+
+CREATE TABLE mirror_entities (
+  binding_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  server_revision INTEGER NOT NULL,
+  canonical_json TEXT NOT NULL,
+  opaque_json TEXT NOT NULL DEFAULT '{}',
+  deleted_at INTEGER,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY(binding_id,entity_type,entity_id)
+);
+CREATE INDEX idx_mirror_entities_list
+  ON mirror_entities(binding_id,entity_type,deleted_at,updated_at DESC);
+
+CREATE TABLE pending_operations (
+  binding_id TEXT NOT NULL,
+  op_id TEXT NOT NULL,
+  batch_id TEXT,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  base_revision INTEGER NOT NULL,
+  field_mask_json TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  secret_refs_json TEXT NOT NULL DEFAULT '{}',
+  created_at INTEGER NOT NULL,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error_code TEXT,
+  in_flight_at INTEGER,
+  PRIMARY KEY(binding_id,op_id)
+);
+CREATE INDEX idx_pending_ops_order
+  ON pending_operations(binding_id,created_at);
+
+CREATE TABLE conflicts (
+  binding_id TEXT NOT NULL,
+  conflict_id TEXT PRIMARY KEY,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  op_id TEXT NOT NULL,
+  base_json TEXT,
+  local_json TEXT NOT NULL,
+  server_json TEXT NOT NULL,
+  conflicting_fields_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  resolved_at INTEGER,
+  resolution TEXT
+);
+
+CREATE TABLE secret_records (
+  secret_ref TEXT PRIMARY KEY,
+  binding_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  field_name TEXT NOT NULL,
+  ciphertext BLOB NOT NULL,
+  nonce BLOB NOT NULL,
+  aad BLOB NOT NULL,
+  key_version INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE(binding_id,entity_type,entity_id,field_name)
+);
+
+CREATE TABLE device_grants (
+  grant_id TEXT PRIMARY KEY,
+  binding_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  platform_ref TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  read_only INTEGER NOT NULL,
+  valid INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE blob_transfers (
+  transfer_id TEXT PRIMARY KEY,
+  binding_id TEXT NOT NULL,
+  sha256 TEXT NOT NULL,
+  direction TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  chunk_size INTEGER NOT NULL,
+  completed_chunks_json TEXT NOT NULL,
+  temp_ref TEXT,
+  state TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+```
+
+- [INFERRED] 类型化 feature 表可以从 `mirror_entities.canonical_json` 投影，也可物理拆表；无论选择哪种，canonical revision/opaque/pending 不得出现两个真源。
+- [KNOWN] secret 表不得进入 Android Auto Backup/iCloud device backup；业务 secret 的跨设备恢复只走 mobile envelope。
+
+## 5. SecretStore
+
+### 5.1 Zephyr 现有服务器静态加密
+
+- [KNOWN] `secret-crypto.js` 使用 ML-KEM-768 encapsulation，HKDF-SHA256，AES-256-GCM，12-byte IV，独立 16-byte tag。
+- [KNOWN] 服务器密钥文件默认 `data/crypto/ml-kem-768-keypair.json`，secret key 2400 bytes，public key 1184 bytes；可由环境变量提供。
+- [KNOWN] 这套格式用于服务器静态字段，不直接等于设备传输 envelope。
+
+### 5.2 设备 envelope v1
+
+- [INFERRED] 为复用 Zephyr 已采用的后量子 primitive，设备加密公钥固定为 ML-KEM-768；设备另生成 P-256/ES256 signing key 做 request proof。
+- [INFERRED] `alg = ML-KEM-768+HKDF-SHA256+AES-256-GCM`。
+- [INFERRED] HKDF：
+
+```text
+salt = SHA-256(UTF8("zephyr-mobile-envelope-v1"))
+info = AAD bytes
+length = 32
+```
+
+- [INFERRED] AAD 是以下 UTF-8 字段用单个 NUL `0x00` 连接，数字使用无前导零十进制 ASCII：
+
+```text
+zephyr-mobile-secret-v1
+serverId
+userId
+deviceId
+entityType
+entityId
+fieldName
+entityRevision
+keyVersion
+```
+
+- [INFERRED] JSON 中 `ct/iv/tag/data/aad` 使用标准 Base64（有 padding）；canonical test vector 在 `contracts/test-vectors/sync-v1.json`。
+- [INFERRED] 解密前必须逐字段重建 AAD 并 constant-time 比较 envelope.aad；entityRevision/keyVersion 不匹配则拒绝。
+- [INFERRED] Android：ML-KEM private key 由 Keystore AES-GCM wrapping key 包裹；ES256 signing key 直接不可导出生成在 Keystore。iOS：ML-KEM private key 由 ThisDeviceOnly Keychain wrapping key 包裹；P-256 signing key 优先 Secure Enclave。
+- [INFERRED] rooted/jailbroken 环境只显示风险，不改变服务器 ACL，也不声称绝对防提取。
+
+## 6. Server DB migration 版本
+
+| 版本 | 内容 | 回滚 |
+| --- | --- | --- |
+| `mobile_0001` | [INFERRED] devices、entity versions、field revisions、changes、ops、runs | [INFERRED] 无客户端绑定时可 drop；有数据时只 forward-fix |
+| `mobile_0002` | [INFERRED] client_tokens 加密表 + JSON 导入 | [INFERRED] 可从保留 JSON 恢复，但禁止自动降级双写 |
+| `mobile_0003` | [INFERRED] sensitive grants、refresh generation/proof | [INFERRED] 撤销全部 mobile credential 后 forward-fix |
+| `mobile_0004` | [INFERRED] 各业务 service revision/tombstone/change hooks | [INFERRED] 不可丢 change history；从 DB pre-migration backup 整体回滚 |
+| `mobile_0005` | [INFERRED] AI/Snippet/settings 正规化 | [INFERRED] 保留 legacy JSON 只读镜像一个版本周期 |
+
+- [KNOWN] 每次 migration 必测：空库、当前生产库、重复执行、崩溃中断、回滚/恢复、10k/100k 数据规模。
+- [INFERRED] migration 前执行 WAL checkpoint + 在线备份 API，不直接复制活跃 WAL DB 文件。
+
+## 7. Tauri One → 原生 One
+
+### 7.1 输入
+
+- [KNOWN] 旧 One 使用 Tauri + 本地 Zephyr core；绑定/SID/deviceToken/snapshot 曾进入 localStorage。
+- [KNOWN] 这些 credential 不能原样成为新 device identity。
+
+### 7.2 过渡导出
+
+```json
+{
+  "format": "zephyr-one-native-migration",
+  "version": 1,
+  "sourceAppVersion": "...",
+  "createdAt": 0,
+  "serverProfiles": [],
+  "bindings": [{"baseUrl":"...","username":"...","tokenId":"..."}],
+  "entities": [],
+  "secretEnvelope": "one-time encrypted payload",
+  "hashes": {}
+}
+```
+
+- [INFERRED] SID、deviceToken、设备私钥绝不导出；Client Token 和业务 secret 只进入一次性迁移 envelope。
+- [INFERRED] 原生版导入后必须重新登录/绑定生成新 device keys，再由完整同步校准 revision。
+- [KNOWN] SAF URI/iOS bookmark 必须重新授权。
+- [INFERRED] 成功 marker 写入后迁移不可重复；加密源文件保留一个版本周期，由用户确认删除。
+
+## 8. 备份恢复与 mobile sync 的关系
+
+- [KNOWN] 主端完整备份恢复替换全 DB 和数据密钥，可能让所有 cursor/revision/device/token 回到过去。
+- [INFERRED] 导入成功后服务端递增 `instanceEpoch`，撤销所有 mobile access/refresh，清空 change cursor 可用性，并要求所有 One 重新登录+bootstrap。
+- [INFERRED] One 不允许用导入前 pending op 自动覆盖恢复后的主端；先导出本地未同步变更供用户确认，再重新 bootstrap。
+- [INFERRED] 备份 metadata 进入同步，但备份 archive 本体只有用户显式下载时走 blob，不自动复制到所有设备。
+
+## 9. 数据完整性门
+
+1. [KNOWN] 新业务字段必须分类为 editableSync/opaquePreserve/deviceLocal/serverOnly。
+2. [INFERRED] editable field 必须存在 field revision；secret field 必须有 AAD 和 test vector。
+3. [KNOWN] 列表 payload 不含明文 secret；hasX/masked 语义与 Zephyr 一致。
+4. [INFERRED] token JSON 迁移后磁盘扫描不得发现活动 token 明文。
+5. [INFERRED] DB 导入/迁移/restore 任一失败均恢复旧 DB+key，并能重新打开服务。
+6. [KNOWN] username 改名不改变 owner userId、ACL、device 或 token 归属。
+7. [INFERRED] backup restore 改变 epoch 后旧 cursor/device proof 全部失效。

--- a/FREEZE/zephyr one for mobile/DEVELOPMENT.md
+++ b/FREEZE/zephyr one for mobile/DEVELOPMENT.md
@@ -2,13 +2,13 @@
 
 > 文档状态：产品约束 + Zephyr 继承修订版 v1.2（用户要求优先）
 >
-> 审计基线：仓库 `Lanlan13-14/zephyr-ssh`，提交 `3a61d2f`（2026-08-08）
+> 审计基线：仓库 `Lanlan13-14/zephyr-ssh`，提交 `8dd5b98`（2026-08-08）
 >
 > 目标产品：以 Android Kotlin + Jetpack Compose、iOS Swift + SwiftUI 原生实现 Zephyr One 的移动操作能力；排除无移动用途的账号安全/服务器部署后台，并通过“文件同步”完成 One 有用途账号数据的完整双向同步
 >
 > 产品范围合同：[`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)。该合同约束“必须做什么”，本文约束总体“怎样实现”；范围冲突时合同优先。
 >
-> 细化规范：Zephyr 业务继承见 [`ZEPHYR_PARITY.md`](ZEPHYR_PARITY.md)，逐屏落点见 [`SCREEN_CATALOG.md`](SCREEN_CATALOG.md)，同步顺序见 [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)，DDL/Secret/迁移见 [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)，协议引擎见 [`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)，机器合同见 [`contracts/`](contracts/)。这些细化文件在各自主题内覆盖本文早期概述。
+> 细化规范：Zephyr 业务继承见 [`ZEPHYR_PARITY.md`](ZEPHYR_PARITY.md)，逐屏落点见 [`SCREEN_CATALOG.md`](SCREEN_CATALOG.md)，双平台视觉/返回/动画见 [`MOBILE_EXPERIENCE.md`](MOBILE_EXPERIENCE.md)，SSH/Telnet 手感见 [`TERMINAL_EXPERIENCE.md`](TERMINAL_EXPERIENCE.md)，RDP/VNC 交互见 [`REMOTE_DESKTOP_EXPERIENCE.md`](REMOTE_DESKTOP_EXPERIENCE.md)，Zephyr AI 全能力浮窗见 [`AI_FLOATING_WORKSPACE.md`](AI_FLOATING_WORKSPACE.md)，共享资源零驻留与按次使用见 [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)，同步顺序见 [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)，DDL/Secret/迁移见 [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)，协议引擎见 [`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)，机器合同见 [`contracts/`](contracts/)。这些细化文件在各自主题内覆盖本文早期概述。
 
 ## 0. 标记与置信度
 
@@ -843,7 +843,9 @@ CREATE TABLE mobile_applied_ops (
 - [INFERRED] 设备私钥不可导出时优先不可导出；不支持硬件密钥的设备退化为 Keychain/Keystore 保护的软件密钥并在安全页明确显示。
 - [KNOWN] 完整镜像模式必须同步当前账号自有的连接凭据、SSH Key、代理密码、AI secret 和 Client Token；不能用默认关闭的“只同步 metadata”偷换产品要求。
 - [INFERRED] 可额外提供用户主动选择的“此设备不下载敏感字段”安全模式，但它是明确降级：UI 必须显示该设备不是完整镜像，并且不能改变主端仍保有完整数据的事实。
-- [INFERRED] 共享连接默认不下发 owner secret；如果主端允许 shared user 使用但不 reveal，原生端应通过主端会话代理连接，或明确提示“该共享连接仅可由主端执行”，不能绕过 ACL索取凭据。
+- [KNOWN] shared-to-me 资源全部排除在 mobile mirror/SecretStore/local DB 外；共享 AI、笔记、文件和业务操作每次在线请求主端并实时重验 ACL，细节见 [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)。
+- [KNOWN] 共享连接默认使用主端 relay，owner secret 不下发；若 owner policy 允许原生 direct，主端只可签发一次、短时、绑定 device/session/resource/revision/purpose/nonce 的 encrypted use envelope，One 仅在 native SessionSecretArena 内解密、不持久化并尽力清零。
+- [KNOWN] direct 模式意味着连接材料曾在 One 内存出现，不能宣传“秘密未到设备”；若 owner 要求绝不下发则强制 relay，relay 不可用时拒绝连接。
 - [KNOWN] Client Token envelope 解密后只进入 SecretStore；文件同步导出/恢复必须能恢复 token record 与 secret，确保 Zephyr 与 One 互备。
 
 ## 13. “文件同步”与底层 Zephyr Agent 能力整合
@@ -1289,6 +1291,11 @@ Zephyr 主端                  https://...
 - [KNOWN] 同步状态机：[`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)
 - [KNOWN] DDL、Secret 与迁移：[`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)
 - [KNOWN] 原生协议引擎决策：[`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)
+- [KNOWN] 原生移动视觉、返回和动画：[`MOBILE_EXPERIENCE.md`](MOBILE_EXPERIENCE.md)
+- [KNOWN] SSH/Telnet 终端交互：[`TERMINAL_EXPERIENCE.md`](TERMINAL_EXPERIENCE.md)
+- [KNOWN] RDP/VNC 远程桌面交互：[`REMOTE_DESKTOP_EXPERIENCE.md`](REMOTE_DESKTOP_EXPERIENCE.md)
+- [KNOWN] Zephyr AI 浮窗与能力对齐：[`AI_FLOATING_WORKSPACE.md`](AI_FLOATING_WORKSPACE.md)
+- [KNOWN] 共享资源零驻留与按次使用：[`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)
 - [KNOWN] 需求追踪与实际状态：[`TRACEABILITY.md`](TRACEABILITY.md)、[`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md)
 - [KNOWN] OpenAPI、entity/error registry、JSON Schema 与 vectors：[`contracts/`](contracts/)
 - [KNOWN] 主功能与协议说明：[`../../README.md`](../../README.md)

--- a/FREEZE/zephyr one for mobile/DEVELOPMENT.md
+++ b/FREEZE/zephyr one for mobile/DEVELOPMENT.md
@@ -1,12 +1,14 @@
 # Zephyr Android / iOS 原生 App 完整开发文档
 
-> 文档状态：产品约束修订版 v1.1（用户要求优先）
+> 文档状态：产品约束 + Zephyr 继承修订版 v1.2（用户要求优先）
 >
-> 审计基线：仓库 `Lanlan13-14/zephyr-ssh`，提交 `ae65756`（2026-08-07）
+> 审计基线：仓库 `Lanlan13-14/zephyr-ssh`，提交 `3a61d2f`（2026-08-08）
 >
 > 目标产品：以 Android Kotlin + Jetpack Compose、iOS Swift + SwiftUI 原生实现 Zephyr One 的移动操作能力；排除无移动用途的账号安全/服务器部署后台，并通过“文件同步”完成 One 有用途账号数据的完整双向同步
 >
-> 产品范围合同：[`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)。该合同约束“必须做什么”，本文约束“怎样实现”；范围冲突时合同优先。
+> 产品范围合同：[`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)。该合同约束“必须做什么”，本文约束总体“怎样实现”；范围冲突时合同优先。
+>
+> 细化规范：Zephyr 业务继承见 [`ZEPHYR_PARITY.md`](ZEPHYR_PARITY.md)，逐屏落点见 [`SCREEN_CATALOG.md`](SCREEN_CATALOG.md)，同步顺序见 [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)，DDL/Secret/迁移见 [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)，协议引擎见 [`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)，机器合同见 [`contracts/`](contracts/)。这些细化文件在各自主题内覆盖本文早期概述。
 
 ## 0. 标记与置信度
 
@@ -247,7 +249,7 @@ server/
 1. [INFERRED] **首页**（dashboard）：连接卡片、搜索、协议/标签筛选、最近连接、活动摘要。
 2. [INFERRED] **会话**（document/session）：正在连接、已连接、断线、可恢复的 SSH/Telnet/RDP/VNC 会话。
 3. [INFERRED] **资料**（folder）：笔记、最近文件、代码片段；进入具体 SSH 会话后由终端上下文 dock 的“文件”入口接管 SFTP。
-4. [INFERRED] **工具**（crossed tools）：远程批量执行、AI、文件同步、代理、SSH Key、外观和 One 设置；不出现账号安全、服务器管理或独立 Zephyr Agent入口。
+4. [INFERRED] **工具**（crossed tools）：远程批量执行、AI、文件同步、代理、SSH Key、JumpHost、外观、One 设置，以及“服务器”二级分组中的服务器设置与备份恢复；不出现账号安全、Web部署管理、多用户管理或独立 Zephyr Agent入口。逐屏路径以 [`SCREEN_CATALOG.md`](SCREEN_CATALOG.md) 为准。
 
 [INFERRED] Web 顶栏里的 Activity 合并到首页二级页；AI 是工具入口和页面级 action，不单独挤占第五个导航槽。顶部仍保留原生标题与页面 action，例如搜索、添加、同步状态；浮岛只负责根目的地切换。
 
@@ -512,8 +514,9 @@ ClientTokenRecord
 
 FileSyncConfig
   serverProfileId, enabled, automaticEnabled, intervalSec,
-  lastAttemptAt, lastSuccessAt, lastCursor, lastError,
-  conflictCount, updatedAt
+  bindingState, registryHash, bootstrapId, bootstrapPageToken,
+  lastAttemptAt, lastSuccessAt, appliedCursor, acknowledgedCursor,
+  pendingCount, lastError, conflictCount, rerunRequested, updatedAt
 
 FileSyncShareProfile
   id, serverProfileId, displayName, localGrantRef,
@@ -834,19 +837,7 @@ CREATE TABLE mobile_applied_ops (
 
 ## 12. Secret 同步
 
-[INFERRED] TLS 是最低要求，但绑定后的 deviceToken 泄漏不应直接暴露所有连接密码。服务端向设备返回 secret 时，使用绑定公钥派生会话密钥并生成 AES-256-GCM envelope。
-
-```json
-{
-  "alg": "ECDH-P256-HKDF-SHA256+A256GCM",
-  "ephemeralPublicKey": { "kty": "EC", "crv": "P-256", "x": "...", "y": "..." },
-  "salt": "...",
-  "nonce": "...",
-  "ciphertext": "...",
-  "aad": "server/user/connection/id/password",
-  "keyVersion": 1
-}
-```
+[INFERRED] TLS 是最低要求，但绑定后的 access credential 泄漏不应直接暴露所有连接密码。为继承 Zephyr `secret-crypto.js` 已采用的 ML-KEM-768 方向，正式设备 envelope 使用 `ML-KEM-768+HKDF-SHA256+AES-256-GCM`；设备另持有 ES256 signing key 证明请求来源。JSON Schema、AAD 的 NUL 分隔字节、Base64、tag、keyVersion、entityRevision 与跨端测试向量以 [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md) 和 [`contracts/schemas/secret-envelope.schema.json`](contracts/schemas/secret-envelope.schema.json) 为唯一细节真源，禁止 Android/iOS各自解释一版。
 
 - [INFERRED] 服务端生成 envelope 时可短暂接触明文，因为现有 Web 主端本来就需要解密凭据建立会话；明文不得进入 change log、日志或缓存。
 - [INFERRED] 设备私钥不可导出时优先不可导出；不支持硬件密钥的设备退化为 Keychain/Keystore 保护的软件密钥并在安全页明确显示。
@@ -1082,7 +1073,7 @@ Zephyr 主端                  https://...
 - [KNOWN] App 前台启动、绑定完成、用户点“立即同步”、自动间隔到期、网络恢复、本地写入 debounce、主端 wake event 时触发同步。
 - [INFERRED] 手动同步不受自动同步总开关影响：只要设备仍绑定，用户始终可点“立即同步”；完全解绑后才禁用。
 - [INFERRED] 同一账号同一时刻只运行一个 sync actor；新触发合并为 rerun flag，不并发修改 cursor。用户连续点击只产生一次当前任务 + 最多一次尾随任务。
-- [INFERRED] 每轮顺序固定为：验证绑定/registry → push 本地 pending ops → pull changes 到最新 → 处理 blob → ack cursor → 更新状态。首次绑定使用 bootstrap。
+- [INFERRED] 普通轮顺序固定为：验证绑定/registry → push 本地 pending ops → pull changes 到最新 → 处理 blob → ack cursor → 更新状态。首次绑定固定为 bootstrap → catch-up pull → push bootstrap期间 pending ops → pull → blob → ack；事务、崩溃恢复和 cursor 不变量以 [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md) 为准。
 
 ### 17.3 平台后台行为
 
@@ -1293,6 +1284,13 @@ Zephyr 主端                  https://...
 ## 26. 当前仓库对应代码索引
 
 - [KNOWN] 用户确认的移动端产品范围合同：[`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)
+- [KNOWN] Zephyr 业务继承规范：[`ZEPHYR_PARITY.md`](ZEPHYR_PARITY.md)
+- [KNOWN] 原生逐屏规格：[`SCREEN_CATALOG.md`](SCREEN_CATALOG.md)
+- [KNOWN] 同步状态机：[`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)
+- [KNOWN] DDL、Secret 与迁移：[`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)
+- [KNOWN] 原生协议引擎决策：[`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)
+- [KNOWN] 需求追踪与实际状态：[`TRACEABILITY.md`](TRACEABILITY.md)、[`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md)
+- [KNOWN] OpenAPI、entity/error registry、JSON Schema 与 vectors：[`contracts/`](contracts/)
 - [KNOWN] 主功能与协议说明：[`../../README.md`](../../README.md)
 - [KNOWN] 现有 One 设备绑定与 pull：[`../../one-client-manager.js`](../../one-client-manager.js)
 - [KNOWN] 现有 One pull-only engine：[`../../zephyr_one/src/js/sync/sync-engine.js`](../../zephyr_one/src/js/sync/sync-engine.js)

--- a/FREEZE/zephyr one for mobile/IMPLEMENTATION_STATUS.md
+++ b/FREEZE/zephyr one for mobile/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Zephyr One 原生实现状态
 
-> [KNOWN] 基线：`main@3a61d2f`，2026-08-08。
+> [KNOWN] 基线：`main@8dd5b98`，2026-08-08。
 >
 > [KNOWN] 本文件只报告仓库实际存在的代码与合同，不把设计文档当实现。
 
@@ -41,7 +41,7 @@
 | F-007 | ACL/share | `implemented-zephyr` | `missing` | [KNOWN] 原生 capability UI 未实现 |
 | F-008 | SSH/SFTP | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 SSH engine 未定 |
 | F-009 | Telnet | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 parser/transport 未实现 |
-| F-010 | RDP | `implemented-zephyr` | `legacy-one` | [KNOWN] 当前 Web/WASM；原生 core 未进仓库 |
+| F-010 | RDP | `implemented-zephyr` | `partial-desktop-native` | [KNOWN] `main@8dd5b98` 已把桌面 One 的 WASM 管线换成原生 FreeRDP（`zephyr_one/native/zephyr-one-rdp/` C shim + Rust FFI + e2e）；该实现面向 Tauri 桌面壳，Android Surface / iOS UIView 绑定仍缺失 |
 | F-011 | VNC | `implemented-zephyr` | `legacy-one` | [KNOWN] 当前 noVNC；原生 RFB core 未定 |
 | F-012 | 终端 IME | `implemented-zephyr` | `specified` | [KNOWN] Web 行为合同已有；原生 SurfaceController 未实现 |
 | F-013 | 笔记 | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生列表/编辑/冲突未实现 |
@@ -62,6 +62,16 @@
 | F-028 | 系统 App Lock | `partial` | `legacy-one` | [KNOWN] Tauri hook 非正式 BiometricPrompt/LA 实现 |
 | F-029 | 四色原生图标 | `specified` | `partial` | [KNOWN] SVG/manifest 有；production path/adaptive/alternate assets 未生成 |
 | F-030 | Tauri → native migration | `specified` | `missing` | [KNOWN] migration artifact/exporter/importer 未实现 |
+| F-031 | Android progress-driven 自定义返回 | `specified` | `missing` | [KNOWN] Compose navigation/animation 代码不存在 |
+| F-032 | iOS 全 push interactive 右滑 | `specified` | `missing` | [KNOWN] SwiftUI/UIKit navigation 代码不存在 |
+| F-033 | Termux/SwiftTerm 级终端交互 | `specified` | `missing` | [KNOWN] 两端 M0 引擎和 UI 尚未实现 |
+| F-034 | RDP/VNC 完整移动交互 | `specified` | `blocked` | [KNOWN] 桌面已有 FreeRDP C shim 可复用为 core 参考，但移动 Surface/UIView 绑定、direct/trackpad 手势与真机验证仍未做；VNC RFB core 仍未选定 |
+| F-035 | Zephyr AI 全能力浮窗 | `specified` | `missing` | [KNOWN] 116-tool baseline 已有；原生浮窗和 NativeSurfaceBridge 不存在 |
+| F-036 | Shared-to-me 零驻留在线 API | `specified` | `missing` | [KNOWN] 当前 mobile shared endpoints 不存在 |
+| F-037 | Shared direct use envelope | `specified` | `missing` | [KNOWN] session-bound envelope/AAD/vector/arena 未实现 |
+| F-038 | Shared strict relay | `specified` | `partial` | [KNOWN] Zephyr 有现有 session/proxy 部件；mobile relay 合同未实现 |
+| F-039 | Shared AI 主端执行零泄漏 | `specified` | `partial` | [KNOWN] AI runtime 在主端；One residency/stream client 未实现 |
+| F-040 | Shared Note 在线内存 viewer | `specified` | `missing` | [KNOWN] NotesService ACL 已有；原生 no-store viewer 未实现 |
 
 ## 当前可复用测试资产
 

--- a/FREEZE/zephyr one for mobile/IMPLEMENTATION_STATUS.md
+++ b/FREEZE/zephyr one for mobile/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,93 @@
+# Zephyr One 原生实现状态
+
+> [KNOWN] 基线：`main@3a61d2f`，2026-08-08。
+>
+> [KNOWN] 本文件只报告仓库实际存在的代码与合同，不把设计文档当实现。
+
+## 状态枚举
+
+- `implemented-zephyr`：Zephyr Web/server 已有并有代码。
+- `legacy-one`：旧 Tauri One 已有，不能当 Kotlin/Swift 原生完成。
+- `specified`：本目录已写可执行合同，但生产代码未实现。
+- `partial`：有部分 server/legacy 实现，缺完整合同目标。
+- `blocked`：前置模型/依赖未冻结或现有实现必须迁移。
+- `missing`：没有实现也没有足够合同。
+
+## 总览
+
+| 层 | 状态 | 证据/缺口 |
+| --- | --- | --- |
+| 产品合同 | `specified` | [KNOWN] `PRODUCT_REQUIREMENTS.md` |
+| Zephyr 继承规则 | `specified` | [KNOWN] `ZEPHYR_PARITY.md` |
+| machine contracts | `specified` | [KNOWN] `contracts/openapi-mobile-v1.json`、schemas、registries、vectors |
+| Android Kotlin/Compose | `missing` | [KNOWN] 仓库没有 `mobile/android` 或 Kotlin 原生 App |
+| iOS Swift/SwiftUI | `missing` | [KNOWN] 仓库没有 `mobile/ios` 或 Swift 原生 App |
+| mobile v1 server API | `missing` | [KNOWN] 当前没有 `/api/mobile/v1/*` 路由 |
+| Tauri One | `legacy-one` | [KNOWN] `zephyr_one/` 存在，pull-only/localStorage/内嵌 core |
+| Zephyr business services | `implemented-zephyr` | [KNOWN] resource/notes/authz/settings/workspace/AI 等 service |
+| 完整双向同步 | `specified` | [KNOWN] 当前仅 `/api/one/sync/pull`；新状态机未实现 |
+| 原生协议 engines | `blocked` | [KNOWN] Kotlin/iOS SSH/RDP/VNC 依赖 ADR 未完成 |
+
+## 功能状态
+
+| ID | 功能 | Zephyr 现状 | 原生 One 现状 | 阻断 |
+| --- | --- | --- | --- | --- |
+| F-001 | 账号登录/TOTP | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生状态机未实现；现有 API 已支持返回 SID |
+| F-002 | Client Token 前置绑定 | `partial` | `legacy-one` | [KNOWN] 当前 OneClientManager 可绑定；缺 device keys/refresh/proof |
+| F-003 | Device registry | `partial` | `legacy-one` | [KNOWN] `one_clients` 表存在；缺 mobile v1 字段和 tombstone |
+| F-004 | 完整双向同步 | `missing` | `missing` | [KNOWN] 当前 pull-only |
+| F-005 | Secret envelope | `partial` | `missing` | [KNOWN] server at-rest ML-KEM 已有；device envelope 未实现 |
+| F-006 | Connection CRUD | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 UI/本地镜像未实现 |
+| F-007 | ACL/share | `implemented-zephyr` | `missing` | [KNOWN] 原生 capability UI 未实现 |
+| F-008 | SSH/SFTP | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 SSH engine 未定 |
+| F-009 | Telnet | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 parser/transport 未实现 |
+| F-010 | RDP | `implemented-zephyr` | `legacy-one` | [KNOWN] 当前 Web/WASM；原生 core 未进仓库 |
+| F-011 | VNC | `implemented-zephyr` | `legacy-one` | [KNOWN] 当前 noVNC；原生 RFB core 未定 |
+| F-012 | 终端 IME | `implemented-zephyr` | `specified` | [KNOWN] Web 行为合同已有；原生 SurfaceController 未实现 |
+| F-013 | 笔记 | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生列表/编辑/冲突未实现 |
+| F-014 | Snippet | `implemented-zephyr` | `legacy-one` | [KNOWN] 当前塞在 user_settings 数组，需实体正规化 |
+| F-015 | AI | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 AI UI 未实现；conversation schema 未冻结 |
+| F-016 | Docker/监控/日志 | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生 remote panels 未实现 |
+| F-017 | 批量执行 | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生逐机结果 UI 未实现 |
+| F-018 | Proxy/SSH Key/JumpHost | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生管理页未实现 |
+| F-019 | 工作区恢复 | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生移动 state adapter 未实现 |
+| F-020 | Deep Link | `implemented-zephyr` | `legacy-one` | [KNOWN] App/Universal Link wiring 未实现 |
+| F-021 | 活动 | `implemented-zephyr` | `legacy-one` | [KNOWN] append-only change hook/原生页未实现 |
+| F-022 | 服务器设置 | `implemented-zephyr` | `legacy-one` | [KNOWN] 原生有用途 section 未实现 |
+| F-023 | 备份恢复 | `implemented-zephyr` | `legacy-one` | [KNOWN] Web/旧 One E2E 已有；原生 document flow 未实现 |
+| F-024 | Client Token 完整互备 | `partial` | `missing` | [KNOWN] 当前 JSON 明文且 sync 只给 metadata |
+| F-025 | ZFT2 文件桥接 | `implemented-zephyr` | `legacy-one` | [KNOWN] JS/Dart 已有；Kotlin/Swift 未实现 |
+| F-026 | Android SAF foreground bridge | `missing` | `missing` | [KNOWN] 原生项目不存在 |
+| F-027 | iOS security-scoped bridge | `missing` | `missing` | [KNOWN] 原生项目不存在 |
+| F-028 | 系统 App Lock | `partial` | `legacy-one` | [KNOWN] Tauri hook 非正式 BiometricPrompt/LA 实现 |
+| F-029 | 四色原生图标 | `specified` | `partial` | [KNOWN] SVG/manifest 有；production path/adaptive/alternate assets 未生成 |
+| F-030 | Tauri → native migration | `specified` | `missing` | [KNOWN] migration artifact/exporter/importer 未实现 |
+
+## 当前可复用测试资产
+
+- [KNOWN] 241 个 Node `*.test.mjs` 文件覆盖 Zephyr 多个业务面。
+- [KNOWN] `authz.test.mjs`：owner/admin/ACL/expiry/revoke/防枚举。
+- [KNOWN] `auth-hardening.test.mjs`：锁定、reset token、TOTP exhaustion。
+- [KNOWN] `notes-deeplink.test.mjs`：Note revision/soft-delete、Deep Link、Workspace ACL。
+- [KNOWN] `one-client-manager.test.mjs`：Token 前置、撤销、interval clamp。
+- [KNOWN] `zephyr-one-backup-restore.test.mjs`：真实导出、错误密码、正确导入。
+- [KNOWN] `zephyr_one/tests/zft2-protocol.test.mjs`：ZFT2 round-trip/flags/bad magic/length mismatch。
+- [KNOWN] Telnet/SSH/RDP/mobile IME 有现成回归测试，可改造成跨端 fixture。
+
+## 开工顺序
+
+1. [INFERRED] 先实现 server `mobile_0001…0005` 与 machine contract validator。
+2. [INFERRED] 迁移 Client Token 明文 JSON，补全 change hooks/tombstones。
+3. [INFERRED] 建 Android/iOS 原生项目和共享 fixture runner。
+4. [INFERRED] M0 冻结 SSH/RDP/VNC/terminal engine ADR 并跑真机 spike。
+5. [INFERRED] 本地 DB/SecretStore/绑定/bootstrap。
+6. [INFERRED] Connection/Note/Settings/Token 首批完整 sync，再扩展 registry 每个实体。
+7. [INFERRED] 会话协议和文件桥接。
+8. [INFERRED] 其余页面、迁移、商店发布门。
+
+## 禁止状态漂移
+
+- [KNOWN] 新提交改变本表任一状态时，必须附代码路径和测试路径；不能只改为“完成”。
+- [KNOWN] `implemented-zephyr` 不等于 `implemented-one`。
+- [KNOWN] `specified` 不等于生产可用。
+- [KNOWN] 任一 `blocked/missing` 的产品必需功能存在时，不得发布“Zephyr One 完整实现”。

--- a/FREEZE/zephyr one for mobile/MOBILE_EXPERIENCE.md
+++ b/FREEZE/zephyr one for mobile/MOBILE_EXPERIENCE.md
@@ -1,0 +1,192 @@
+# Zephyr One 移动原生体验与视觉系统
+
+> [KNOWN] 产品定位：Zephyr One 不是“能连 SSH 的 Zephyr Lite”，而是 Zephyr 的 Android/iOS 原生客户端。除 [`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md) 明确排除的 Web 部署/账号管理面外，功能必须与 Zephyr 对齐；移动端重构是为了获得更好的交互，不是删功能。
+>
+> [INFERRED] 本文冻结视觉、交互和动画原则；具体业务字段仍以 Zephyr service、entity registry 和 screen catalog 为准。
+
+## 1. 设计目标
+
+1. [KNOWN] **能力完整**：所有有移动用途的 Zephyr 能力都有原生入口、完整状态、真实服务和测试，不用“手机不适合”当删功能理由。
+2. [KNOWN] **平台原生**：iOS 与 Android 共用 Zephyr 品牌和信息架构，但分别遵守平台导航、返回、sheet、菜单、字体、安全区、触觉和系统控件习惯。
+3. [INFERRED] **内容优先**：连接、终端、远程桌面、文件和正文占主屏；chrome 在需要时出现，不把桌面 Web 顶栏/侧栏压缩进手机。
+4. [INFERRED] **直接操控**：拖动、缩放、远程指针、sheet、返回和浮岛 selection 都实时跟手；动画只解释状态变化，不延迟操作。
+5. [KNOWN] **协议与 UI 解耦**：Termux/FreeRDP/VNC 候选提供行为和协议核心参考，不决定 Zephyr One 的视觉层级、导航和数据权限。
+6. [INFERRED] **渐进披露而非功能隐藏**：常用项在首层，复杂设置按 section/sheet/搜索展开；被折叠不等于被删除。
+
+## 2. 一个品牌，两套平台语法
+
+### 2.1 共享 Zephyr 品牌
+
+- [KNOWN] Frost/Lava/Asagi/Cyber 四套色板、图标几何、品牌 mark 和连接协议语义共享。
+- [INFERRED] 共享 design tokens：颜色语义、spacing/radius 层级、状态图标、协议色、mono 字体用途、motion 语义名称。
+- [INFERRED] 不共享硬编码像素布局；Android 使用 dp/sp，iOS 使用 pt/Dynamic Type。
+- [INFERRED] 品牌色只用于 selection、primary action、协议状态和少量高价值 emphasis，不把整屏染成主题色。
+
+### 2.2 iOS 表现
+
+- [KNOWN] 所有 push 进入的二级及更深页面必须支持从左边缘开始的 interactive swipe-back；手势 1:1 驱动当前页和上一页，支持中途取消。没有“只有点左上角才能返回”的普通页面。
+- [KNOWN] 优先使用 `NavigationStack`/UIKit 原生 interactive pop；不得通过隐藏系统 back button、错误替换 navigation delegate、全屏 horizontal drag 或透明 overlay 意外关闭 `interactivePopGestureRecognizer`。
+- [KNOWN] 需要自定义 Zephyr 转场时使用可交互 transition/`UIViewPropertyAnimator` 并与 percent-driven progress 对接；视觉可定制，但 edge arbitration、取消、速度延续和 accessibility escape 保留系统语义。
+- [KNOWN] 横向 pager、terminal selection、RDP/VNC direct touch、AI panel drag 不得吞掉 iOS 左边缘返回：边缘保留优先级；远程指针从安全内缩区开始，必须碰边时提供明确 pointer-lock/返回处理。
+- [KNOWN] 根页面、modal/sheet 和 destructive confirmation 不伪装成 push：根页无 pop；sheet 用 interactive dismiss；有脏数据时显示确认但不永久禁用后续右滑。
+- [INFERRED] `NavigationSplitView` 在 iPad collapse 后同样保留 compact column 的 interactive pop；外接键盘 `⌘[`/Escape 与右滑结果一致。
+- [INFERRED] 表单采用 grouped/list section；紧凑选择使用 `Menu`/popover，复杂编辑与确认使用 system sheet/full-screen cover。
+- [INFERRED] sheet 使用系统 detent、interactive dismiss 和键盘避让；有未保存数据时拦截 dismiss 并说明。
+- [INFERRED] 触觉使用 `UISelectionFeedbackGenerator`/`UIImpactFeedbackGenerator`/`UINotificationFeedbackGenerator`，只在 selection 改变、snap、成功和错误时触发。
+- [INFERRED] 字体优先 SF Pro/SF Mono 与 Dynamic Type；不得固定字号导致最大无障碍字体截断。
+- [INFERRED] iPad 使用 `NavigationSplitView`、多栏资料/设置和可选外接键盘命令；不把手机浮岛拉成横跨整屏长条。
+
+### 2.3 Android 表现
+
+- [KNOWN] 使用 AndroidX/Compose 的返回事件和 `PredictiveBackHandler` progress，但不采用效果差、与 Zephyr One 空间层级不一致的默认应用内 predictive-back 视觉；应用内 push/pop、浮窗、sheet 由 One 实现自己的 progress-driven 返回动画。
+- [KNOWN] 自定义的是返回**视觉和空间映射**，不是私造返回协议：系统 back progress 是唯一手势真源，必须支持 commit/cancel、3-button back、hardware Escape/back 和 accessibility action；返回业务逻辑不绑在动画完成回调上。
+- [KNOWN] 返回动画 1:1 跟随 progress，从当前 presentation state 开始；取消回弹到原位，commit 延续当前速度完成。底层 destination 从手势开始就可见，不能在松手后才截屏/创建。
+- [INFERRED] push/pop 使用水平 shared-axis：当前页最多移动约 28% 宽度并轻微降 elevation/opacity，底层页从小幅反向 offset 到 0；不整页 scale、不橡皮筋、不夸张 parallax。RTL 方向自动镜像。
+- [KNOWN] 根 Activity 返回系统主页/跨任务时交还系统动画；One 不覆盖系统级 home/task transition。自定义只管 App 内 navigation、AI overlay 和自有 sheet。
+- [INFERRED] 表单脏状态、selection mode、AI overlay 与普通 navigation 使用单一职责 callback stack；一次手势只改变一个层级。
+- [INFERRED] floating island 保留 Zephyr 品牌，但 touch target、ripple/press state、system bars 与 Android edge-to-edge 规则一致。
+- [INFERRED] 触觉通过 platform haptic APIs；不用自制固定震动替代系统语义。
+- [INFERRED] 字体跟随用户 fontScale；终端字号单独可调，但普通 UI 不绕过系统字号。
+- [INFERRED] Android 平板/折叠屏使用 window size class：compact 单列、medium 双栏、expanded 导航/内容/详情；配置变化不丢会话。
+
+### 2.4 不能为了“统一”做的事
+
+- [KNOWN] 不在 iOS 模仿 Android 返回键/ripple，不在 Android 模仿 iOS 全局 edge swipe。
+- [INFERRED] 不强制两个平台 sheet 的 detent、context menu、toolbar placement 和 destructive confirmation 像素相同。
+- [KNOWN] 不自绘系统键盘、文件选择器、生物识别、权限弹窗或分享面板。
+- [INFERRED] 不把玻璃模糊当品牌本身；材质只表示浮层层级，性能/对比度不允许时退为高不透明 tonal surface。
+
+## 3. 响应式信息架构
+
+| 宽度/场景 | 布局 |
+| --- | --- |
+| compact phone portrait | [KNOWN] 四入口浮岛 + 单层内容；详情 push/full screen |
+| phone landscape | [INFERRED] 缩短 chrome；终端/RDP/VNC 进入 edge-to-edge；非沉浸页仍可双栏 |
+| foldable half-open | [INFERRED] 避开 hinge；列表/详情分置两区，不跨折痕放主操作 |
+| iPad/Android tablet | [INFERRED] NavigationSplitView/自适应三栏；浮岛最大宽固定 |
+| hardware keyboard/mouse | [KNOWN] keyboard shortcuts、hover/secondary click、wheel、pointer capture；不只支持触屏 |
+| IME open | [KNOWN] 根浮岛与 session dock 隐藏；terminal shortcuts 贴 IME；viewport resize |
+
+[INFERRED] 页面复杂度通过二级导航、搜索、section collapse 和 contextual actions 消化；不得为维持“四入口”而删服务器设置、备份恢复、AI 或 Client Token。
+
+## 4. 视觉语言
+
+### 4.1 Surfaces
+
+- [INFERRED] 背景、content surface、elevated card、floating chrome、modal scrim 五级；每级有明确用途，不叠无意义卡片。
+- [INFERRED] 列表优先使用分组和间距，不给每一行套阴影卡片。
+- [INFERRED] 浮岛、session dock 和 selection toolbar 才使用 floating surface；普通 top bar 不做第二层玻璃。
+- [INFERRED] terminal/RDP/VNC 是沉浸式工作面，chrome 默认最少，点击/边缘手势呼出。
+
+### 4.2 Typography
+
+- [INFERRED] 页面标题、section title、body、caption、mono data 五级；主机、端口、fingerprint、命令、路径使用 mono，不把普通正文全设 mono。
+- [INFERRED] 数字状态使用 tabular figures，防止延迟/FPS/进度变化时跳动。
+- [INFERRED] 终端字体必须支持清晰区分 `0/O`、`1/l/I`、常用 Nerd Font glyph fallback 和 CJK；fallback 不得改变 cell width。
+
+### 4.3 Color and status
+
+- [KNOWN] protocol color 是辅助识别，不替代协议文字/图标。
+- [INFERRED] 成功/警告/错误/离线/待同步/冲突有独立语义色并满足对比度；状态不可只靠红绿。
+- [INFERRED] terminal ANSI palette 与 App chrome 主题分离；切 App 主题不得重写服务器输出颜色。
+- [INFERRED] RDP/VNC framebuffer 不受 App 色彩滤镜影响。
+
+## 5. Motion 原则
+
+### 5.1 何时动画
+
+- [INFERRED] 动画只服务于：来源→目标空间关系、状态连续性、层级变化、手势跟随、完成/错误反馈。
+- [INFERRED] 数据 refresh、终端输出、远程 framebuffer、日志 tail 不做装饰动画；优先降低 latency。
+- [INFERRED] destructive action 不用俏皮 bounce；错误可轻微 haptic/颜色反馈，不摇晃整屏。
+
+### 5.2 原生能力
+
+- [KNOWN] Android gesture-driven motion 使用 Compose `Animatable` + `snapTo/animateTo`；导航使用 Compose enter/exit transition，系统返回使用 predictive-back progress。
+- [KNOWN] iOS 使用 SwiftUI transaction/spring 和系统 navigation/sheet；需要可交互中断或 UIKit surface 时使用 `UIViewPropertyAnimator`，它支持动态修改动画。
+- [INFERRED] keyboard、popover、context menu、haptic、iOS sheet/navigation 等系统已提供且体验合格的 transition 不重复实现；Android 应用内 predictive-back 视觉按 §2.3 自定义，但仍使用系统 progress/commit/cancel。
+- [INFERRED] 动画从当前 presentation value 开始，允许中途反向；用户点击后的业务动作不等待动画完成。
+
+### 5.3 House motion
+
+| 场景 | 规则 |
+| --- | --- |
+| press | [INFERRED] 0–100ms 内反馈；scale 0.97–0.99，仅卡片/浮岛项，不缩整页 |
+| floating island selection | [INFERRED] critical damping、无 overshoot、可重定向；标签短 crossfade |
+| sheet | [INFERRED] 跟随系统；自定义 drag 1:1，释放速度交给 spring |
+| list insert/delete | [INFERRED] subtle placement/opacity；批量变更不同时飞入数十行 |
+| sync state | [INFERRED] phase icon/content transition；进度连续，不循环炫技 |
+| terminal/RDP toolbar | [INFERRED] 120–180ms fade/offset；出现不挤压 viewport |
+| remote pointer | [KNOWN] 不做补间追帧；按协议位置立即更新，避免视觉延迟 |
+
+### 5.4 Reduced motion 与节能
+
+- [KNOWN] iOS Reduce Motion / Android animator duration scale 和 accessibility 状态必须被尊重。
+- [INFERRED] Reduced Motion 下取消位移 spring、parallax、shared-axis，改为短 crossfade/即时切换；gesture 仍 1:1 跟手。
+- [INFERRED] 低电量/热限制下停掉无限装饰动画，不降低 terminal/RDP/VNC 输入优先级。
+- [INFERRED] 动画期间不得阻塞 semantics tree、点击命中或后退。
+
+## 6. 移动端功能重构方法
+
+| Zephyr Web 模式 | One 原生转换 | 不允许 |
+| --- | --- | --- |
+| 顶栏 + 左侧 tab | [INFERRED] 四根入口 + stack/split detail | 缩成汉堡菜单后丢入口 |
+| 大型 modal 表单 | [INFERRED] 分 section sheet/full screen editor | 一屏塞全部字段 |
+| hover action | [INFERRED] swipe/context menu/toolbar + 可发现主操作 | 只有长按才能找到关键功能 |
+| 多终端网格 | [INFERRED] 手机 session switcher；平板 split | 手机上缩成四个不可读小窗 |
+| 桌面右键 | [INFERRED] context menu/secondary click/long press | 只做触屏而不支持鼠标 |
+| 文件拖放 | [INFERRED] share sheet/document picker/drop on tablet | 自制文件浏览权限绕过系统 |
+| dense settings | [INFERRED] 搜索 + section + role/capability gate | 以“太复杂”为由删除 |
+| toast-only error | [KNOWN] inline state + retry + requestId diagnostics | 模糊“失败”toast |
+
+## 7. 体验性能门
+
+- [INFERRED] 触摸/按键视觉反馈必须在下一帧出现；不因等待网络冻结。
+- [INFERRED] 60Hz 设备交互帧预算 16.7ms，120Hz 设备 8.3ms；remote decode/render 与 UI chrome 分线程/队列。
+- [INFERRED] terminal 输入到本地 glyph commit p95 ≤ 50ms；CJK composition 不重复提交。
+- [INFERRED] RDP/VNC 手势只更新 transform/pointer，网络发送合并但最后位置不丢；UI thread 不做像素格式转换。
+- [INFERRED] 长列表 2,000 connection、10,000 sync entity、100,000 行 scrollback 不一次性 compose/render。
+- [INFERRED] 动画性能测试用系统 profiler、jank stats 和 XCTest metrics；“看起来顺”不是验收证据。
+
+## 8. 无障碍
+
+- [COMMON] Android touch target 至少 48dp；iOS 至少 44pt。
+- [KNOWN] TalkBack/VoiceOver 要能读出 connection、protocol、status、selected、conflict 和 action；终端 accessibility 需单独 spike，不能仅暴露一个黑色画布。
+- [INFERRED] 外接键盘可以完成根导航、搜索、切会话、终端快捷键、关闭 sheet 和确认；焦点不被动画丢失。
+- [INFERRED] context dock/extra keys 报告 modifier latched/locked 状态，不只变颜色。
+- [INFERRED] 远程桌面提供“触控板模式”给精细操作；direct touch 不是唯一模式。
+
+## 9. 体验验收矩阵
+
+每个核心 flow 必须在以下组合验证：
+
+```text
+Android compact / tablet / foldable
+Android gesture nav / 3-button nav
+Android Gboard / Samsung / hardware keyboard / mouse
+
+iPhone compact / large / landscape
+iPad split view / Stage Manager / hardware keyboard / trackpad
+
+light / dark / Frost / Lava / Asagi / Cyber
+normal / largest font
+Reduce Motion / screen reader
+online / high latency / packet loss / offline
+```
+
+[KNOWN] 只有静态截图通过不能验收交互；必须有 gesture trace、IME、动画中断、旋转/resize、后台恢复和真机录屏证据。
+
+### 9.1 返回专项验收
+
+- [KNOWN] Android：0/25/50/75/100% back progress 几何采样；commit、cancel、反向、快速连做、3-button、hardware back、RTL、60/120Hz；一次手势只 pop 一层。
+- [KNOWN] Android：根页交还系统 home/task；AI expanded→half→peek→closed→page pop 的层级顺序逐步验证。
+- [KNOWN] iOS：每个 push route 自动遍历 edge swipe 30% cancel 与 70% commit；自定义 back button、scroll view、pager、map/remote surface、AI overlay、RTL、Reduce Motion 均测试。
+- [KNOWN] iOS：测试不能只调用 `dismiss/pop`；XCUITest/真机必须从物理左边缘拖动并验证上一页在手势期间可见。
+- [INFERRED] frame/jank 证据中不得出现返回首帧空白、底层页晚创建、手势取消跳变或完成后重复 pop。
+
+## 10. 发布硬门：不是阉割版
+
+- [KNOWN] 需求矩阵中 Zephyr 有移动用途的能力必须全部为 Android implemented + iOS implemented + server compatible + automated test + 真机验收。
+- [KNOWN] 可以改变布局、入口、交互和平台表现；不能降低字段、协议、ACL、同步、错误处理或操作能力。
+- [KNOWN] 平台不允许完全等价后台行为时，必须提供前台实现、系统调度和明确状态，不得直接删除功能。
+- [KNOWN] 成熟协议库只能减少重复造协议轮子，不能成为删 Zephyr feature、复用旧 UI 或跳过原生体验的理由。
+- [KNOWN] 任一核心页面只是 WebView、任一必需能力被列为“以后再说”、或 Android/iOS 只有一端完整，都不得称为 Zephyr One 正式版。

--- a/FREEZE/zephyr one for mobile/NATIVE_ENGINE_DECISIONS.md
+++ b/FREEZE/zephyr one for mobile/NATIVE_ENGINE_DECISIONS.md
@@ -37,9 +37,10 @@
 
 **决定**：
 
-- [INFERRED] 采用经过 fuzz 的共享 terminal state machine（首选 `libvterm` 类 C core），Android Canvas/Compose graphics 与 iOS CoreText/Metal 原生绘制。
+- [INFERRED] 不强求一套共享 terminal renderer。Android M0 首选评估 Termux `terminal-emulator` + `terminal-view`（其仓库明确说明这两个模块源自 Apache-2.0 Android Terminal Emulator 代码）；iOS M0 首选评估 MIT 的 SwiftTerm UIKit/Metal terminal。两端必须通过同一 VT/Unicode/IME/scrollback fixture，业务行为一致即可。
+- [KNOWN] Termux 当前 App 整仓是 GPLv3-only；可借鉴交互和只在许可证审计后复用明确例外模块，不能把整套 Termux App/extra-keys UI 无选择复制进 One。SwiftTerm 提供 iOS UIView、Unicode/grapheme/BiDi、resize、hyperlink 和可选 Metal，但 selection/accessibility 完整性必须由 M0 实测，不能只信 README。
 - [KNOWN] 不嵌 Web xterm iframe，不把隐藏 WebView 当 renderer。
-- [KNOWN] 继承 `WTERM_MOBILE_VIEWPORT_CONTRACT.md` 行为：单一 SurfaceController、composition 不滚、IME 开合 rows/cols 同步、用户上滑不被输出抢回。
+- [KNOWN] 终端交互合同见 [`TERMINAL_EXPERIENCE.md`](TERMINAL_EXPERIENCE.md)：单一 SurfaceController、composition 不滚、IME 开合 rows/cols 同步、用户上滑不被输出抢回、extra keys/selection/hardware keyboard 完整。
 
 **C ABI 最小面**：
 
@@ -69,18 +70,29 @@ terminal_scrollback_read
 - [INFERRED] provider 对 write/open-write/truncate/mkdir/delete/rename 返回明确 access denied；已打开 handle 在 policy 变只读时拒绝后续写并关闭写 handle。
 - [INFERRED] 映射前验证目录授权仍有效；路径丢失/授权撤销返回 `file_share_unavailable`，不能让整个 session 只报 generic connect failed。
 
-**许可证门**：
+**上游与许可证证据**：
 
-- [COMMON] FreeRDP 使用 LGPL 系列许可；发布前必须确定动态/静态链接合规、提供 notices/源码或 relink 所需材料，并经项目许可审核。
+- [KNOWN] FreeRDP 官方仓库 README/LICENSE 声明 Apache-2.0；官方树同时包含 `client/Android` 与 `client/iOS`，2026-07 仍各有提交，说明移动 adapter 可作为实现和测试参考，不只是桌面 core。
+- [KNOWN] Apache-2.0 不免除发布审计：必须固定 commit/version、保留 LICENSE/NOTICE、记录本地 patch、生成 SBOM，并审计其构建实际链接的 OpenSSL/FFmpeg/channel 等依赖许可证。
+- [KNOWN] Zephyr One 不能直接采用 FreeRDP 示例 App 的 UI；只复用 core、channel、平台 glue 和测试经验，Compose/SwiftUI 浮层、手势、权限和状态仍按 One 合同实现。
+
+**仓库内已有实证（桌面，不是移动端）**：
+
+- [KNOWN] `main@851df26` 已把 Zephyr One 桌面壳的 WASM RDP 换成原生 FreeRDP：仓库存在 `zephyr_one/native/zephyr-one-rdp/`，含 C shim（`csrc/zephyr_rdp.{h,c}`）、Rust FFI（`src/ffi.rs`）、length-prefixed 协议（`src/proto.rs`）、C 单测和 e2e 脚本。
+- [KNOWN] 该实现只面向 Linux/Windows/macOS 桌面；树内没有 Android Surface 或 iOS UIView/Metal 绑定，因此**不能据此宣称移动端 RDP 已实现**。
+- [KNOWN] 它已验证了 ADR-004 的三个关键假设，可直接继承而不必重新试错：accessor-only settings API 可同时适配 FreeRDP 2/3；damage rect 增量上屏可行；GDI 为 BGRA32、需在 pack 阶段转 RGBA。
+- [KNOWN] 已被实测证伪的两个默认行为必须在移动 adapter 复用同样修法：FreeRDP WLog 默认写 stdout 会冲垮二进制协议流（须在启动时隔离 fd1）；`freerdp_client_add_device_channel` 会 stat 映射路径，目录不存在即整体 settings 组装失败（须前置校验并返回具体错误码）。
+- [INFERRED] 移动 adapter 应复用同一 C shim 与协议测试向量，只替换 surface/audio/输入/文件授权的平台层；分叉成第二套 C 代码属于回归。
 
 ## ADR-005：VNC
 
 **决定**：
 
-- [INFERRED] 首选共享 LibVNCClient 类 RFB core，经小 C adapter 输出 framebuffer dirty rect；若许可/移动稳定性不过门，选择维护范围受控的 RFB core。
-- [KNOWN] 不在原生 App 中嵌 noVNC 页面。
+- [INFERRED] 首选共享 LibVNCClient 类 RFB core，经小 C adapter 输出 framebuffer dirty rect；TigerVNC/MultiVNC 作为行为、encoding、移动手势和互操作参考。若许可/移动稳定性不过门，选择其他成熟 core 或维护范围受控的 RFB adapter，不从 UI 层重写协议。
+- [KNOWN] LibVNCClient/TigerVNC 当前仓库许可证为 GPL-2.0 系列，MultiVNC 为 GPL-3.0；Zephyr 本身 GPL-3.0-only 不等于组合一定自动兼容，必须审计具体版本、链接方式、依赖和 App Store 分发义务。
+- [KNOWN] 不在原生 App 中嵌 noVNC 页面，也不照搬第三方 VNC viewer UI。
 
-**必须通过**：RFB 3.3/3.7/3.8、常见 pixel format/encoding、增量更新、剪贴板、键鼠、认证失败、断线恢复、未知 security type 拒绝。
+**必须通过**：RFB 3.3/3.7/3.8、常见 pixel format/encoding、增量更新、剪贴板、键鼠、认证失败、断线恢复、未知 security type 拒绝，以及 [`REMOTE_DESKTOP_EXPERIENCE.md`](REMOTE_DESKTOP_EXPERIENCE.md) 的 direct/trackpad/IME/弱网手势矩阵。
 
 ## ADR-006：Telnet
 
@@ -120,7 +132,7 @@ terminal_scrollback_read
 | --- | --- | --- | --- | --- | --- |
 | SSH/SFTP | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] 审核 |
 | Terminal | [INFERRED] IME+CJK | [INFERRED] IME+CJK | [INFERRED] VT fixture | [INFERRED] 大输出 | [INFERRED] 审核 |
-| RDP | [INFERRED] 全通道子集 | [INFERRED] 全通道子集 | [INFERRED] cert/input/drive | [INFERRED] 必须 | [INFERRED] LGPL 门 |
+| RDP | [INFERRED] 全通道子集 | [INFERRED] 全通道子集 | [INFERRED] cert/input/drive | [INFERRED] 必须 | [KNOWN] FreeRDP Apache-2.0 + transitive deps 审核 |
 | VNC | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] RFB fixture | [INFERRED] 必须 | [INFERRED] 审核 |
 | Telnet | [INFERRED] 编码/route | [INFERRED] 编码/route | [KNOWN] 复用现有 tests | [INFERRED] 必须 | [INFERRED] 审核 |
 

--- a/FREEZE/zephyr one for mobile/NATIVE_ENGINE_DECISIONS.md
+++ b/FREEZE/zephyr one for mobile/NATIVE_ENGINE_DECISIONS.md
@@ -1,0 +1,127 @@
+# Zephyr One 原生协议引擎决策
+
+> [KNOWN] Zephyr 的业务行为必须继承；Node `ssh2`、Go/WASM RDP、noVNC 和 DOM 终端不能直接嵌入 Kotlin/Swift 原生 App。
+>
+> [INFERRED] 状态：M0 决策基线。候选必须完成 ABI、许可证、真机和 Zephyr fixture 验证后才能写入 lockfile；未验证的版本号不在本文伪造。
+
+## ADR-001：共享 C 协议 core，双端原生 UI
+
+**决定**：
+
+- [INFERRED] Android/iOS 共用边界清晰的 C ABI adapter：terminal、RDP、VNC 可共享；平台网络、KeyStore/Keychain、Surface/UIView、音频、剪贴板和文件授权由平台层实现。
+- [KNOWN] Android UI 是 Compose，iOS UI 是 SwiftUI；共享 core 不拥有导航、表单或 App 状态。
+- [INFERRED] C ABI 只使用固定宽度整数、byte span、opaque handle 和 callback vtable；不跨 ABI 传 C++/Rust/Swift/Kotlin object。
+
+**理由**：
+
+- [KNOWN] Zephyr 已有跨协议一致字段、ACL、路由、错误和测试语义；共享 adapter 可减少 Android/iOS 行为分叉。
+- [INFERRED] 两套完全独立协议实现会把证书、编码、IME、文件重定向和错误映射变成两套真源。
+
+## ADR-002：SSH/SFTP
+
+**决定**：
+
+- [INFERRED] 首选共享 `libssh2` C core + Zephyr adapter；TLS/crypto backend 和算法集合在构建清单中显式固定。
+- [INFERRED] 平台端提供 socket transport abstraction，使 direct、SOCKS5、HTTP CONNECT 和多级 SSH jump 共用 Zephyr route planner。
+- [INFERRED] 若 M0 证明 `libssh2` 无法满足所需 host-key/agent/key 算法或八级 jump，备选是 Android SSHJ + iOS SwiftNIO SSH；切换需新 ADR，不允许悄悄分叉。
+
+**必须通过**：
+
+- RSA/Ed25519 key、encrypted private key、password、host-key unknown/change。
+- SFTP list/stat/read/write/rename/delete、1 GiB、mtime conflict、取消。
+- SOCKS5、HTTP CONNECT、1/2/8 级 jump。
+- PTY xterm-256color、resize、UTF-8/CJK、大输出、断线重连。
+- 与 Zephyr `resource-service` dependency/ACL 错误逐项映射。
+
+## ADR-003：终端 parser 与 renderer
+
+**决定**：
+
+- [INFERRED] 采用经过 fuzz 的共享 terminal state machine（首选 `libvterm` 类 C core），Android Canvas/Compose graphics 与 iOS CoreText/Metal 原生绘制。
+- [KNOWN] 不嵌 Web xterm iframe，不把隐藏 WebView 当 renderer。
+- [KNOWN] 继承 `WTERM_MOBILE_VIEWPORT_CONTRACT.md` 行为：单一 SurfaceController、composition 不滚、IME 开合 rows/cols 同步、用户上滑不被输出抢回。
+
+**C ABI 最小面**：
+
+```c
+terminal_new / terminal_free
+terminal_feed_utf8
+terminal_resize
+terminal_key / terminal_paste
+terminal_snapshot_cells
+terminal_cursor
+terminal_dirty_regions
+terminal_scrollback_read
+```
+
+## ADR-004：RDP
+
+**决定**：
+
+- [INFERRED] 首选 FreeRDP native client core，经 C adapter 接 Android Surface 和 iOS UIView/Metal；不继续移动端 Go/WASM pipeline。
+- [INFERRED] 使用 FreeRDP accessor API，不读取内部 settings struct；adapter 隔离 FreeRDP 2/3 ABI 差异。
+- [INFERRED] GDI/graphics update 转成 dirty rectangles，不每帧复制整屏；像素格式在 adapter 中固定并测试。
+- [KNOWN] RDP 功能门：TLS/NLA、证书、动态分辨率、音频、剪贴板、输入、触控、麦克风、摄像头、位置、RDPDR drive。
+
+**文件 drive**：
+
+- [KNOWN] Zephyr UI 的 `readOnly` 必须落到 provider 操作检查；协议层没有可相信的单一“只读目录”产品开关。
+- [INFERRED] provider 对 write/open-write/truncate/mkdir/delete/rename 返回明确 access denied；已打开 handle 在 policy 变只读时拒绝后续写并关闭写 handle。
+- [INFERRED] 映射前验证目录授权仍有效；路径丢失/授权撤销返回 `file_share_unavailable`，不能让整个 session 只报 generic connect failed。
+
+**许可证门**：
+
+- [COMMON] FreeRDP 使用 LGPL 系列许可；发布前必须确定动态/静态链接合规、提供 notices/源码或 relink 所需材料，并经项目许可审核。
+
+## ADR-005：VNC
+
+**决定**：
+
+- [INFERRED] 首选共享 LibVNCClient 类 RFB core，经小 C adapter 输出 framebuffer dirty rect；若许可/移动稳定性不过门，选择维护范围受控的 RFB core。
+- [KNOWN] 不在原生 App 中嵌 noVNC 页面。
+
+**必须通过**：RFB 3.3/3.7/3.8、常见 pixel format/encoding、增量更新、剪贴板、键鼠、认证失败、断线恢复、未知 security type 拒绝。
+
+## ADR-006：Telnet
+
+**决定**：
+
+- [INFERRED] 直接移植 Zephyr `telnet-transport.js` 的 IAC 状态机与 fixture，不引入重量级库。
+- [KNOWN] 支持 IAC、DO/DONT/WILL/WONT、SB/SE、ECHO、SGA、TTYPE、NAWS、BINARY；默认 terminal type `xterm-256color`。
+- [KNOWN] UTF-8/GBK/Big5/Latin-1 编解码行为与 Zephyr 测试一致；密码只作 in-band auto-login。
+
+## ADR-007：本地数据库
+
+**决定**：
+
+- [INFERRED] Android 使用 Room/SQLite；iOS 使用 GRDB/SQLite；两端共享 SQL fixture 与 migration expectation，不共享 ORM object。
+- [KNOWN] WAL、事务、revision/cursor/pending op 必须由 SQLite 保证；普通 preferences 不保存镜像和 secret。
+- [INFERRED] schema 逻辑真源见 `DATA_AND_MIGRATION.md`，平台 migration 不能自行删列或改默认。
+
+## ADR-008：HTTP/WebSocket
+
+**决定**：
+
+- [INFERRED] Android 主网络栈固定 OkHttp；iOS 固定 URLSession。
+- [KNOWN] 同一平台不能同时用两个主 HTTP 栈处理认证与 retry，避免 Cookie/SID/证书 pin 分叉。
+- [INFERRED] 统一 adapter 实现 requestId、body limit、redirect credential stripping、一次 refresh、Retry-After 和 jitter backoff。
+
+## ADR-009：密钥
+
+**决定**：
+
+- [KNOWN] 继承 Zephyr 已使用的 ML-KEM-768 方向做设备加密 envelope；另用 ES256 hardware-backed signing key 做 device proof。
+- [INFERRED] Android 通过 NDK/经过审计的 PQ 实现处理 ML-KEM，private key 由 Keystore wrapping key 加密；iOS 同理由 Keychain ThisDeviceOnly wrapping。
+- [KNOWN] 不自己实现密码学 primitive；所有跨语言输出必须跑 test vector。
+
+## M0 Spike 退出门
+
+| 引擎 | Android 真机 | iOS 真机 | Zephyr fixture | 30 分钟稳定 | License |
+| --- | --- | --- | --- | --- | --- |
+| SSH/SFTP | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] 审核 |
+| Terminal | [INFERRED] IME+CJK | [INFERRED] IME+CJK | [INFERRED] VT fixture | [INFERRED] 大输出 | [INFERRED] 审核 |
+| RDP | [INFERRED] 全通道子集 | [INFERRED] 全通道子集 | [INFERRED] cert/input/drive | [INFERRED] 必须 | [INFERRED] LGPL 门 |
+| VNC | [INFERRED] 必须 | [INFERRED] 必须 | [INFERRED] RFB fixture | [INFERRED] 必须 | [INFERRED] 审核 |
+| Telnet | [INFERRED] 编码/route | [INFERRED] 编码/route | [KNOWN] 复用现有 tests | [INFERRED] 必须 | [INFERRED] 审核 |
+
+- [KNOWN] 任一引擎只有模拟器成功、只有 connect 没有功能矩阵、没有许可证结论或没有真机内存/泄漏结果，都不能从 provisional 变 accepted。

--- a/FREEZE/zephyr one for mobile/PRODUCT_REQUIREMENTS.md
+++ b/FREEZE/zephyr one for mobile/PRODUCT_REQUIREMENTS.md
@@ -18,6 +18,9 @@
 - [INFERRED] SSH/RDP/VNC/终端等复杂协议核心可复用成熟 native library；复用协议库不等于非原生 UI。
 - [KNOWN] 仓库已有 `zephyr_one/` Tauri 实现作为迁移/兼容来源，不作为新 Android/iOS UI 架构。
 - [KNOWN] Logo、四色主题、图标和总体视觉与 Zephyr 保持一致；移动端按已冻结浮岛、终端和 IME 规范适配。
+- [KNOWN] Zephyr One 的产品定位是 **Zephyr 的完整移动端原生客户端**，不是 Zephyr Lite、远程连接工具集合或阉割版客户端；原生重构的目标是在手机、平板、触控、键盘和系统生命周期下获得比压缩 Web UI 更好的体验。
+- [KNOWN] Android 与 iOS 共用 Zephyr 品牌、能力、数据和协议合同，但分别采用各自平台的导航、返回、sheet、菜单、文件选择、权限、触觉、字体、安全区和动画能力；不得为了像素一致破坏平台习惯。
+- [KNOWN] 成熟的 SSH/终端/RDP/VNC native library 可以复用协议和渲染核心，但不能决定 One 的产品范围，也不能把第三方 App UI、WebView 或桌面交互直接照搬进 One。
 
 ## 3. 功能范围
 
@@ -29,6 +32,10 @@
 - [KNOWN] 主端要求 CAPTCHA/IP策略时，One 登录流程必须遵守服务端结果，但不提供这些策略的配置页面。
 - [KNOWN] 自定义 CSS/JS 是 Web 页面注入配置，在 One 原生 UI 没有执行用途，也不提供编辑页面；文件同步是否备份其原始值由服务端完整快照兼容层处理，不能当成 One 功能入口。
 - [KNOWN] 手机上的布局可改成全屏工作区、sheet、会话列表和宽屏多栏，但保留的移动操作能力不能因布局变化而消失。
+- [KNOWN] 当前绑定账号**自己拥有**的数据进入 One 完整双向镜像；其他用户通过 ACL 分享给当前账号的资源不属于其镜像，不能落入 One 本地数据库、SecretStore、搜索索引、离线缓存、备份、日志或系统集成，每次查看/使用都在线请求 Zephyr 并实时重验权限。
+- [KNOWN] “移动端优化”只允许改变布局、信息层级、手势、系统集成和渐进披露，不允许减少字段、协议选项、ACL、错误状态、同步语义或操作能力；复杂功能必须重构成适合移动端的 flow，而不是隐藏或延期成无期限占位。
+- [KNOWN] Termux 可作为 SSH/Telnet terminal 输入、scrollback、selection、extra keys、IME、硬件键盘和 PTY resize 的交互参考，但 One 不复制其 drawer、视觉皮肤或本地 shell 产品定位。
+- [KNOWN] RDP/VNC 使用成熟 core 时，Zephyr 已承诺的通道或设置若上游缺失，必须通过 adapter、受控 fork、替换核心或发布阻断解决，不能把缺库能力转化成产品删项。
 
 ## 4. Zephyr Agent、Zephyr Client 与文件同步命名
 
@@ -53,7 +60,7 @@
 
 - [KNOWN] 文件同步按 iCloud 类语义工作：Zephyr 与已绑定 One 都可修改数据，最终通过版本、冲突和墓碑收敛。
 - [KNOWN] 同步不是只下拉，不是只备份，不是只同步 connections/notes，也不是只同步 metadata。
-- [KNOWN] 默认同步当前账号在 One 有用途的完整持久数据和敏感字段，包括：连接、凭据、代理、SSH Key、跳板、笔记、代码片段、AI 使用数据/所需配置、服务器设置、备份恢复 metadata/加密包引用、活动、资源 ACL/分享状态、工作区持久状态和 Client Token record + secret。
+- [KNOWN] 默认同步当前账号**拥有**且在 One 有用途的完整持久数据和敏感字段，包括：连接、凭据、代理、SSH Key、跳板、笔记、代码片段、AI 使用数据/所需配置、服务器设置、备份恢复 metadata/加密包引用、活动、自己拥有资源的 ACL/分享状态、工作区持久状态和 Client Token record + secret；其他用户共享给当前账号的资源全部排除在镜像之外。
 - [KNOWN] 不把 SMTP、CAPTCHA/IP策略、备案或账号安全配置同步成 One 的可操作功能。
 - [INFERRED] One不理解的Web展示/登录字段可在加密 opaque snapshot中保留；One不展示、不编辑、不回写覆盖。
 - [KNOWN] Zephyr 后续新增持久业务字段只有在 One 存在产品用途时进入可编辑同步 registry；未知/无用途字段按 opaque preservation 处理，不得被旧 One 清空。
@@ -62,6 +69,11 @@
 - [INFERRED] 敏感字段通过绑定设备公钥 envelope 传输，落入 Android Keystore/iOS Keychain保护的 SecretStore；日志、普通 preferences、change log 和导出包不出现明文。
 - [INFERRED] 活 socket/PTY进程、设备身份私钥、数据库 master key、Android SAF URI、iOS bookmark等不可移植运行态不跨设备复制；对应连接定义、产品意图和可持久 metadata仍同步。
 - [INFERRED] 删除通过 tombstone 传播，离线设备不能把已删除 Token/资源静默复活；恢复必须显式执行。
+- [KNOWN] 共享 AI 每次由 One 向 Zephyr 主端发起请求，Provider Key、Env secret、Client Token 和共享资源 resolved credential 保留在主端；One 只收脱敏 stream/trace/结果和有权查看的内容。
+- [KNOWN] 共享笔记不离线、不本地索引、不恢复草稿；正文和编辑每次在线经主端 `view/edit + expectedRevision + allowAiRead/Write` 校验，当前 viewer 的内存 buffer 离页/锁屏/撤销即清。
+- [KNOWN] 共享连接默认支持主端 relay（凭据不下发）；需要原生直连时，Zephyr 可按次下发绑定 device/session/resource/purpose/expiry/nonce 的加密 use envelope，只含该会话最小连接材料，不持久化，并在握手/断开/失败/撤销时尽力清零。
+- [KNOWN] direct 模式不能宣传“凭据从未到达设备”；若资源拥有者要求秘密绝不进入 One，必须强制 relay，relay 不可用则拒绝而不是静默降级。
+- [KNOWN] 共享零驻留、按次 session、撤销、内存销毁和测试合同见 [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)。
 
 ## 7. 自动与手动同步
 
@@ -95,6 +107,14 @@
 - [KNOWN] 终端采用 `terminal viewport + 快捷键矩阵 + terminal context dock`。
 - [KNOWN] 系统键盘出现时隐藏根浮岛/context dock，快捷键矩阵贴紧 IME，终端 viewport 和 PTY rows/cols 同步 resize，光标保持可见。
 - [KNOWN] Zephyr One 使用 Frost、Lava、Asagi、Cyber 四套图标并按平台能力随主题切换。
+- [KNOWN] RDP/VNC 使用沉浸式 remote surface，并同时提供 direct touch 与 trackpad 两种模式；键盘、modifier、剪贴板、通道和 session 工具通过移动端 context dock/sheet 提供。
+- [KNOWN] 动画优先调用系统原生导航、sheet、keyboard/inset、predictive back、spring、interactive animator 和 haptic；手势动画必须跟手、可中断，不得以动画延迟 terminal/remote input。
+- [KNOWN] iOS Reduce Motion、Android animator/accessibility 设置必须被尊重；终端字符、remote pointer 和 framebuffer 不做增加输入延迟的装饰补间。
+- [KNOWN] Android App 内返回使用系统 back progress/commit/cancel 作为真源，但由 One 实现符合自身层级的可交互预测性返回视觉；根 Activity 返回主页/跨任务仍交给系统。
+- [KNOWN] iOS 所有 push 进入的普通页面都必须支持可取消、跟手的左边缘右滑返回；scroll/pager/terminal/RDP/VNC/AI 手势不得无故吞掉系统返回边缘。
+- [KNOWN] Zephyr AI 在 One 默认使用覆盖当前页面的原生浮窗/detent/side panel，而不是强迫进入隔离的聊天页；底层页面、终端或 RDP/VNC 画面必须持续可见，用户能看见 AI 的目标、执行 trace 和验证结果。
+- [KNOWN] 同版本 Zephyr 的全部 model-visible AI capability/tool、risk、confirmation、playbook 和安全边界必须在 One 保持一致；Web DOM 操作通过原生版本化 semantic/action bridge 提供等价能力，不能因改成原生 UI 而删除。
+- [KNOWN] 详细视觉、交互和动画合同见 [`MOBILE_EXPERIENCE.md`](MOBILE_EXPERIENCE.md)，终端见 [`TERMINAL_EXPERIENCE.md`](TERMINAL_EXPERIENCE.md)，远程桌面见 [`REMOTE_DESKTOP_EXPERIENCE.md`](REMOTE_DESKTOP_EXPERIENCE.md)，AI 浮窗与能力见 [`AI_FLOATING_WORKSPACE.md`](AI_FLOATING_WORKSPACE.md)。
 
 ## 11. 发布阻断条件
 
@@ -109,3 +129,13 @@
 - [KNOWN] One 再次出现独立 Zephyr Agent 产品页。
 - [KNOWN] 用整页 WebView代替要求的原生页面。
 - [KNOWN] 用平台后台限制作为删除功能的理由，而不是明确说明并做前台/补偿实现。
+- [KNOWN] 把 One 定位或发布成 Zephyr Lite/阉割版，只实现连接协议而缺失其他保留能力，或用“移动端不方便”删除复杂功能。
+- [KNOWN] SSH/Telnet 没有达到冻结的 IME、scrollback、selection、extra keys、硬件键盘、mouse mode 和 PTY resize 交互门。
+- [KNOWN] RDP/VNC 只有画面或基本点击，缺 direct/trackpad、键盘、剪贴板、证书、通道、文件授权、弱网恢复或 Zephyr 已承诺设置。
+- [KNOWN] 自绘动画破坏 iOS/Android 返回事件、sheet、键盘、Reduce Motion，或动画/重组增加 terminal 与 remote input 延迟。
+- [KNOWN] Android 应用内返回没有 progress-driven 自定义视觉、不能取消/反向、一次手势改变两层，或错误覆盖根页系统 home/task transition。
+- [KNOWN] iOS 任一普通 push 页面只能点按钮返回，或 pager/terminal/remote/AI overlay 吞掉左边缘 interactive swipe-back。
+- [KNOWN] Zephyr AI 被降级成独立全屏聊天页、浮窗遮住/暂停目标 surface、用户看不到 tool trace/目标/确认/验证，或 One 的 AI tool catalog 少于同版本 Zephyr。
+- [KNOWN] 任一 shared-to-me 实体、正文、ACL grant 或 secret 被写入 One 镜像、SecretStore、索引、离线缓存、备份、日志、通知、诊断或系统搜索。
+- [KNOWN] 共享 AI 收到 Provider/Env/Client Token/resolved credential；共享笔记离线可读；ACL 撤销后仍可从本地缓存继续使用。
+- [KNOWN] 共享连接 use envelope 可跨 device/session/resource/purpose/expiry 重放、被持久化，或 strict relay 失败时静默降级为凭据下发。

--- a/FREEZE/zephyr one for mobile/README.md
+++ b/FREEZE/zephyr one for mobile/README.md
@@ -15,25 +15,33 @@
 1. [`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)：用户确认的产品范围；决定必须做什么和明确排除什么。
 2. [`ZEPHYR_PARITY.md`](ZEPHYR_PARITY.md)：Zephyr 已有认证、ACL、资源、协议、笔记、AI、设置、备份、Token 和测试怎样继承到原生 One。
 3. [`SCREEN_CATALOG.md`](SCREEN_CATALOG.md)：四入口信息架构、服务器设置/备份恢复落点和每屏完整状态。
-4. [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)：首次 bootstrap、普通 push/pull、幂等、冲突、墓碑、blob 和崩溃恢复。
-5. [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)：服务端新增 DDL、Android/iOS 逻辑 DB、SecretStore、Token 明文 JSON 和 Tauri 迁移。
-6. [`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)：SSH/SFTP、终端、RDP、VNC、Telnet、网络和密码学的 M0 决策门。
-7. [`DEVELOPMENT.md`](DEVELOPMENT.md)：总体架构、视觉参数、能力矩阵、里程碑和质量目标。
-8. [`TRACEABILITY.md`](TRACEABILITY.md)：需求 → Zephyr 事实源 → One code → One tests；发布门。
-9. [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md)：只报告当前仓库真实完成度。
+4. [`MOBILE_EXPERIENCE.md`](MOBILE_EXPERIENCE.md)：iOS/Android 平台原生视觉、Android 自定义返回、iOS 全面右滑、动画和响应式体验。
+5. [`TERMINAL_EXPERIENCE.md`](TERMINAL_EXPERIENCE.md)：参考 Termux 行为的 SSH/Telnet 输入、IME、scrollback、selection、extra keys 和 PTY 体验。
+6. [`REMOTE_DESKTOP_EXPERIENCE.md`](REMOTE_DESKTOP_EXPERIENCE.md)：RDP/VNC 成熟核心、direct/trackpad、键盘、通道、弱网和沉浸式 UI。
+7. [`AI_FLOATING_WORKSPACE.md`](AI_FLOATING_WORKSPACE.md)：Zephyr AI 全能力对齐、浮窗、可见操作闭环和原生 semantic bridge。
+8. [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)：共享资源零驻留、AI/笔记主端请求、连接 direct use envelope 与 strict relay。
+9. [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)：首次 bootstrap、普通 push/pull、幂等、冲突、墓碑、blob 和崩溃恢复。
+10. [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)：服务端新增 DDL、Android/iOS 逻辑 DB、SecretStore、Token 明文 JSON 和 Tauri 迁移。
+11. [`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)：SSH/SFTP、终端、RDP、VNC、Telnet、网络和密码学的 M0 决策门。
+12. [`DEVELOPMENT.md`](DEVELOPMENT.md)：总体架构、视觉参数、能力矩阵、里程碑和质量目标。
+13. [`TRACEABILITY.md`](TRACEABILITY.md)：需求 → Zephyr 事实源 → One code → One tests；发布门。
+14. [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md)：只报告当前仓库真实完成度。
 
 ## 机器合同
 
 | 文件 | 作用 |
 | --- | --- |
 | [`contracts/openapi-mobile-v1.json`](contracts/openapi-mobile-v1.json) | Mobile v1 登录、设备、同步、敏感验证和文件桥接 API |
+| [`contracts/ai-capability-baseline.json`](contracts/ai-capability-baseline.json) | 从 Zephyr 真实 catalog 派生的 116 个 AI tool/capability/risk/confirmation/schema 对齐基线 |
 | [`contracts/entity-registry.json`](contracts/entity-registry.json) | 每个同步实体的 editable/secret/opaque/deviceLocal/serverAuthority 分类和当前阻断 |
 | [`contracts/error-registry.json`](contracts/error-registry.json) | 稳定错误码、HTTP 状态、retryable 和客户端动作 |
 | [`contracts/schemas/sync-operation.schema.json`](contracts/schemas/sync-operation.schema.json) | push operation JSON Schema |
 | [`contracts/schemas/sync-change.schema.json`](contracts/schemas/sync-change.schema.json) | change feed JSON Schema |
-| [`contracts/schemas/secret-envelope.schema.json`](contracts/schemas/secret-envelope.schema.json) | 设备 secret envelope JSON Schema |
+| [`contracts/schemas/secret-envelope.schema.json`](contracts/schemas/secret-envelope.schema.json) | 自有镜像设备 secret envelope JSON Schema |
+| [`contracts/schemas/shared-use-envelope.schema.json`](contracts/schemas/shared-use-envelope.schema.json) | 共享连接一次 session/device/resource/purpose 绑定 use envelope JSON Schema |
 | [`contracts/schemas/error.schema.json`](contracts/schemas/error.schema.json) | 统一错误 envelope JSON Schema |
-| [`contracts/test-vectors/sync-v1.json`](contracts/test-vectors/sync-v1.json) | AAD 字节和同步边界测试向量 |
+| [`contracts/test-vectors/sync-v1.json`](contracts/test-vectors/sync-v1.json) | 自有镜像 AAD 和同步边界测试向量 |
+| [`contracts/test-vectors/shared-use-v1.json`](contracts/test-vectors/shared-use-v1.json) | 共享 use AAD 与错 device/session/resource/purpose/expiry/replay 向量 |
 
 ## 已冻结的产品边界
 
@@ -45,6 +53,9 @@
 - [KNOWN] 删除 One、查看/旋转/删除/重置 Token 必须经过当前密码或 TOTP 敏感验证。
 - [KNOWN] 普通页使用四入口悬浮岛；服务器设置和备份恢复都位于“工具 → 服务器”，不得因根导航只有四项而消失。
 - [KNOWN] 终端使用 viewport + 快捷键矩阵 + context dock；IME 打开时隐藏 root/dock，viewport 与 PTY rows/cols 同步。
+- [KNOWN] Android App 内返回采用系统 progress 驱动的 One 自定义预测性返回视觉；iOS 每个普通 push 层级全面支持 interactive 右滑返回。
+- [KNOWN] Zephyr AI 默认是叠在当前 page/terminal/RDP/VNC 上的原生浮窗；底层目标持续可见，能力/tool catalog 与同版本 Zephyr 完全一致。
+- [KNOWN] 只有当前账号拥有的数据进入完整镜像；别人共享给当前账号的资源全部在线按次使用且不落地。共享 AI/笔记由主端授权和执行；共享连接可选择 strict relay，或使用绑定单会话的短时加密 use envelope 原生直连。
 
 ## 设计与品牌资料
 

--- a/FREEZE/zephyr one for mobile/README.md
+++ b/FREEZE/zephyr one for mobile/README.md
@@ -1,30 +1,64 @@
 # Zephyr One for Mobile
 
-此目录集中保存 Zephyr One Android / iOS 原生 App 的产品、架构、交互和品牌设计资料。
+此目录是 Zephyr One Android / iOS 原生 App 的产品合同、Zephyr 能力继承规范、机器协议、逐屏交互、数据迁移和发布追踪入口。
 
-## 内容
+## 当前真实状态
 
-- [`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)：用户确认的产品范围合同；规定功能、绑定、完整同步、Token互备、命名和发布阻断项。
-- [`DEVELOPMENT.md`](DEVELOPMENT.md)：Kotlin + Jetpack Compose、Swift + SwiftUI 原生 App 完整技术开发文档。
+- [KNOWN] Android 目标是 Kotlin + Jetpack Compose；iOS 目标是 Swift + SwiftUI；不用整页 WebView 冒充原生。
+- [KNOWN] 仓库当前还没有新的 Kotlin/Swift 原生项目；`../../zephyr_one/` 是旧 Tauri 迁移/兼容来源，不代表原生实现完成。
+- [KNOWN] Zephyr 主端已有认证、ACL、连接、笔记、工作区、AI、备份、Client Token、ZFT2 等业务实现。
+- [KNOWN] 旧 `/api/one/sync/pull` 仍是整包 pull-only；正式 `/api/mobile/v1` 双向同步尚未实现。
+- [KNOWN] 本目录已经把 Zephyr 的现有业务规则提取成 One 的可执行规格和 machine-readable contracts；实际实现状态逐项见 [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md)。
+
+## 阅读顺序
+
+1. [`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md)：用户确认的产品范围；决定必须做什么和明确排除什么。
+2. [`ZEPHYR_PARITY.md`](ZEPHYR_PARITY.md)：Zephyr 已有认证、ACL、资源、协议、笔记、AI、设置、备份、Token 和测试怎样继承到原生 One。
+3. [`SCREEN_CATALOG.md`](SCREEN_CATALOG.md)：四入口信息架构、服务器设置/备份恢复落点和每屏完整状态。
+4. [`SYNC_STATE_MACHINE.md`](SYNC_STATE_MACHINE.md)：首次 bootstrap、普通 push/pull、幂等、冲突、墓碑、blob 和崩溃恢复。
+5. [`DATA_AND_MIGRATION.md`](DATA_AND_MIGRATION.md)：服务端新增 DDL、Android/iOS 逻辑 DB、SecretStore、Token 明文 JSON 和 Tauri 迁移。
+6. [`NATIVE_ENGINE_DECISIONS.md`](NATIVE_ENGINE_DECISIONS.md)：SSH/SFTP、终端、RDP、VNC、Telnet、网络和密码学的 M0 决策门。
+7. [`DEVELOPMENT.md`](DEVELOPMENT.md)：总体架构、视觉参数、能力矩阵、里程碑和质量目标。
+8. [`TRACEABILITY.md`](TRACEABILITY.md)：需求 → Zephyr 事实源 → One code → One tests；发布门。
+9. [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md)：只报告当前仓库真实完成度。
+
+## 机器合同
+
+| 文件 | 作用 |
+| --- | --- |
+| [`contracts/openapi-mobile-v1.json`](contracts/openapi-mobile-v1.json) | Mobile v1 登录、设备、同步、敏感验证和文件桥接 API |
+| [`contracts/entity-registry.json`](contracts/entity-registry.json) | 每个同步实体的 editable/secret/opaque/deviceLocal/serverAuthority 分类和当前阻断 |
+| [`contracts/error-registry.json`](contracts/error-registry.json) | 稳定错误码、HTTP 状态、retryable 和客户端动作 |
+| [`contracts/schemas/sync-operation.schema.json`](contracts/schemas/sync-operation.schema.json) | push operation JSON Schema |
+| [`contracts/schemas/sync-change.schema.json`](contracts/schemas/sync-change.schema.json) | change feed JSON Schema |
+| [`contracts/schemas/secret-envelope.schema.json`](contracts/schemas/secret-envelope.schema.json) | 设备 secret envelope JSON Schema |
+| [`contracts/schemas/error.schema.json`](contracts/schemas/error.schema.json) | 统一错误 envelope JSON Schema |
+| [`contracts/test-vectors/sync-v1.json`](contracts/test-vectors/sync-v1.json) | AAD 字节和同步边界测试向量 |
+
+## 已冻结的产品边界
+
+- [KNOWN] One 完整实现当前账号有直接移动用途的能力：连接、SSH/Telnet/RDP/VNC、SFTP、Docker/监控/日志、批量执行、Proxy/SSH Key/JumpHost、Snippet、笔记、活动、AI、服务器设置、备份恢复、分享资源、工作区、Client Token 与文件同步。
+- [KNOWN] One 不提供：多用户管理、独立 Zephyr Agent 页、当前账号安全设置、SMTP/邮件、CAPTCHA/IP白名单/防爆破配置、ICP/公安备案、自定义 CSS/JS 编辑执行。
+- [KNOWN] One 内原 Agent 位置统一叫“文件同步”；主端入口叫“Zephyr Client”并继续兼容旧 Agent。
+- [KNOWN] 文件同步是 iCloud 类完整双向镜像，有 push、cursor、idempotency、conflict、tombstone、secret envelope、用户间隔和立即同步；不是 pull-only 备份。
+- [KNOWN] 开启前主端必须已有 Client Token；One 用 Zephyr 账号密码并在需要时通过 TOTP 后选择 Token 绑定。
+- [KNOWN] 删除 One、查看/旋转/删除/重置 Token 必须经过当前密码或 TOTP 敏感验证。
+- [KNOWN] 普通页使用四入口悬浮岛；服务器设置和备份恢复都位于“工具 → 服务器”，不得因根导航只有四项而消失。
+- [KNOWN] 终端使用 viewport + 快捷键矩阵 + context dock；IME 打开时隐藏 root/dock，viewport 与 PTY rows/cols 同步。
+
+## 设计与品牌资料
+
 - [`branding/manifest.json`](branding/manifest.json)：四色图标 palette、geometry、源文件 SHA-256 与生产规则。
-- [`branding/source/`](branding/source/)：用户提交的 Frost / Lava / Asagi / Cyber 四色 SVG 及预览 HTML 权威设计源。
-- [`references/bottom-floating-island.jpg`](references/bottom-floating-island.jpg)：普通页面四入口底部浮岛视觉参考。
-- [`references/terminal-ime-closed.jpg`](references/terminal-ime-closed.jpg)：终端系统键盘收起状态参考。
-- [`references/terminal-ime-open.jpg`](references/terminal-ime-open.jpg)：终端系统键盘弹出状态参考。
-- [`references/manifest.json`](references/manifest.json)：三张参考图的原始文件名、像素尺寸、SHA-256 和设计角色。
-- [`original-uploads/zephyr-one-icons.zip`](original-uploads/zephyr-one-icons.zip)：用户提交的原始图标压缩包。
+- [`branding/source/`](branding/source/)：Frost / Lava / Asagi / Cyber SVG 和预览设计源。
+- [`references/bottom-floating-island.jpg`](references/bottom-floating-island.jpg)：四入口底部浮岛参考。
+- [`references/terminal-ime-closed.jpg`](references/terminal-ime-closed.jpg)：终端 IME 收起参考。
+- [`references/terminal-ime-open.jpg`](references/terminal-ime-open.jpg)：终端 IME 打开参考。
+- [`references/manifest.json`](references/manifest.json)：参考图尺寸、hash 和角色。
+- [`original-uploads/zephyr-one-icons.zip`](original-uploads/zephyr-one-icons.zip)：原始用户图标包。
 
-## 已冻结的关键决策
+## 更新规则
 
-- [KNOWN] Android 使用 Kotlin + Jetpack Compose、iOS 使用 Swift + SwiftUI；旧 Tauri `zephyr_one/` 是迁移/兼容来源。
-- [KNOWN] Zephyr One完整实现当前账号有直接移动用途的能力，并保留用户要求的服务器设置和备份恢复。
-- [KNOWN] One不提供当前账号安全设置、SMTP、CAPTCHA/IP策略、备案、自定义CSS/JS管理、多用户或独立Agent页；登录时只被动遵守主端认证策略。
-- [KNOWN] One内原Zephyr Agent设置改名“文件同步”；主端入口统一叫“Zephyr Client”并继续兼容旧Agent。
-- [KNOWN] 文件同步像iCloud一样完整双向镜像One有用途的账号数据、凭据和Client Token，不限于连接/笔记。
-- [KNOWN] 开启同步要求主端先创建 Token，然后在 One 输入 Zephyr 用户名、密码，并在启用 TOTP 时通过动态码后绑定设备。
-- [KNOWN] 文件同步同时提供用户自定义自动间隔和“立即同步”；删除 One 设备、查看/旋转/删除/重置 Token 必须走密码或 TOTP 敏感验证。
-- [INFERRED] 普通页面使用四入口底部浮岛；选中项展开为“图标 + 文字”胶囊，其他项只显示图标。
-- [INFERRED] 终端使用 `terminal viewport + 快捷键矩阵 + terminal context dock`；系统键盘出现时隐藏 dock，矩阵紧贴 IME，viewport 与 PTY rows/cols 同步 resize。
-- [INFERRED] Zephyr One 使用 Frost / Lava / Asagi / Cyber 四套应用图标，并按平台能力随主题切换；正式 launcher asset 先把 “One” 文字转成固定 path。
-
-[KNOWN] 设计参考和原始压缩包按收到的字节保存；校验值记录在 `DEVELOPMENT.md` 与 `branding/manifest.json`。
+- [KNOWN] 改 Zephyr 业务字段时必须同步检查 entity registry、OpenAPI、Android model、iOS model 和跨端 fixture。
+- [KNOWN] 新增持久字段必须分类为 `editableSync / opaquePreserve / deviceLocal / serverOnly`；未分类则 CI 失败。
+- [KNOWN] 只有文档或页面没有真实服务、Android/iOS 测试和真机证据，不得把 `IMPLEMENTATION_STATUS.md` 改为 implemented。
+- [KNOWN] `PRODUCT_REQUIREMENTS.md` 与技术文档冲突时产品合同优先；用户后续明确要求高于现有文件。

--- a/FREEZE/zephyr one for mobile/REMOTE_DESKTOP_EXPERIENCE.md
+++ b/FREEZE/zephyr one for mobile/REMOTE_DESKTOP_EXPERIENCE.md
@@ -1,0 +1,189 @@
+# Zephyr One RDP / VNC 原生移动体验规范
+
+> [KNOWN] RDP 和 VNC 可以复用成熟 native protocol core，但不能把第三方客户端 UI、Web canvas 或桌面鼠标交互直接照搬进 Zephyr One。
+>
+> [KNOWN] RDP 当前首选 FreeRDP；VNC 候选是 LibVNCClient/TigerVNC/MultiVNC 类 RFB core，最终选型必须通过 M0 功能、许可证、iOS/Android、真机和 Zephyr fixture 门。
+
+## 1. 方案结论
+
+### RDP
+
+- [KNOWN] FreeRDP 官方仓库使用 Apache-2.0，当前同时维护 `client/Android` 和 `client/iOS`，且有 Android/iOS channel/platform 代码。
+- [INFERRED] One 复用 FreeRDP core、settings accessor、channel、证书和 protocol parsing；渲染 surface、连接状态、手势、工具栏、权限、文件授权和 Zephyr 设置 UI 自己实现。
+- [KNOWN] 必须支持 Zephyr 已有 RDP 能力：TLS/NLA、domain、证书、分辨率、质量、FPS、音频、剪贴板、麦克风、摄像头、位置、storage/drive、direct/trackpad touch。
+
+### VNC
+
+- [KNOWN] LibVNCClient 提供成熟 RFB client、TLS/auth/encoding、Android cross-compile；TigerVNC 与 MultiVNC 提供成熟行为/移动参考。
+- [KNOWN] LibVNC/TigerVNC/MultiVNC 是 GPL 系列，Zephyr 自身是 GPL-3.0-only，但仍需确认版本兼容、静态链接、App Store/Play 分发、源码/notice 和依赖链。
+- [INFERRED] VNC 首选“共享 RFB core + Zephyr adapter”，而不是 noVNC WebView；若候选无法满足 iOS、许可证或内存门，才维护范围受控的自有 RFB core。
+
+## 2. 共享 RemoteSurface 架构
+
+```text
+RemoteSessionController
+ ├─ protocol adapter (FreeRDP / RFB)
+ ├─ FrameMailbox (latest complete frame / dirty rects)
+ ├─ RemoteSurface (SurfaceView/Metal/UIKit view)
+ ├─ ViewportTransform (fit / zoom / pan / rotation)
+ ├─ PointerController (direct / trackpad / hardware mouse)
+ ├─ KeyboardController (IME / hardware / modifiers)
+ ├─ ClipboardBridge
+ ├─ ChannelController (audio/mic/camera/location/drive)
+ ├─ Certificate/TrustController
+ └─ SessionChromeController
+```
+
+- [KNOWN] protocol callback 不直接操作 Compose/SwiftUI state；通过 bounded mailbox/actor 交付 dirty rect、cursor、status 和 channel event。
+- [INFERRED] UI thread/GPU thread只消费最新可显示 frame；积压时丢过时 video frame，不丢 input、clipboard、resize 或 channel control。
+- [INFERRED] protocol core 不知道浮岛、sheet、主题或 navigation。
+
+## 3. 屏幕布局
+
+### 3.1 沉浸 surface
+
+- [KNOWN] RDP/VNC session 默认 edge-to-edge，framebuffer 是主内容；root 四入口浮岛隐藏。
+- [INFERRED] 顶部只保留可自动隐藏的状态 pill：connection name、网络/质量、录入模式；点击显示完整 chrome。
+- [INFERRED] 底部 session dock：键盘、pointer mode、modifiers、clipboard、display、channels/files、more、disconnect。
+- [INFERRED] chrome 叠加在 surface，不 resize remote desktop；只有系统 IME 改变可用 viewport时，根据用户策略 resize 或 pan-to-caret。
+
+### 3.2 手机与平板
+
+- [INFERRED] 手机一次显示一个 remote session，不切四格缩略操作；session switcher 用 sheet/edge-safe horizontal switch。
+- [INFERRED] 平板可 split 两 session，但每个 pane 达到最小交互尺寸；不足自动退回单 session + thumbnail switcher。
+- [INFERRED] 外接显示器可把 remote session 放外屏，本机保留控制/会话页；这是增强项，不降低主屏功能。
+
+## 4. Viewport 模式
+
+| 模式 | 语义 | 默认场景 |
+| --- | --- | --- |
+| Fit | [INFERRED] 整个远程桌面适配 viewport，可能留边 | 首次连接/观察 |
+| Fill width | [INFERRED] 宽度填满，垂直可 pan | 文档/桌面 |
+| 1:1 | [INFERRED] 远程像素对应设备逻辑/物理策略 | 精细检查 |
+| Custom zoom | [INFERRED] pinch 后保持用户 scale/anchor | 交互 |
+| Dynamic resolution | [KNOWN] 请求服务器匹配可用 viewport | RDP 支持时首选 |
+
+- [INFERRED] pinch 缩放围绕双指焦点，双指平移，双击在 fit 与最近 zoom 间切换。
+- [INFERRED] transform 每帧 1:1 跟手；释放只对 pan 边界/惯性使用平台 decay/spring。
+- [INFERRED] rubber band 只用于 viewport 超出边界的视觉阻力，释放回合法范围；远程 pointer 坐标只在合法 transform 中计算。
+- [KNOWN] orientation/IME/split resize 不能把 pointer 映射留在旧矩阵。
+
+## 5. 两种触控模式
+
+### 5.1 Direct touch
+
+- 单指 tap = remote primary click；drag = remote drag。
+- long press = remote secondary click，进入前 haptic；可在设置交换行为。
+- 双指 scroll = remote wheel；pinch = local viewport zoom，优先于 remote gesture。
+- [INFERRED] direct 模式适合 Windows touch UI/大目标；不把手指位置做加速度偏移。
+
+### 5.2 Trackpad
+
+- 单指移动 = 相对 pointer move，不按下。
+- 单指 tap = left click；double tap + drag = drag lock。
+- 双指 tap = right click；双指 drag = wheel；pinch = viewport zoom。
+- 三指/额外手势默认不占用系统导航；用户可自定义但不能覆盖 edge-back/home。
+- [INFERRED] pointer acceleration 使用稳定曲线并提供 0.5–2.5 sensitivity；切模式保留 remote cursor，不跳到手指位置。
+
+### 5.3 Mouse / trackpad hardware
+
+- [KNOWN] primary/secondary/middle、wheel、hover、relative movement、button chord 必须直通。
+- [INFERRED] Android pointer capture/iPad pointer APIs 只在用户进入 capture mode 后启用，Esc/系统 gesture 可退出。
+- [INFERRED] hover 显示 remote cursor，不自动显示整套 chrome。
+
+## 6. 键盘
+
+- [INFERRED] 点 keyboard action 显示系统 IME + 一行 remote modifier bar：Ctrl/Alt/Shift/Win/Cmd/Esc/Tab/arrows。
+- [INFERRED] RDP 默认把平台 Meta 映射到 Win；VNC 按 X key mapping；映射可查看和修改。
+- [INFERRED] system IME 文本通过 Unicode/text channel；程序级 key shortcut 通过 scan/key code，不把 Ctrl+C 当普通字符串。
+- [KNOWN] IME 出现时默认不把 remote desktop永久改分辨率：RDP 提供 `resize remote / pan to cursor` 用户策略；VNC 通常 pan viewport。
+- [INFERRED] hardware keyboard 不显示软 modifier bar，除非用户固定显示。
+
+## 7. Clipboard
+
+- [KNOWN] 只有连接启用 clipboard 且用户/ACL允许时桥接。
+- [INFERRED] 文本 clipboard 默认询问/本次允许/总是允许策略；图片/文件显示大小和方向，避免后台静默复制大对象。
+- [INFERRED] remote→local 不在后台读取/覆盖系统 clipboard；显示“远程剪贴板可用”action，由用户确认写入。
+- [KNOWN] clipboard 内容不写日志、analytics 或同步 feed。
+
+## 8. Channels 与权限
+
+| Channel | One 行为 |
+| --- | --- |
+| Audio playback | [KNOWN] 会话级开关；显示实际输出 route；后台按平台 audio policy |
+| Microphone | [KNOWN] 远端实际请求时申请权限；状态 pill 常驻可见；一键 mute |
+| Camera | [KNOWN] 实际请求时申请；前/后摄像头选择；系统 privacy indicator |
+| Location | [KNOWN] 实际请求时申请；精确/近似按平台结果，不伪造 |
+| Drive/files | [KNOWN] 用户显式选择目录；显示 read-only/read-write 和授权状态 |
+| Clipboard | [KNOWN] 独立开关；拒绝不终止整个 session |
+
+- [KNOWN] 权限拒绝只关闭对应 channel；protocol 能继续则 session 保持。
+- [INFERRED] 永久拒绝显示系统设置 deep link；不连续弹权限框。
+
+## 9. RDP Drive 与 VNC 文件边界
+
+- [KNOWN] RDPDR drive 复用 Zephyr `FileSyncShareProfile`，Android SAF/iOS bookmark 是本机授权，不能跨设备复制。
+- [KNOWN] `readOnly` 在 provider 层拒绝 open-write/write/truncate/mkdir/delete/rename；不能只显示开关。
+- [KNOWN] FreeRDP 映射前要验证路径/授权；不可用返回 `file_share_unavailable`，不能把整个连接压成 generic error。
+- [KNOWN] 标准 VNC/RFB 不等于 RDP drive；若服务器/扩展没有 file transfer，VNC 页面不伪造“远程磁盘”。One 仍可通过 Zephyr/SFTP 文件能力处理同一主机文件。
+
+## 10. Certificate 与安全
+
+### RDP
+
+- [KNOWN] 首次证书显示 subject、issuer、validity、SHA-256 fingerprint；信任按 server profile/host/port 保存。
+- [KNOWN] 证书变化默认阻断，不能普通 toast 一键忽略。
+- [INFERRED] NLA/认证失败、TLS policy、CredSSP、证书错误分开报告。
+
+### VNC
+
+- [KNOWN] unknown security type 明确拒绝，不降级到未知弱模式。
+- [INFERRED] TLS/VeNCrypt/X509 等按 core capability 列表显示；不把普通 VNC password 描述成强加密。
+
+## 11. Frame/render 性能
+
+- [INFERRED] Android 优先 SurfaceView/HardwareBuffer/OpenGL/Vulkan 中经 spike 证明的一条；iOS 优先 Metal layer。Compose/SwiftUI 只承载 host 与 chrome。
+- [INFERRED] dirty rect merge 有上限；rect 太多时单帧退化为 bounding/full frame，下一帧恢复，不长期 full-copy。
+- [INFERRED] 像素格式转换、解码和颜色转换不在 main thread；cursor 可独立 layer，避免每次移动重绘 framebuffer。
+- [INFERRED] mailbox 最大 2–3 个 frame；display latest，统计 dropped frames。输入 event 独立高优先队列并 coalesce move，不 coalesce down/up/key。
+- [INFERRED] quality/FPS 是目标；UI 显示 negotiated/actual resolution、codec/encoding、FPS、latency、drop。
+
+## 12. Session chrome 与动画
+
+- [INFERRED] tap 空白处切 chrome 显隐；pointer/drag 中不误触 chrome。
+- [INFERRED] chrome 显隐 120–180ms opacity + 4–8pt offset，不 scale framebuffer，不改变 remote coordinate system。
+- [INFERRED] mode switch 使用选中态/haptic，remote cursor 不做飞行动画。
+- [INFERRED] disconnect sheet 跟系统 detent/back；连接重试状态在原 surface 上连续更新，不跳回首页再弹 modal。
+- [KNOWN] gesture-driven viewport/sheet 动画必须可中断，从当前值继续；Reduce Motion 下去掉空间位移。
+
+## 13. 错误与恢复
+
+```text
+resolving → connecting → tls/cert → authenticating → negotiating
+→ first-frame → connected → degraded → reconnecting → disconnected
+```
+
+- [INFERRED] 每阶段有具体错误和 elapsed time；首帧超时与 TCP connect timeout 分开。
+- [INFERRED] 网络切换后可自动重连，使用同 session definition；credential/ACL/Token revoked 则停止并要求处理。
+- [KNOWN] 本地 viewport/keyboard/mode 可以恢复；不伪称恢复远端未保存进程状态。
+
+## 14. M0 功能/许可证门
+
+### FreeRDP
+
+- [KNOWN] 以官方 master/固定 release source + Apache-2.0 为候选；版本、patch SHA、build flags 和 notices 进入 lockfile。
+- [INFERRED] Android/iOS 各验证 TLS/NLA、证书、graphics、dynamic resolution、clipboard、audio、input、RDPDR；mic/camera/location 若上游平台实现不足，写 adapter/patch，不删 Zephyr 开关。
+
+### VNC
+
+- [INFERRED] 对 LibVNCClient、TigerVNC core、MultiVNC-derived mobile adapter 做同一矩阵：RFB versions、Raw/CopyRect/Hextile/ZRLE/Tight、TLS/security types、clipboard、pointer/key、dirty rect、取消、iOS build。
+- [KNOWN] 任何 GPL 候选先过许可证清单；“仓库也是 GPL”不自动替代 App Store/依赖合规审核。
+
+## 15. 真机验收
+
+- [INFERRED] Windows Server/Windows 10/11 RDP；xrdp/FreeRDP shadow；不同 DPI/分辨率；弱网/旋转/后台。
+- [INFERRED] TigerVNC/RealVNC/UltraVNC/libvncserver 常见服务器，覆盖 security/encoding 差异。
+- [INFERRED] 手机 direct touch 完成窗口拖动、右键、滚动、文本选取；trackpad 完成精细 resize/菜单操作。
+- [INFERRED] hardware keyboard/mouse、iPad trackpad、Android DeX/平板、多点触控。
+- [INFERRED] 30 分钟连接无泄漏/ANR；快速切 50 次 session；frame/input queue bounded。
+- [KNOWN] 缺任一 Zephyr 已承诺 channel/设置不能用“现成库不支持”作为正式版删项理由；要补 adapter、fork、替换库或阻断发布。

--- a/FREEZE/zephyr one for mobile/SCREEN_CATALOG.md
+++ b/FREEZE/zephyr one for mobile/SCREEN_CATALOG.md
@@ -43,6 +43,14 @@ sync-conflict
 - [INFERRED] destructive action 使用原生 dialog/sheet，不使用浏览器 prompt/confirm。
 - [INFERRED] 所有错误页包含 requestId 的可复制诊断入口，但默认不显示 secret/host/user/path。
 
+### 2.1 Shared-to-me 在线零驻留态
+
+- [KNOWN] 自己拥有的资源走本地 mirror；shared-to-me 不落地，列表/详情/正文/会话每次在线请求 Zephyr。完整合同见 [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md)。
+- [KNOWN] shared row 显示“来自 <owner> · 在线使用 · 不保存到此设备”、capability 和 expiry；没有 `offline-with-cache`，离线只能进入 `offline-no-cache`。
+- [KNOWN] Shared Connection 打开前明确 owner policy：`主端 relay（凭据保留主端）` 或 `本次原生直连（加密连接材料仅驻留会话内存）`；不能用模糊“安全连接”混淆。
+- [KNOWN] Shared Note/AI/File 离线、ACL revoke、owner delete 后立即退出内容并清内存，不自动复制成 owned resource。
+- [KNOWN] 用户主动下载/复制/export 是显式动作，显示 owner policy、目标位置和审计；默认不进 clipboard/search/widget/recent。
+
 ## 3. S01 启动与本地解锁
 
 **入口**：App launch。
@@ -222,15 +230,25 @@ sync-conflict
 
 **共同**：owner/shared/capability、revision conflict、share sheet、依赖引用删除保护。
 
-## 19. S44 AI
+## 19. S44 AI 浮动 Workspace
 
-**页面**：会话列表、聊天、Provider/模型选择、附件、计划/Memory/Skills/Env、运行权限确认。
+**入口/形态**：每个有上下文的页面显示 Zephyr AI launcher；手机打开为覆盖当前 surface 的 `peek / half / expanded` 原生浮窗，横屏/平板可停靠侧栏。默认不 push 到隔离聊天页，底层 connection/terminal/RDP/VNC/file/note 页面持续可见和更新。
 
-**运行**：SSE/stream events；取消 run；permission 请求用原生 confirmation sheet；后台中断后可按 runId 恢复事件。
+**浮窗内容**：context header、conversation、Provider/模型、协作/run/permission/think 模式、附件、计划、Memory/Skills/Env、用量、tool trace、target marker、confirmation、verification、stop/take-over。完整细节见 [`AI_FLOATING_WORKSPACE.md`](AI_FLOATING_WORKSPACE.md)。
 
-**安全**：共享 Provider 不展示 API Key；Env 只显示 hasValue；notes read/write 分权；工具继续由主端 capability registry 执行。
+**能力**：从同版本 Zephyr `ai-capabilities.js`、`ai-extended-capabilities.js` 和真实 model-visible catalog 派生；Connection、Proxy/Key/Jump/Snippet、Terminal、RDP/VNC、Files/SFTP、Notes、Docker、ACL、Web/browser、Memory/Env、Plan、Workspace/attachments、Subagents、Sandbox、原生 UI action 全部对齐，不能维护手机子集。
 
-**离线**：已同步历史可读、草稿可写；发送按钮显示需要联网。
+**可见执行**：observation → proposed action → confirmation → execution → verification 全链在浮窗展示；底层页面高亮 semantic target，终端显示目标 session/range，RDP/VNC 显示 capture/action marker 与 before/after。
+
+**原生桥接**：Web DOM action 替换为 versioned `NativeSurfaceBridge` semantic node/action；旧 surface version/captureId 必须拒绝。业务写操作仍调用 Zephyr canonical service，不通过 UI 模拟绕过 ACL/revision。
+
+**运行**：SSE/stream events；显式停止 run；收起面板不取消；后台中断后按 runId 恢复。AI stream 不得触发 terminal/remote surface 重组。
+
+**返回**：Android back 逐级关闭 picker → 降 detent → 收起 AI → 底层 page pop，动画由 back progress 驱动；iOS panel 内 push 层级支持 interactive swipe-back，左边缘不被 panel drag 吞掉。
+
+**安全**：共享 Provider 不展示 API Key；Env 默认只显示 hasValue；notes read/write 分权；humanOnly secret 能力不进入模型；risk/confirmation/playbook 与 Zephyr 一致。
+
+**离线**：已同步历史可读、草稿可写；发送按钮显示需要联网；正在服务端运行的任务显示最后事件和恢复状态。
 
 ## 20. S45 文件同步
 

--- a/FREEZE/zephyr one for mobile/SCREEN_CATALOG.md
+++ b/FREEZE/zephyr one for mobile/SCREEN_CATALOG.md
@@ -1,0 +1,315 @@
+# Zephyr One 原生逐屏规格与 Zephyr 功能落点
+
+> [KNOWN] 本目录的产品合同要求四入口浮岛、完整移动操作能力、服务器设置、备份恢复和文件同步。
+>
+> [INFERRED] 本文冻结每项 Zephyr 功能在 One 的页面归属，解决“功能要求存在但导航无落点”的问题。
+
+## 1. 根导航
+
+| 根入口 | 一级内容 | 不放入 |
+| --- | --- | --- |
+| 首页 | [KNOWN] 连接库、最近连接、搜索/筛选、活动摘要、同步状态 | [KNOWN] 多用户管理、账号安全 |
+| 会话 | [KNOWN] SSH/Telnet/RDP/VNC 运行会话、断线/恢复、批量任务状态 | [KNOWN] 设置长表单 |
+| 资料 | [KNOWN] SFTP 最近文件、下载、笔记、代码片段 | [KNOWN] SMTP/备案 |
+| 工具 | [KNOWN] AI、远程批量、Docker/监控、Proxy、SSH Key、JumpHost、文件同步、服务器、备份恢复、外观、One 设置 | [KNOWN] 独立 Agent 页 |
+
+- [KNOWN] 服务器设置路径固定为 `工具 → 服务器 → 设置`。
+- [KNOWN] 备份恢复路径固定为 `工具 → 服务器 → 备份与恢复`。
+- [KNOWN] Zephyr Client Token 路径固定为 `工具 → 文件同步 → Client Token`。
+- [KNOWN] Root 浮岛只切换四个目的地；二级功能使用 NavigationStack/Navigation Compose，不新增第五项。
+
+## 2. 全局页面状态合同
+
+[INFERRED] 每个列表/详情/编辑页必须实现：
+
+```text
+initial-loading
+content
+empty
+offline-with-cache
+offline-no-cache
+permission-denied
+not-found-or-revoked
+retryable-error
+fatal-incompatible
+saving-local
+pending-sync
+sync-conflict
+```
+
+- [KNOWN] local-first 保存先提交本地 DB + pending op；按钮完成态写“已保存，待同步”，不能把网络失败说成保存失败。
+- [KNOWN] server-only 操作（登录、Token sensitive action、备份恢复、AI run）必须等服务端确认，不能 optimistic success。
+- [KNOWN] capability 不足的 action 隐藏或禁用并显示原因；服务端拒绝后仍显示稳定错误。
+- [INFERRED] destructive action 使用原生 dialog/sheet，不使用浏览器 prompt/confirm。
+- [INFERRED] 所有错误页包含 requestId 的可复制诊断入口，但默认不显示 secret/host/user/path。
+
+## 3. S01 启动与本地解锁
+
+**入口**：App launch。
+
+**状态**：
+- [KNOWN] App Lock 未开启：直接读取本地镜像。
+- [KNOWN] 已开启：BiometricPrompt/LocalAuthentication，允许平台设备凭据 fallback。
+- [KNOWN] 系统认证不可用：显示设置不可用，不创建 One 专用密码。
+- [INFERRED] 锁定时遮住 app switcher snapshot，清除内存中已解密 secret。
+
+**测试**：成功、取消、锁定、系统无生物识别、回前台立即/1/5 分钟策略、屏幕捕获。
+
+## 4. S02 主端与绑定
+
+**流程页**：服务器地址 → capabilities → 账号密码 → TOTP/CAPTCHA → Token 选择 → 设备名/间隔 → bootstrap。
+
+**字段**：
+- baseUrl：HTTPS/WSS，显式自签证书 pairing。
+- username/password：只在表单生命周期存在。
+- TOTP：账号要求时出现。
+- Client Token：只列当前账号 metadata；零 Token 显示主端创建引导。
+- deviceName：1–120。
+- interval：30 秒～24 小时。
+
+**状态**：invalid URL、TLS untrusted、server too old、CAPTCHA system session、account locked、TOTP exhausted、zero Token、wrong-owner Token、bootstrap progress、bootstrap conflict/failure。
+
+**保存**：绑定成功前不显示“已开启”；首次 bootstrap 完成后才进入文件同步已开启。
+
+## 5. S10 首页/连接库
+
+**顶部**：标题、全局搜索、同步状态按钮、账号菜单。
+
+**内容**：最近连接、协议/标签/ownership/收藏筛选、连接卡片、活动摘要。
+
+**卡片字段**：protocol、name、host:port、tags、remark、owner own/shared、capabilities、pending/conflict、最近连接时间。
+
+**操作**：
+- `use`：连接。
+- `edit`：编辑。
+- owner/create：复制。
+- `delete`：删除。
+- test：临时测试。
+- 临时连接：不保存、session 结束或 TTL 后清理。
+
+**空态**：新建连接、扫描 deep link、从主端同步。
+
+## 6. S11 连接编辑器
+
+**Section 顺序**：
+1. 基础：name/protocol/host/port/username/domain/encoding。
+2. 认证：password、saved SSH key、inline private key/passphrase。
+3. 路由：direct/proxy/jump，jump 有序最多 8 级。
+4. RDP 通道：sound/clipboard/mic/camera/location/storage。
+5. RDP 显示：resolution/quality/fps/touch mode/sensitivity。
+6. 文件同步目录意图：off/ask/local share/server bridge。
+7. Metadata：tags/remark/share/ACL。
+8. 固定操作：测试、保存、不保存直接连接。
+
+**规则**：
+- [KNOWN] masked secret 不回填真实值；“保持不变/替换/清除”三态明确。
+- [KNOWN] 选中的 dependency 必须有 `use`；被撤销时显示“路由需要修复”。
+- [KNOWN] Telnet 清除 SSH key/private key，保留 in-band password 和 proxy/jump。
+- [KNOWN] RDP 枚举和默认值按 `ZEPHYR_PARITY.md`。
+- [INFERRED] 有未保存修改时返回需确认；配置改变 protocol 时只清除不兼容字段，其他字段保留草稿。
+
+## 7. S20 会话列表
+
+**分组**：连接中、已连接、断线可恢复、已最小化、历史任务。
+
+**行项目**：协议、连接名、状态、延迟/时长、sessionId、本地/主端执行、权限变化。
+
+**操作**：恢复、重连、关闭、详情；批量关闭必须确认。
+
+- [KNOWN] 工作区恢复不自动连接、不自动重放命令。
+- [KNOWN] ACL revoked 的 tab 保留说明但不可恢复，reason=`resource_revoked`。
+
+## 8. S21 SSH/Telnet 终端
+
+**布局**：terminal viewport + 快捷键矩阵 + terminal context dock。
+
+**Dock**：键盘、文件、片段、笔记、会话、断开。
+
+**IME**：
+- [KNOWN] 打开时隐藏 root 浮岛/context dock；快捷键矩阵贴 IME；viewport resize；PTY rows/cols 同步。
+- [KNOWN] CJK composition 期间不滚，commit 后最多一次校正。
+- [KNOWN] 用户上滑阅读时远端输出不抢滚动；在底部时保持跟随。
+- [KNOWN] 唯一 surface controller 处理 tap/input/composition/enter/output/viewport。
+
+**Telnet 差异**：明文警示；encoding；无 SFTP dock；auto-login 状态。
+
+## 9. S22 RDP
+
+**Surface**：全屏原生渲染；悬浮工具条按触控显示/隐藏。
+
+**工具**：键盘、direct/relative touch、剪贴板、声音、分辨率、文件 drive、证书、重连、断开。
+
+**权限**：会话真正请求麦克风/摄像头/位置/文件时再申请；拒绝单通道不退出会话。
+
+**证书页**：subject、issuer、validity、SHA-256 fingerprint、首次/已变更；变化默认阻断。
+
+**文件 drive**：显示 profile、授权有效性、最终只读值；只读 provider 层执行。
+
+## 10. S23 VNC
+
+**工具**：键盘、指针模式、缩放、剪贴板、画质/颜色、重连、断开。
+
+**错误**：认证失败、unsupported security type、证书/TLS 扩展不可用、pixel format unsupported；禁止未知弱模式自动降级。
+
+## 11. S30 资料首页
+
+**入口卡片**：文件、笔记、代码片段、下载。
+
+**最近文件**只显示用户主动浏览/下载 metadata；路径默认不进 telemetry。
+
+## 12. S31 SFTP 文件管理
+
+**结构**：连接选择 → breadcrumb → 文件列表/网格 → preview/editor。
+
+**操作与 capability**：list/stat/read/download=`fileRead`；upload/new/edit/rename/delete=`fileWrite`。
+
+**状态**：连接断开、权限撤销、目录不存在、编码、下载暂停/继续、mtime conflict、hash mismatch。
+
+**编辑器**：读取时记录 mtime/hash；保存冲突打开 compare/另存/覆盖确认；不静默覆盖。
+
+## 13. S32 笔记
+
+**手机**：列表 → 全屏编辑；平板：group/list/editor 多栏。
+
+**功能**：搜索、group/tag/filter、Markdown 编辑/预览、关联连接、分享、AI read/write、回收站、导入/导出、bulk。
+
+**限制**：标题 200、正文 1 MiB、标签 100、关联 100、bulk 200。
+
+**冲突**：显示 base/local/server，支持三方 merge、保留本机、服务端、复制为新笔记。
+
+## 14. S33 代码片段
+
+**字段**：name 60、command 20000、group 40、autoRun，最多 500。
+
+**操作**：编辑、删除、复制、插入当前终端、执行。
+
+- [KNOWN] 插入不需要 execute；实际执行需要 connection `execute`，危险命令仍经确认策略。
+- [INFERRED] 删除进入同步 tombstone；不整包覆盖其他设备新增的 snippet。
+
+## 15. S40 工具首页
+
+**Section**：
+- 远程操作：批量执行、Docker、监控、日志。
+- 资源：Proxy、SSH Key、JumpHost。
+- AI。
+- 文件同步。
+- 服务器：设置、备份与恢复、运行状态。
+- One：外观、语言、本地解锁、网络、诊断。
+
+## 16. S41 批量执行
+
+**字段**：SSH targets、command、timeout 1–300 秒、concurrency 默认 4、fail-fast。
+
+**结果**：逐主机 status/stdout/stderr/exit code/duration/cancel；denied target 独立显示，不因一台失败取消全部，除非 fail-fast。
+
+**安全**：每个 target 要 `execute`；命令审计只保存截断 metadata，不把秘密/stdout 整段塞进核心 sync。
+
+## 17. S42 Docker/监控/日志
+
+**入口**：选择有 `use/observe/control` 能力的 SSH connection。
+
+**页面**：Docker status/containers/images/logs；CPU/memory/disk/network；服务日志 tail/search/export。
+
+**操作映射**：observe 只读；control 可 start/stop/restart；execute 才允许任意命令。
+
+**离线**：显示最后 snapshot 时间，不把旧值说成实时。
+
+## 18. S43 Proxy / SSH Key / JumpHost
+
+- Proxy：name/host/port/type/username/password，默认 SOCKS5:1080。
+- SSH Key：name/privateKey/passphrase/remark，secret 三态编辑。
+- JumpHost：name + SSH connection dependency。
+
+**共同**：owner/shared/capability、revision conflict、share sheet、依赖引用删除保护。
+
+## 19. S44 AI
+
+**页面**：会话列表、聊天、Provider/模型选择、附件、计划/Memory/Skills/Env、运行权限确认。
+
+**运行**：SSE/stream events；取消 run；permission 请求用原生 confirmation sheet；后台中断后可按 runId 恢复事件。
+
+**安全**：共享 Provider 不展示 API Key；Env 只显示 hasValue；notes read/write 分权；工具继续由主端 capability registry 执行。
+
+**离线**：已同步历史可读、草稿可写；发送按钮显示需要联网。
+
+## 20. S45 文件同步
+
+**主卡**：总开关、automatic 开关、目标间隔、网络策略、立即同步、当前 phase/实体/字节进度、上次尝试/成功、冲突、错误。
+
+**二级**：
+- 绑定详情。
+- 冲突中心。
+- One 设备。
+- Client Token。
+- 本机共享目录/文件桥接。
+- 诊断。
+
+**操作规则**：automatic 关闭仍允许立即同步；解绑前敏感验证；“暂停”不删镜像；“解绑并删本地镜像”先 revoke 后清本机。
+
+## 21. S46 Client Token
+
+**列表**：name/id/created/updated/lastUsed/关联 One/旧 Agent 数；secret 默认隐藏。
+
+**操作**：创建、改名、查看、复制、旋转、删除、重置全部。
+
+**敏感门**：查看/旋转/删除/重置需要当前密码或 TOTP；grant 单次、action+target 绑定。
+
+**影响预览**：旋转/删除前列出会断开的 One/Agent；重置全部要求二次确认但不能替代敏感验证。
+
+## 22. S47 文件桥接与本机共享
+
+**Profile**：displayName、目录授权、readOnly、enabled、autoStart、idle timeout、生命周期。
+
+**Android**：SAF tree；持续在线需前台服务+通知停止 action。
+
+**iOS**：DocumentPicker/security-scoped bookmark；离开 App 后桥接可能暂停，页面明确提示。
+
+**状态**：授权有效/失效、在线、传输字节、打开 handle、最近错误、手动停止。
+
+## 23. S48 服务器设置
+
+**只显示**：当前账号有权限且 One 有用途的 appearance、notes、AI runtime 可用性、版本/能力/运行状态。
+
+**不显示**：账号安全、SMTP、CAPTCHA/IP、防爆破、备案、自定义 CSS/JS、多用户。
+
+**role 状态**：普通用户看到只读公共/effective 设置；admin/super-admin 按服务端授权显示可编辑 section。
+
+## 24. S49 备份与恢复
+
+**导出**：说明范围/加密算法/版本 → 生成 → 系统保存位置 → SHA-256/大小/时间结果。
+
+**导入**：系统文件选择 → 文件 metadata → 当前登录密码 + backup password → 影响确认 → 上传/服务端验证 → 导入/重启 → 所有 One 重新绑定/bootstrap 提示。
+
+**失败**：错误密码、包损坏、缺 DB、key 不匹配、迁移失败、服务重启失败；明确显示“原数据已回滚/未改动”。
+
+## 25. S50 外观与 One 设置
+
+**外观**：auto/light/dark、Frost/Lava/Asagi/Cyber、terminal background/font、RDP 手势默认。
+
+**One**：语言、App Lock、锁定延迟、截图保护、蜂窝策略、下载目录、诊断日志导出、版本/许可证。
+
+**不提供**：One 自建登录密码、账号找回、主端安全策略编辑。
+
+## 26. 无障碍和设备矩阵
+
+- [COMMON] Android 命中区至少 48dp；iOS 至少 44pt。
+- [INFERRED] TalkBack/VoiceOver 顺序：页面标题 → 状态 → 主内容 → 主操作 → 浮岛；选中浮岛项报告 selected。
+- [INFERRED] 图标按钮必须有 action label；状态不能只靠颜色；进度使用可读百分比/实体计数。
+- [INFERRED] 动态字体最大档不截断 destructive action；浮岛极窄时隐藏可见文字但保留 accessibility label。
+- [INFERRED] Reduce Motion 取消位移 spring，保留 120ms crossfade。
+- [INFERRED] 覆盖中文/英文、RTL 准备、浅/深、四色、横/竖、手机/平板、刘海/手势安全区。
+
+## 27. 页面完成门
+
+[KNOWN] 每屏只有在以下全部满足后可标记 implemented：
+
+1. 原生 UI 与所有状态。
+2. ViewModel/Observable state 单向流。
+3. Repository 接入真实 Zephyr service/mobile API。
+4. 本地镜像与 SecretStore。
+5. capability/role gate。
+6. structured error。
+7. Android unit + Compose UI。
+8. iOS unit + XCUITest/SwiftUI inspection。
+9. 至少一台目标平台真机。
+10. `TRACEABILITY.md` 对应测试证据。

--- a/FREEZE/zephyr one for mobile/SHARED_RESOURCE_RESIDENCY.md
+++ b/FREEZE/zephyr one for mobile/SHARED_RESOURCE_RESIDENCY.md
@@ -1,0 +1,151 @@
+# Zephyr One 共享资源零驻留与按次使用合同
+
+> [KNOWN] 本合同适用于“其他用户拥有、通过 Zephyr ACL 分享给当前绑定账号”的资源。绑定账号自己拥有的资源仍按完整双向镜像合同处理。
+>
+> [KNOWN] 核心原则：共享资源不加入 One 的本地镜像，不写本地业务 DB、SecretStore、搜索索引、系统备份、日志、通知正文、诊断包或离线导出；每次查看/使用都在线向 Zephyr 请求并重新检查 ACL。
+>
+> [KNOWN] 共享资源的 `use/view/fileRead` 从不等于 `revealSecret`。Client Token、Zephyr SID/refresh、设备私钥、服务器 data key、AI Provider API Key、AI Env secret、共享资源 owner 的 Token 与管理凭据绝不作为共享 payload 下发。
+
+## 1. 安全事实与术语
+
+- [KNOWN] TLS + device envelope 能保护网络传输；不能让已在 One 进程中解密的明文免受 root/jailbreak、进程注入、内存 dump、恶意键盘或屏幕捕获。
+- [KNOWN] “用完即焚”在移动进程里只能是 **best-effort memory zeroization + 不持久化 + 短寿命**，不能被描述为数学上保证秘密从未出现在设备。
+- [KNOWN] 如果资源拥有者要求连接秘密绝不进入 One，唯一符合语义的方案是 Zephyr 主端代执行/relay；native direct connection 与“秘密不进入设备”不能同时成立。
+- [INFERRED] `Owned mirror`：`ownerUserId == boundUserId`，可进入完整 sync。
+- [INFERRED] `Shared reference`：只由在线响应短暂呈现的 `resourceType/resourceId/displayName/ownerDisplayName/capabilities/revision/expiresAt`，不得持久化。
+- [INFERRED] `Use envelope`：给单个 device、session、resource、purpose 的短时加密连接材料；不含控制面 secret。
+- [INFERRED] `Server relay`：Zephyr 解密并持有 secret，One 只发送输入/动作并接收输出/画面/脱敏结果。
+
+## 2. 同步与本地驻留边界
+
+### 2.1 Mobile sync
+
+- [KNOWN] `/sync/bootstrap`、`/sync/changes` 和 `/sync/push` 只处理当前绑定用户**拥有**的实体；shared-to-me 不进入 entity pages、change feed、tombstone、opaque snapshot 或 local search。
+- [KNOWN] `resourceAcl` 只同步当前用户自己拥有资源的 ACL 管理状态；“别人分享给我”的 grant 不进入镜像，只在在线 shared API 返回。
+- [KNOWN] 服务端 sync adapter 对每个 entity 强制 `ownerUserId == authenticated userId`；不能相信客户端请求里的 ownerId。
+- [KNOWN] One apply transaction 二次检查 owner；不等于 bound user 时返回/记录 `shared_residency_violation`，整页不推进 cursor，并删除该意外 row 的任何临时文件。
+- [KNOWN] shared metadata 也不进入 Room/GRDB、FTS、recent、shortcut、widget、handoff、Spotlight/AppSearch、系统 clipboard history 或备份。
+- [INFERRED] UI 的“最近共享”只能在当前进程内短暂保存 resource id 与显示文本，锁屏、账号切换、memory warning、后台超时或进程结束即丢弃；重新进入必须请求主端。
+
+### 2.2 在线共享目录 API
+
+[INFERRED] 新建只读在线接口，不复用 sync：
+
+```text
+GET  /api/mobile/v1/shared?type=&cursor=
+GET  /api/mobile/v1/shared/{resourceType}/{resourceId}
+POST /api/mobile/v1/shared/{resourceType}/{resourceId}/invoke
+POST /api/mobile/v1/shared/connections/{connectionId}/sessions
+POST /api/mobile/v1/shared/sessions/{sessionId}/refresh
+DELETE /api/mobile/v1/shared/sessions/{sessionId}
+```
+
+- [INFERRED] 每次请求绑定 `userId + deviceId`，重新计算 user status、role ceiling、grant expiry/revoke、resource revision 和 dependency ACL。
+- [KNOWN] 404 合并“不存在/无权”，防止枚举；撤销/过期不能靠缓存延迟。
+- [INFERRED] 列表响应 `Cache-Control: no-store, private`，没有稳定离线 cursor；分页 token 只对短快照有效。
+
+## 3. 共享连接：原生直连与严格 relay
+
+### 3.1 Session open
+
+[INFERRED] One 请求：
+
+```json
+{
+  "mode": "direct-ephemeral | relay-strict",
+  "clientSessionNonce": "base64url-128bit+",
+  "requestedChannels": ["terminal", "clipboard", "audio", "drive"],
+  "deviceKeyVersion": 1
+}
+```
+
+Zephyr 必须：
+
+1. [KNOWN] 校验当前账号 `use`；根据协议校验 `observe/control/execute/fileRead/fileWrite`。
+2. [KNOWN] 服务端解析 Connection、Proxy、SSH Key、JumpHost 依赖并逐项检查 owner/use，沿用 `ResourceService.resolveForConnect` 语义。
+3. [INFERRED] 为 `deviceId + sessionId + resourceId + revision + purpose + nonce + expiresAt` 生成一次 session grant。
+4. [INFERRED] direct 模式把最小连接材料封装成 device-bound use envelope；relay 模式不返回秘密。
+5. [KNOWN] 写审计：actor、owner、resource、mode、capabilities、device、时间、结果；不记 host password/key/token。
+
+### 3.2 Direct-ephemeral use envelope
+
+- [INFERRED] 只允许 SSH/Telnet/RDP/VNC 原生 core 建立该次连接所需的最小字段：endpoint、username、password/private key/passphrase、domain、proxy/jump chain、host/cert policy。
+- [KNOWN] 不包含 Client Token、AI Provider Key、Env secret、Zephyr data key、owner SID、refresh token、resource edit payload 或 `revealSecret` 数据。
+- [INFERRED] envelope 使用 `ML-KEM-768+HKDF-SHA256+AES-256-GCM`，AAD 额外绑定 `shared-use-v1/serverId/userId/deviceId/sessionId/resourceId/revision/purpose/expiresAt/clientNonce`。
+- [INFERRED] TTL 默认 30 秒用于开连；单次成功消费后不能重新下载。网络握手需重试时由仍有效 session grant 重新签发新 nonce envelope，而不是缓存旧密文。
+- [KNOWN] One 不把 envelope 或明文写 Room/GRDB、KeyStore/Keychain、文件、preferences、logs、crash breadcrumbs、analytics、clipboard 或 saved state。
+- [INFERRED] native `SessionSecretArena` 使用可锁页/guarded memory 时启用；避免不可控 String/Swift String/Kotlin String，使用 mutable byte buffer；解密后只把 scoped view 交 adapter。
+- [INFERRED] handshake 完成即清零不再需要的密码/key bytes；session core 内部复制必须审计。断开、失败、取消、后台超时、memory warning、账号锁定、ACL revoke 都触发销毁。
+- [KNOWN] GC/ARC、第三方 native library 和 OS swap 使绝对清零不可证明；UI 必须称“仅本次会话、不会保存”，不能称“设备从未获得秘密”。
+
+### 3.3 Relay-strict
+
+- [INFERRED] SSH/Telnet：Zephyr 主端建立 upstream，One 通过 device-authenticated multiplexed stream 传 PTY input/resize，接收 output/exit；凭据不离开主端。
+- [INFERRED] RDP/VNC：复用/扩展主端 remote proxy，把图形、输入、音频、剪贴板按 capability 转发；owner 可对 clipboard/file/audio/mic/camera/location 设置 channel policy。
+- [INFERRED] relay credential 与 session/device/resource/capability/expiry 绑定；不是 Client Token，不可访问其他资源。
+- [KNOWN] relay 仍会把终端输出、远程画面和用户传输内容带到 One；“秘密不下发”不等于“会话内容不敏感”。One 不持久化 shared transcript/frame/clipboard。
+- [INFERRED] owner policy 可强制 relay；One 用户不能降级到 direct。relay 不可用时明确报错，不能静默下发 secret。
+
+## 4. 共享 AI：只请求主端代执行
+
+- [KNOWN] Zephyr AI runtime、Provider API Key、Env secret、Memory/Skills、tool execution 和 shared resource secret 保留在 Zephyr 主端；One 是原生浮窗 client，不在设备本地重建 shared AI execution。
+- [KNOWN] 每次 AI run/continue/tool confirm 都携带 device access、runId、当前 context reference；Zephyr 主端重新校验当前账号、provider/model visibility、AI permission、resource ACL、note allowAiRead/Write 和 tool capability。
+- [KNOWN] One 收到的只是 stream event、脱敏 tool trace、confirmation、result/verification 和用户有权看的内容；不得收到 Provider key、Env value、Client Token 或工具内部 resolved credentials。
+- [KNOWN] 共享 Connection/Proxy/Key/JumpHost 的 AI 操作由主端 canonical tool/service 执行；`use` 允许主端连接，不允许 AI 或 One 获取 `revealSecret`。
+- [KNOWN] `ui_action` 在 One 通过 `NativeSurfaceBridge` 操作当前设备 UI，但 action 仍由主端签发 scoped intent、One 本地 capability check、用户 confirmation 三层约束；不得附带共享 secret。
+- [INFERRED] AI conversation/message 若包含共享笔记正文、终端输出、remote capture 或文件内容，默认只保存在主端 canonical conversation；One 仅按页在线读取，内存中虚拟化呈现，锁屏/后台超时清除已加载 page。
+- [INFERRED] 用户主动复制、导出、下载 AI 结果属于明确的人为数据外流动作，需显示共享来源和 owner policy；默认关闭 shared content 自动进入系统剪贴板/文件。
+
+## 5. 共享笔记：主端授权读取，不落本地镜像
+
+- [KNOWN] shared note 不进 mobile sync，不写本地 note table/FTS/草稿恢复/系统搜索/Widget；列表和正文每次从 Zephyr 请求。
+- [KNOWN] 打开正文要求实时 `view`；编辑要求 `edit` + expectedRevision；AI 读取/写入还要求 note 的 `allowAiRead/allowAiWrite`。撤销/过期后下一请求立即 404/forbidden，不展示离线副本。
+- [INFERRED] 正文仅驻留当前 viewer/edit session 的 mutable memory buffer；离页、保存/取消、锁屏、后台超时、memory warning、账号切换、ACL revoke 即清除。
+- [INFERRED] shared draft 不写数据库。网络中断时保留在内存并显示“未保存”；App 被系统杀死可能丢失，这是零驻留的明确取舍。
+- [KNOWN] 编辑保存必须主端 canonical `NotesService.update(expectedRevision)`；冲突时重新拉取主端版本，不能把 shared note 拷成当前用户 owned note 来偷偷保留。
+- [INFERRED] owner policy 可禁止 copy/share/screenshot/export；One 在能力可控范围内执行 FLAG_SECURE/敏感屏幕、隐藏系统 preview、禁用 UI action，但不能声称阻止外部摄像。
+
+## 6. 其他共享资源
+
+| 资源 | One 可短暂显示/使用 | 永不落地/永不下发 |
+| --- | --- | --- |
+| Connection | 脱敏 metadata、capabilities、会话状态 | shared row、密码/key；direct 例外仅 session arena |
+| Proxy/SSH Key/JumpHost | 名称/依赖状态；主端解析 | secret、完整 private key、passphrase |
+| Note | 按页正文、内存 draft | DB/FTS/offline/cache/backup |
+| Terminal session | live output/input/exit；内存 scrollback | transcript、command history、credential |
+| RDP/VNC | live framebuffer、pointer state | screenshot/frame cache、clipboard history、credential |
+| SFTP/Agent file | 按次 list/read stream | 自动下载、thumbnail/index；用户主动保存需显式授权 |
+| Docker/monitor/log | live query/result | shared log archive、connection secret |
+| AI | events/trace/result/confirmation | provider key、env secret、resolved credential、local shared conversation mirror |
+| ACL grant | 在线 capability/expiry/owner display | 本地 ACL mirror；当前用户不是 owner 时不可管理 |
+
+[KNOWN] OS 为当前显示创建的 compositor surface、keyboard buffer、socket buffer 不等于产品持久化，但必须启用平台合理保护：敏感窗口/scene preview 遮挡、日志脱敏、crash dump 排除、pasteboard 过期/本地 only（用户主动复制时）。
+
+## 7. 生命周期与撤销
+
+- [INFERRED] 每个 shared viewer/session 注册 revoke channel；Zephyr 在 grant revoke、owner delete、user suspend、device revoke、Token reset 时推送 terminate。
+- [KNOWN] push 只是加速；每个操作仍在主端实时授权，不能依赖“没收到 revoke 所以继续用”。
+- [INFERRED] One 收到 revoke 后：停止输入/stream、销毁 session key/arena、清 shared UI state、退出 viewer，并只留下不含资源内容的本次安全事件。
+- [INFERRED] App 切后台：shared note/AI page 立即遮挡；短 grace 后清；direct terminal 是否保持由 owner policy 决定，但 secret arena 只保留协议 core 仍需要的最小 session key，非握手密码。
+- [KNOWN] 账号解绑、切换 server、App Lock 触发、设备撤销必须清空所有 shared in-memory session，无 shared 数据迁移到新账号。
+
+## 8. 审计、错误和 UX
+
+- [KNOWN] shared row 明确显示“来自 <owner> · 在线使用 · 不保存到此设备”；离线时不展示旧内容，给出重新连接动作。
+- [KNOWN] direct 模式显示“连接材料仅本次会话送达设备，不会保存”；relay 显示“凭据保留在主端”。不能把两者混成同一句安全承诺。
+- [INFERRED] 稳定错误：`shared_online_required`、`shared_grant_expired`、`shared_grant_revoked`、`shared_residency_violation`、`shared_direct_forbidden`、`shared_session_expired`、`shared_session_consumed`、`shared_relay_unavailable`、`shared_content_export_forbidden`。
+- [KNOWN] 审计记录 access/use/edit/AI invoke/export/relay/direct mode、device、结果和 byte count；不记录正文、终端输出、frame、文件内容或 secret。
+
+## 9. 测试和发布门
+
+1. [KNOWN] 构造 shared Connection/Note/ACL 后跑 bootstrap/changes，本地实体页必须为零；owner entity 仍正常同步。
+2. [KNOWN] 服务端故意注入 owner 不匹配实体，One apply 拒绝且 cursor 不推进。
+3. [KNOWN] grep/SQL/FTS/KeyStore/Keychain/preferences/files/log/crash/backup/notification/clipboard 检查均找不到 shared canary。
+4. [KNOWN] direct envelope 错 device/session/resource/revision/purpose/nonce/expiry 全部解密或消费失败；重复消费失败。
+5. [KNOWN] native arena 在 connect success/failure/cancel/revoke/background/memory warning 路径都执行销毁；instrumented allocator 检查已知 buffer 清零，同时文档承认第三方/OS copy 不能绝对证明。
+6. [KNOWN] relay 模式抓包/客户端 hook 不出现 password/private key/provider key/env value/client token；主端 revoke 立即断流。
+7. [KNOWN] shared note 离线不可读、进程重启不可恢复、编辑冲突不生成 owned copy。
+8. [KNOWN] AI 主端执行 shared tool，One 只收到脱敏 trace/result；catalog parity 不因此删 tool。
+9. [KNOWN] 用户主动下载/复制/export 必须有明确 action、capability、owner policy 和审计；没有后台自动外流。
+
+任一 shared-to-me 资源进入 One 镜像、shared secret 进入持久存储、AI Provider/Env/Client Token 下发、ACL 撤销后仍可从缓存使用、或将 direct 模式虚假描述为“秘密未到设备”，均为发布阻断。

--- a/FREEZE/zephyr one for mobile/SYNC_STATE_MACHINE.md
+++ b/FREEZE/zephyr one for mobile/SYNC_STATE_MACHINE.md
@@ -1,0 +1,254 @@
+# Zephyr One 完整双向同步状态机
+
+> [KNOWN] Zephyr 业务语义来源：`resource-service.js`、`notes-service.js`、`authz.js`、`workspace-service.js`、`user-settings-service.js`、`file-agent-manager.js`。
+>
+> [INFERRED] 本文冻结 mobile v1 的客户端顺序、持久化点和崩溃恢复；它替换 `DEVELOPMENT.md` 中分散的 bootstrap/push/pull 描述。
+
+## 1. 持久状态
+
+```text
+UNBOUND
+BOUND_NEEDS_BOOTSTRAP
+BOOTSTRAPPING
+CATCHING_UP
+IDLE
+RUNNING
+CONFLICTED
+REAUTH_REQUIRED
+REVOKED
+FATAL_INCOMPATIBLE
+```
+
+[INFERRED] DB 中按 `(serverId, userId, deviceId)` 保存：
+
+```text
+bindingState
+registryHash
+bootstrapId / bootstrapPageToken / bootstrapSnapshotCursor
+appliedCursor / acknowledgedCursor
+activeRunId / activeRunStartedAt
+lastAttemptAt / lastSuccessAt / lastError
+rerunRequested
+```
+
+[KNOWN] access/refresh credential、设备私钥和业务 secret 不放该表，只存 SecretStore 引用。
+
+## 2. 运行时阶段
+
+```text
+VALIDATE_BINDING
+RECOVER_BOOTSTRAP
+BOOTSTRAP_PAGE
+CATCH_UP_PULL
+PUSH_PENDING
+PULL_CHANGES
+APPLY_BLOBS
+ACK_CURSOR
+COMMIT_SUCCESS
+```
+
+- [INFERRED] 同一 binding 同时只能有一个 actor；新触发只写 `rerunRequested=true`。
+- [INFERRED] 每轮结束后若 rerunRequested=true，清 flag 并再跑一轮；连续触发最多形成“当前轮 + 一次尾随轮”。
+- [INFERRED] 手动同步不受 automaticEnabled 影响；只受绑定是否 live 影响。
+
+## 3. 首次绑定顺序
+
+```text
+1 VALIDATE_BINDING / registry
+2 BOOTSTRAP_PAGE until complete
+3 persist snapshotCursor and mark BOUND snapshot installed
+4 CATCH_UP_PULL from snapshotCursor until hasMore=false
+5 PUSH_PENDING collected during bootstrap
+6 PULL_CHANGES again until hasMore=false
+7 APPLY_BLOBS
+8 ACK_CURSOR
+9 COMMIT_SUCCESS → IDLE
+```
+
+- [INFERRED] bootstrap 使用服务端固定 `snapshotCursor`；分页中途产生的新变化留在 change feed，不混入后续 bootstrap 页。
+- [INFERRED] bootstrap 每页包含稳定 `bootstrapId` 和不可伪造 `nextPageToken`；token 默认 30 分钟过期，过期从空本地 staging 表重新开始。
+- [INFERRED] bootstrap 写入 staging tables，不逐页污染 live mirror；complete 页到达后在一个本地事务中切换 generation。
+- [INFERRED] bootstrap 期间本地新建/编辑只写 live overlay + PendingOperation，不发送；切换 generation 时 overlay 覆盖 staging 的同 entity，并保留其 baseRevision。
+- [INFERRED] 首次必须先 catch-up 再 push，防止在陈旧 snapshot 上提交；push 后再次 pull，保证包含服务端给本设备生成的 canonical revision。
+
+## 4. 普通同步顺序
+
+```text
+1 VALIDATE_BINDING / registry
+2 PUSH_PENDING (dependency topology, max 200 ops/batch)
+3 PULL_CHANGES until hasMore=false
+4 APPLY_BLOBS
+5 ACK_CURSOR
+6 COMMIT_SUCCESS
+```
+
+[INFERRED] 普通轮次先 push 是为了缩短本地编辑可见时间；`baseRevision` 和服务端 conflict 判定保证它不会覆盖未知远端编辑。若服务端返回 `cursor_expired`，立即转 `BOUND_NEEDS_BOOTSTRAP`，不得继续 push。
+
+## 5. 本地写入事务
+
+```text
+BEGIN IMMEDIATE
+  read current entity + revision
+  validate local field constraints
+  write optimistic local entity
+  insert PendingOperation(opId, entityType, entityId, action,
+                          baseRevision, fieldMask, payload,
+                          createdAt, attemptCount=0)
+COMMIT
+signal sync actor
+```
+
+- [KNOWN] `fieldMask` 只包含用户实际修改的 editable fields；masked secret、serverAuthority、opaque 和 deviceLocal 字段不能出现。
+- [INFERRED] 同实体未发送操作可折叠：create+updates → one upsert；create+delete → remove both；updates → merge masks keeping oldest baseRevision；delete dominates later stale edits。
+- [INFERRED] 已发送但结果未知的 op 不生成新 opId 重试；必须以原 opId 重放。
+
+## 6. 服务端 push 事务
+
+```text
+BEGIN IMMEDIATE
+  lookup mobile_applied_ops(ownerUserId, deviceId, opId)
+  if exists → return stored logical result
+  validate binding, registry, entity, capability, fieldMask
+  load current entity + revision + field_revision_map
+  decide accept / merge / conflict / dependency_missing / reject
+  call canonical Zephyr business service
+  write entity revision + field revision entries
+  insert mobile_sync_changes in same transaction
+  insert mobile_applied_ops(result)
+COMMIT
+```
+
+- [KNOWN] 不允许 mobile sync 直接绕开 service 写业务表。
+- [INFERRED] `mobile_applied_ops` 至少保留“最大允许离线重试期 + 30 天”，首版冻结为 180 天；保留期变更必须同步 capabilities。
+- [INFERRED] op 结果包含完整逻辑结果；重放 100 次返回同 status/revision/changeSeq，不重复审计、通知或 Token 旋转。
+
+## 7. 字段合并需要的数据
+
+[INFERRED] 服务端增加：
+
+```sql
+CREATE TABLE mobile_entity_field_revisions (
+  owner_user_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  field_path TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  PRIMARY KEY (owner_user_id, entity_type, entity_id, field_path)
+);
+
+CREATE INDEX idx_mobile_field_revision_entity
+ON mobile_entity_field_revisions(owner_user_id, entity_type, entity_id, revision);
+```
+
+[INFERRED] 判定：
+
+```text
+baseRevision == currentRevision → accept
+baseRevision > currentRevision → reject invalid_revision
+baseRevision < tombstoneRevision → conflict(delete wins)
+any incoming field has fieldRevision > baseRevision → conflict
+otherwise → merge patch onto current canonical entity
+```
+
+- [INFERRED] object/array 默认作为一个原子 field path；只有 registry 明确声明可拆分时才允许 `rdp.quality` 这类子路径。
+- [KNOWN] secret 字段原子冲突；Note content、route dependency、ACL 和 Token secret 不做静默 last-write-wins。
+
+## 8. Change feed 应用
+
+```text
+BEGIN IMMEDIATE
+  assert page.fromCursor == appliedCursor
+  for change ordered by changeSeq:
+    verify entity registry and ACL projection
+    if revision <= local serverRevision: skip canonical body, keep overlay
+    else apply upsert/tombstone to mirror
+    rebase or conflict pending local operations
+  appliedCursor = page.nextCursor
+COMMIT
+```
+
+- [INFERRED] cursor 与一页业务变更处于同一事务；崩溃只能发生在“整页都没提交”或“整页和 cursor 都提交”。
+- [INFERRED] 自己 push 的 change 仍会进入 feed；按 revision/changeSeq 去重，不依赖服务端过滤 actorDeviceId。
+- [KNOWN] ACL 撤销 change 优先应用：立即移除 secret、终止对应会话授权、将工作区 tab 标记 `resource_revoked`。
+- [INFERRED] 不认识的 entityType 在最低兼容版本内是 fatal registry mismatch；已声明 opaque 类型保存原始 canonical JSON，不开放编辑。
+
+## 9. 冲突
+
+| 类型 | 处理 |
+| --- | --- |
+| [KNOWN] revision/field overlap | [INFERRED] 本地记录 conflict；保留 server、本地和 base 三份 |
+| [KNOWN] Note content | [INFERRED] 可尝试三方文本合并；失败生成冲突副本 |
+| [KNOWN] Secret | [INFERRED] 不自动拼接；选择一侧后重新 envelope |
+| [KNOWN] Delete vs edit | [INFERRED] tombstone 胜；恢复作为新 revision，不撤销历史删除 |
+| [KNOWN] ACL | [KNOWN] 服务端权限权威；不能“保留本机”覆盖撤销 |
+| [KNOWN] append-only Activity | [KNOWN] eventId 去重，无可编辑冲突 |
+| [KNOWN] Token rotate/delete | [INFERRED] 服务端事务权威；受影响 binding 立即失效 |
+
+[INFERRED] UI 操作：使用服务端、保留本机、复制为新项、手工合并。每个选择产生新的 opId 和当时最新 baseRevision；不能修改旧冲突 op 的身份后重放。
+
+## 10. Tombstone 和 retention
+
+- [KNOWN] Note 已有 soft delete/restore；其他业务实体目前多为 hard delete，mobile v1 上线前必须加 tombstone。
+- [INFERRED] tombstone 至少保存 `entityType/entityId/ownerUserId/deletedRevision/deletedAt/deletedBy/lastKnownName`，不保存秘密。
+- [INFERRED] 首版 tombstone retention 冻结为 180 天，且不得短于 capabilities 声明的最大离线窗口。
+- [INFERRED] 设备 `lastAckedCursor` 早于即将 GC 的最老 change 时，设备下次同步必须收到 `cursor_expired` 并重新 bootstrap。
+- [INFERRED] 永久删除敏感实体的物理清理和 change/tombstone GC 分离；审计只留非秘密 metadata。
+
+## 11. Blob
+
+- [INFERRED] 大附件/备份不进入 JSON change payload；实体只携带 content-addressed manifest：`sha256,size,mime,chunks,encrypted`。
+- [INFERRED] chunk 默认 4 MiB，服务端 capabilities 可下调；每块校验 SHA-256，最终校验整 blob。
+- [INFERRED] 上传使用稳定 uploadId 和幂等 chunk index；断线只补缺块。
+- [INFERRED] 下载先写临时文件，整体验证后原子 rename；错误 hash 删除临时文件并返回 `blob_hash_mismatch`。
+- [KNOWN] local SAF URI/iOS bookmark 是 deviceLocal，只同步“需要该文件/目录”的产品意图。
+
+## 12. 崩溃恢复矩阵
+
+| 崩溃位置 | 重启行为 |
+| --- | --- |
+| [INFERRED] 写 entity 前 | 无状态，重新执行用户操作 |
+| [INFERRED] entity 与 pending op 事务中 | SQLite 回滚，两者都不存在 |
+| [INFERRED] push 已发、响应未存 | 用同 opId 重放，服务端返回首次结果 |
+| [INFERRED] 服务端业务写后、change 前 | 禁止出现；同一事务回滚 |
+| [INFERRED] change page 应用中 | 本地事务回滚，重拉同页 |
+| [INFERRED] page commit 后、ack 前 | 从 persisted appliedCursor 继续，ack 可重放 |
+| [INFERRED] bootstrap staging 中 | 用 bootstrapId/pageToken 恢复；过期清 staging 重来 |
+| [INFERRED] blob 分块中 | 查缺块续传，不重传已验证块 |
+| [INFERRED] Token rotation 请求未知 | 原 grant/opId 查询结果；禁止直接再旋转一次 |
+
+## 13. 状态转移
+
+| 当前 | 事件 | 下一状态 |
+| --- | --- | --- |
+| `UNBOUND` | bind success | `BOUND_NEEDS_BOOTSTRAP` |
+| `BOUND_NEEDS_BOOTSTRAP` | run | `BOOTSTRAPPING` |
+| `BOOTSTRAPPING` | snapshot complete | `CATCHING_UP` |
+| `CATCHING_UP` | pull/push/pull success | `IDLE` |
+| `IDLE` | trigger | `RUNNING` |
+| `RUNNING` | success | `IDLE` |
+| `RUNNING` | conflict only | `CONFLICTED`（同步其余实体继续） |
+| any bound | SID expired | 数据面不变；管理面要求登录 |
+| any bound | refresh invalid/token missing | `REAUTH_REQUIRED` |
+| any bound | device revoked/account unavailable | `REVOKED` |
+| any bound | protocol/registry incompatible | `FATAL_INCOMPATIBLE` |
+| `CONFLICTED` | all conflicts resolved | `IDLE` |
+| `REAUTH_REQUIRED` | successful rebind | `BOUND_NEEDS_BOOTSTRAP` |
+
+## 14. 调度
+
+- [KNOWN] interval 范围 30 秒～24 小时。
+- [KNOWN] 前台按用户目标精确触发；后台由系统调度，UI 同时显示“目标间隔”和“实际上次同步”。
+- [INFERRED] Android 15 分钟及以上使用 periodic WorkManager；更短后台间隔只有用户明确开启持续同步时使用 foreground service。
+- [COMMON] iOS BGTask 不保证固定间隔；短间隔仅前台有效，后台靠 BGAppRefresh/BGProcessing、silent push 和回前台补偿。
+- [INFERRED] retry backoff：1s、2s、4s、8s、16s、30s、60s、最大 15min，加入 0.5–1.5 jitter；429 优先 Retry-After。
+
+## 15. 必测不变量
+
+1. [KNOWN] 同 opId 重放 100 次只产生一次业务副作用。
+2. [INFERRED] 任一 crash point 后实体、pending op、cursor 不产生半事务。
+3. [INFERRED] 字段不重叠自动合并，重叠稳定冲突。
+4. [KNOWN] ACL 撤销和 tombstone 不被离线设备复活。
+5. [KNOWN] masked/unknown/opaque/serverAuthority 字段不进入 One fieldMask。
+6. [KNOWN] 每个 entity registry 项自动跑 bootstrap/push/pull/delete/restore/conflict/secret/unknown-field。
+7. [INFERRED] Web + Android + iOS 三方写入都生成同一 change feed。
+8. [KNOWN] 自动关闭不影响手动“立即同步”。

--- a/FREEZE/zephyr one for mobile/TERMINAL_EXPERIENCE.md
+++ b/FREEZE/zephyr one for mobile/TERMINAL_EXPERIENCE.md
@@ -1,0 +1,192 @@
+# Zephyr One SSH / Telnet 终端交互规范
+
+> [KNOWN] 参考基线：`termux/termux-app@3df69d1d` 的 `terminal-view`、`terminal-emulator`、extra keys 与输入行为；Zephyr 的 `FREEZE/WTERM_MOBILE_VIEWPORT_CONTRACT.md`、SSH/Telnet 字段、代理/跳板、会话、SFTP 和 ACL 仍是业务真源。
+>
+> [KNOWN] Termux 参考的是成熟终端“手感”和 Android 行为，不是照搬 Termux App 的视觉、drawer、shell runtime 或产品信息架构。
+
+## 1. 结论
+
+- [KNOWN] SSH 与 Telnet 共用同一原生 terminal surface、IME、scrollback、selection、extra keys、hardware keyboard 和 session dock。
+- [KNOWN] 两者只在 transport/negotiation/security 上不同：SSH 加密并支持 SFTP/keys/proxy/jump；Telnet 明文、IAC/NAWS/TTYPE/encoding/in-band auto-login。
+- [INFERRED] Android 可以评估直接复用/分叉 Termux `terminal-emulator` 与 `terminal-view` 中 Apache-2.0 来源模块，但必须完成许可证文件级审计、Compose host adapter、accessibility 和现代 API 适配。
+- [INFERRED] iOS 首选评估 MIT `SwiftTerm` 的 UIKit/Metal terminal view 与 parser；通过 `UIViewRepresentable` 嵌入 SwiftUI。它不提供 Zephyr SSH 业务层，仍需连接、ACL、route、SFTP 和 session adapter。
+- [KNOWN] 两端共享 Zephyr terminal behavior fixtures，不要求共享 renderer 源码；体验等价高于代码统一。
+
+## 2. Termux 中值得继承的具体行为
+
+[KNOWN] 以下均由 Termux 当前代码确认：
+
+1. `TerminalView` 是真正的 text editor，提供 `InputConnection`，不是隐藏输入框代理。
+2. 单击 terminal 获得焦点并显示软键盘；selection 时单击先退出 selection。
+3. 一指垂直拖动按字体行高累计 residual，再转为完整 row scroll，低速滚动不丢亚行距离。
+4. fling 使用原生 `Scroller`；scrollback 边界限制在 transcript 与底部之间。
+5. alternate buffer 无 mouse tracking 时滚动转为 Up/Down，适配 `less` 等全屏程序。
+6. mouse tracking active 时把 wheel/tap/move 转成 terminal mouse event，而不是总滚本地 transcript。
+7. pinch 以阈值改变 font size，并立即重新计算 rows/columns。
+8. 长按触发系统 haptic，进入文本选择；拖 selection handle 时隐藏 floating toolbar，松手后恢复。
+9. physical mouse 支持 wheel、左键、右键 context menu、中键粘贴。
+10. Ctrl 字符映射完整处理 `Ctrl+A..Z`、`Ctrl+Space`、`Ctrl+[\]^_/?` 和 DEL。
+11. Alt 在 code point 前发送 ESC，兼容 readline Alt+B/Alt+F。
+12. Shift+PageUp/PageDown 滚整屏 scrollback。
+13. extra keys 支持 modifier、keyboard toggle、paste、scroll mode 等动作。
+14. view 尺寸变化时以 cell width/line spacing 算出列行并通知 terminal session/PTTY。
+
+[INFERRED] Zephyr One 继承这些行为，但重新设计 visual chrome、快捷键布局、会话切换和工具 dock。
+
+## 3. TerminalSurface 单一所有者
+
+```text
+TerminalSurfaceController
+ ├─ input connection / marked text / composition
+ ├─ hardware key + modifier state
+ ├─ gesture arbitration
+ ├─ scrollback viewport
+ ├─ selection + system actions
+ ├─ terminal mouse protocol
+ ├─ resize → PTY NAWS
+ ├─ renderer dirty regions
+ └─ accessibility snapshot
+```
+
+- [KNOWN] 不允许 Compose TextField/SwiftUI TextField、terminal view 和 extra-key layer 分别发送 Enter/IME commit；一个事件只能有一个 owner。
+- [KNOWN] composition update 只更新 marked-text overlay，不写 PTY；commit exactly once；cancel 不发远端。
+- [INFERRED] UI state 与 terminal engine state 分离：toolbar/session list 可以重组，terminal session/scrollback 不重建。
+
+## 4. 输入链路
+
+### 4.1 Android
+
+- [INFERRED] TerminalView 暴露真实 `InputConnection`；优先 char-based input，但为 Gboard/Samsung/中文/日文/韩文维护 composing region。
+- [INFERRED] `commitText`、`setComposingText`、`finishComposingText`、`deleteSurroundingText`、editor action 与 physical `KeyEvent` 各自有 fixture。
+- [KNOWN] Ctrl+Space ROM workaround 只在检测/设置开启时使用，不全局吞 Space。
+- [INFERRED] hardware key repeat 由系统 repeatCount 驱动；不以动画 timer 伪造。
+
+### 4.2 iOS
+
+- [INFERRED] UIKit terminal view 实现 `UIKeyInput`/`UITextInput` 等价输入面；markedTextRange 完整支持 CJK。
+- [INFERRED] `UIKeyCommand` 提供 Cmd/Control/Option、方向、PageUp/Down、Tab、Esc 和 session shortcut；不得让 SwiftUI 上层吞 terminal key。
+- [INFERRED] iPad hardware keyboard 的 key repeat、modifier lock 与 software keyboard 使用同一 canonical key encoder。
+
+### 4.3 粘贴
+
+- [KNOWN] 只在用户动作后读取 clipboard。
+- [INFERRED] 终端启用 bracketed paste 时包裹 `ESC[200~`/`ESC[201~`。
+- [INFERRED] 含换行、多行或超过 4 KiB 时显示预览/确认；可选择“粘贴但不执行最后换行”。
+- [KNOWN] 密码/Token 写剪贴板走敏感自动清理策略，普通 terminal copy 不擅自清理用户 clipboard。
+
+## 5. Scrollback 与程序鼠标模式
+
+### 5.1 手势仲裁
+
+```text
+selection active      → selection handles own drag
+pinch active          → font scale owns pointers
+terminal mouse mode   → direct tap/drag goes remote; two-finger scroll local/remote by setting
+normal primary buffer → one-finger vertical scrollback
+alternate buffer      → translate scroll to app Up/Down/Page unless mouse mode owns it
+```
+
+- [INFERRED] 手势从第一帧并行识别，超过 axis/slop 后锁定 winner；不在 scroll 中途突然变 selection/pinch。
+- [INFERRED] keyboard-visible 状态下向下 overscroll 到 bottom 不关闭键盘；键盘关闭只有明确按钮/系统手势。
+- [KNOWN] 用户离开 bottom 后远端输出不抢回；显示“↓ 新输出 N 行”按钮。用户回到底部才恢复 follow-output。
+- [INFERRED] `SCROLL` toggle 可临时强制 local scrollback，解决 tmux/vim mouse mode 下查看本地历史。
+
+### 5.2 性能
+
+- [INFERRED] scrollback 默认 100,000 行，可设 10k/50k/100k/500k；底层 chunk/ring 存储，不持有每行 Compose/UIView object。
+- [INFERRED] fling 使用平台 decay：Android spline/decay，iOS UIScrollView-like deceleration；边界无无意义 bounce 到 terminal 内容之外。
+- [INFERRED] renderer 只重绘 dirty rows/selection/cursor；scroll 使用 tile/texture reuse，不能每次复制完整 transcript。
+
+## 6. 字体缩放与 PTY resize
+
+- [INFERRED] pinch 连续显示 preview，但实际字号以 0.5sp/pt 或单级 threshold 稳定提交；范围默认 8–32，可在设置扩展。
+- [KNOWN] 字号、orientation、IME、shortcut matrix、split view、floating keyboard、Stage Manager 改变可见 viewport 都要重算 rows/cols。
+- [INFERRED] resize debounce 16–50ms，最后值必须发送；拖 iPad/折叠屏 resize 时不积压数百个 NAWS/window-change。
+- [KNOWN] 最少 4×4 cells；不足时收起非必要 chrome，不把 terminal 算成负高度。
+- [INFERRED] resize 前后光标尽量保持在同一可见 anchor；服务器 reflow 与本地 scrollback reflow 行为需 fixture。
+
+## 7. 文本选择
+
+- [KNOWN] 长按进入 selection，立即 system haptic；不是打开自绘菜单后再选。
+- [INFERRED] Android 使用 ActionMode/system text toolbar；iOS 使用 edit menu。操作：复制、全选、搜索、分享、打开链接、复制命令。
+- [INFERRED] 单/双/三击：单击焦点，双击 word，三击 logical line；在 mouse-reporting mode 下 double/triple selection 需要 selection modifier 或临时 scroll mode，避免误发远端鼠标。
+- [KNOWN] selection 期间锁定会冲突的 root/session swipe；结束后恢复。
+- [INFERRED] bidi/CJK/wide glyph/combining/emoji selection 坐标按 grapheme + cell map，不按 UTF-16 index 猜测。
+
+## 8. 快捷键矩阵
+
+### 8.1 默认布局
+
+```text
+Row 1: Esc  Ctrl  Alt  Tab  ←  ↓  ↑  →
+Row 2: /    -     |    Home End PgUp PgDn keyboard
+```
+
+- [INFERRED] 手机默认一行主键 + 可横滑/展开第二行；平板可两行常驻。
+- [KNOWN] 用户可重排；同步保存语义 key id，不同步像素位置。
+- [INFERRED] Ctrl/Alt/Shift/Fn 支持 one-shot latch；双击 lock；再次点击 release。状态有文字/形状/semantics/haptic，不只靠颜色。
+- [INFERRED] 按住箭头重复，初始 delay/频率跟平台 keyboard repeat；松手立即停止。
+- [KNOWN] `keyboard`、`paste`、`scroll`、`snippets`、`sessions` 是 action，不伪装成发给 PTY 的字符串。
+
+### 8.2 与冻结 IME 布局结合
+
+- [KNOWN] IME 收起：terminal viewport → 快捷键矩阵 → context dock。
+- [KNOWN] IME 打开：root 浮岛/context dock 隐藏，快捷键矩阵紧贴 IME，terminal viewport resize。
+- [INFERRED] Android 读 WindowInsets.ime；iOS 读 keyboard layout guide/safe area；不使用固定键盘高度。
+- [INFERRED] floating/split hardware keyboard 时矩阵仍可用，不误判整屏键盘高度。
+
+## 9. Session 体验
+
+- [KNOWN] 手机不把多个 terminal 缩成不可读网格；使用全屏 session + 快速切换器。
+- [INFERRED] session dock 左右滑切换或打开 sheet；手势必须避开 iOS edge-back/Android predictive back，不占系统边缘。
+- [INFERRED] 外接键盘：Ctrl+Alt+N/P（Android/兼容）和 Cmd+Shift+[/]（iPad）切换，可在设置改。
+- [KNOWN] 切 session 不重连、不重置 scrollback、selection、IME composition；composition 未完成时先 commit/cancel 按平台合同处理。
+- [INFERRED] background session output 有 badge，可独立 mute bell；高输出不触发频繁 haptic/notification。
+
+## 10. SSH 与 Telnet 差异
+
+| 能力 | SSH | Telnet |
+| --- | --- | --- |
+| 加密 | [KNOWN] SSH transport | [KNOWN] 无；每次新建/公网目标警示 |
+| 认证 | [KNOWN] password/key/passphrase | [KNOWN] in-band username/password auto-login |
+| route | [KNOWN] direct/SOCKS5/HTTP/最多 8 jump | [KNOWN] direct/SOCKS5/HTTP/SSH jump route |
+| terminal resize | [KNOWN] PTY window-change | [KNOWN] NAWS |
+| terminal type | [KNOWN] xterm-256color | [KNOWN] TTYPE xterm-256color |
+| encoding | [KNOWN] UTF-8 为主 | [KNOWN] UTF-8/GBK/Big5/Latin-1 |
+| files | [KNOWN] SFTP | [KNOWN] 无 SFTP，文件 dock 隐藏并说明 |
+| host identity | [KNOWN] host key unknown/change | [KNOWN] 无等价 cryptographic identity |
+
+[KNOWN] 除这些协议差异外，terminal 交互、快捷键、selection、scrollback、会话和动画一致。
+
+## 11. 动画
+
+- [INFERRED] terminal glyph、cursor、selection handle、remote output 不做补间动画。
+- [INFERRED] shortcut matrix/dock 显隐使用系统 keyboard/inset 同步曲线；如果拿不到系统曲线则 120–180ms critical fade/translate，不先动 chrome 再 resize terminal。
+- [INFERRED] session switcher 可跟手拖动并可中断；terminal bitmap/texture 只作过渡 snapshot，完成后恢复 live surface。
+- [KNOWN] Reduce Motion 下 session switch 使用 crossfade/即时切换；终端输入和 scroll 性能不变。
+
+## 12. 测试门
+
+### 输入
+
+- Gboard、Samsung、AOSP、中文拼音、日文、韩文、emoji、dead key、hardware keyboard。
+- Enter exactly once、backspace/delete、Ctrl+Space、Alt+B/F、Ctrl+C/D/Z、Fn/arrow、key repeat。
+- composition update/cancel/commit、keyboard show/hide 50 次。
+
+### 终端程序
+
+- bash/zsh/fish、vim/neovim、tmux/screen、less/man、htop、nano、fzf、top、curses mouse app。
+- primary/alternate buffer、DEC mouse modes、bracketed paste、application cursor/keypad、OSC 8 links、truecolor、wide/combining/BiDi。
+
+### 几何与性能
+
+- 旋转、split screen、fold/unfold、iPad resize、floating keyboard、fontScale、最大字号。
+- 100k scrollback fling、10 MB/s output、大量 ANSI、selection 跨 10k 行。
+- input→glyph p95 ≤ 50ms；连续 fling/输出无 ANR/main-thread stall；resize 最终 rows/cols 正确。
+
+### 反向测试
+
+- [KNOWN] 注入双 owner 发送 Enter 必须失败。
+- [KNOWN] 注入 output 抢回 bottom 必须失败。
+- [KNOWN] mouse mode 下错误滚本地/远端必须失败。
+- [KNOWN] IME 打开后 dock 遮住 terminal 或 cursor 必须失败。

--- a/FREEZE/zephyr one for mobile/TRACEABILITY.md
+++ b/FREEZE/zephyr one for mobile/TRACEABILITY.md
@@ -27,7 +27,7 @@
 | R-021 | ACL/分享 | `authz.js/sharing-service.js` | `ZEPHYR_PARITY §4` | — | `authz.test.mjs` | `partial` |
 | R-022 | SSH | `server.js ssh2` + tests | `ZEPHYR_PARITY §6.1` | — | native tests — | `missing` |
 | R-023 | Telnet | `telnet-transport.js` + tests | `ZEPHYR_PARITY §6.2` | — | native tests — | `missing` |
-| R-024 | RDP | Web/WASM + cert/route tests | `ZEPHYR_PARITY §6.3` | — | native tests — | `blocked` |
+| R-024 | RDP | `zephyr_one/native/zephyr-one-rdp` 桌面 FreeRDP shim + cert/route tests | `ZEPHYR_PARITY §6.3` | 桌面 only | C/Rust/e2e 桌面测试；无移动测试 | `partial-desktop-only` |
 | R-025 | VNC | noVNC/WebSocket | `ZEPHYR_PARITY §6.4` | — | native tests — | `blocked` |
 | R-026 | 终端 IME/快捷键/dock | WTerm mobile contract | `SCREEN_CATALOG S21` | — | native UI tests — | `specified` |
 | R-027 | SFTP 文件/预览/编辑 | server SFTP APIs | `SCREEN_CATALOG S31` | — | native tests — | `missing` |
@@ -38,7 +38,7 @@
 | R-032 | 批量执行 | `/api/remote-execute` | `SCREEN_CATALOG S41` | — | server tests only | `partial` |
 | R-033 | Docker/监控/日志 | AI/SSH tools | `SCREEN_CATALOG S42` | — | server tests only | `partial` |
 | R-034 | Proxy/Key/Jump | `resource-service.js` | `SCREEN_CATALOG S43` | — | server tests only | `partial` |
-| R-035 | AI 使用能力 | AI runtime/services | `SCREEN_CATALOG S44` | — | server tests only | `partial` |
+| R-035 | Zephyr AI 全能力浮窗 | AI runtime + live 116-tool catalog | `AI_FLOATING_WORKSPACE` / `SCREEN_CATALOG S44` / AI baseline | — | catalog parity contract only | `specified-ui-and-bridge-missing` |
 | R-036 | Activity | `storage.queryActivities` | entity registry | — | server tests only | `partial` |
 | R-037 | 服务器设置 | settings APIs | `SCREEN_CATALOG S48` | — | — | `specified` |
 | R-038 | 备份导出 | `/api/data/export` | `SCREEN_CATALOG S49` | legacy Web | `zephyr-one-backup-restore` server/Web | `partial` |
@@ -54,6 +54,16 @@
 | R-048 | Tauri → native migration | legacy `zephyr_one` | `DATA_AND_MIGRATION §7` | — | — | `specified` |
 | R-049 | structured error registry | mixed server errors | `contracts/error-registry.json` | — | schema only | `specified` |
 | R-050 | 需求覆盖发布门 | 本文件 | `IMPLEMENTATION_STATUS.md` | — | CI validator pending | `specified` |
+| R-051 | Android 自定义 progress 返回视觉 | Android system back APIs | `MOBILE_EXPERIENCE §2.3/§9.1` | — | spec contract only | `specified-ui-missing` |
+| R-052 | iOS 全 push interactive 右滑 | iOS navigation semantics | `MOBILE_EXPERIENCE §2.2/§9.1` | — | spec contract only | `specified-ui-missing` |
+| R-053 | Termux 级 SSH/Telnet 手感 | Termux behavior + Zephyr WTerm | `TERMINAL_EXPERIENCE` | — | spec contract only | `specified-engine-ui-missing` |
+| R-054 | RDP/VNC 完整移动交互 | FreeRDP/VNC core + Zephyr fields | `REMOTE_DESKTOP_EXPERIENCE` | — | spec contract only | `specified-engine-ui-missing` |
+| R-055 | AI 原生 semantic/action bridge | Zephyr `ui_action`/tool catalog | `AI_FLOATING_WORKSPACE §4` | — | catalog parity contract only | `specified-bridge-missing` |
+| R-056 | Shared-to-me 零驻留 | Zephyr ACL/ResourceService | `SHARED_RESOURCE_RESIDENCY §2/§6` | — | spec contract only | `specified-api-client-missing` |
+| R-057 | Shared connection direct use envelope | ResourceService dependency ACL | `SHARED_RESOURCE_RESIDENCY §3.2` | — | vectors/implementation missing | `specified-crypto-missing` |
+| R-058 | Shared connection strict relay | Zephyr SSH/RDP/VNC proxies | `SHARED_RESOURCE_RESIDENCY §3.3` | — | relay protocol missing | `specified-server-client-missing` |
+| R-059 | Shared AI 主端执行 | Zephyr AI runtime/tools | `SHARED_RESOURCE_RESIDENCY §4` | — | residency E2E missing | `specified-client-missing` |
+| R-060 | Shared Note 在线暂存 | NotesService/Authz | `SHARED_RESOURCE_RESIDENCY §5` | — | residency E2E missing | `specified-client-missing` |
 
 ## 发布判定算法
 

--- a/FREEZE/zephyr one for mobile/TRACEABILITY.md
+++ b/FREEZE/zephyr one for mobile/TRACEABILITY.md
@@ -1,0 +1,70 @@
+# Zephyr One 需求 → Zephyr 事实源 → One 实现 → 测试追踪矩阵
+
+> [KNOWN] 这是发布门，不是愿望清单。`One code` 或 `One tests` 为空时，该项不是原生完成。
+
+| ID | 产品需求 | Zephyr 事实源 | 合同/页面 | One code | One tests | 当前状态 |
+| --- | --- | --- | --- | --- | --- | --- |
+| R-001 | Kotlin/Compose + Swift/SwiftUI 原生 | `PRODUCT_REQUIREMENTS §2` | `DEVELOPMENT §4-6` | — | — | `missing` |
+| R-002 | 不用整页 WebView | 旧 `public/*` 仅迁移参考 | `ZEPHYR_PARITY §1.2` | — | — | `missing` |
+| R-003 | 四入口浮岛 | references image | `SCREEN_CATALOG §1` | — | — | `specified` |
+| R-004 | 系统本地解锁 | Tauri `auth` 仅迁移参考 | `SCREEN_CATALOG S01` | — | — | `missing` |
+| R-005 | Zephyr 账号登录 | `server.js /api/auth/login` | OpenAPI `LoginRequest` | — | `auth-hardening.test.mjs` 仅 server | `partial` |
+| R-006 | TOTP 登录 | `server.js /api/auth/totp/verify` | `ZEPHYR_PARITY §3` | — | `auth-hardening.test.mjs` 仅 server | `partial` |
+| R-007 | 遵守 CAPTCHA/IP/锁定 | `checkLoginGuards/verifyCaptcha` | `SCREEN_CATALOG S02` | — | `auth-hardening.test.mjs` 部分 | `partial` |
+| R-008 | 主端已有 Token 才绑定 | `one-client-manager.js bind` | OpenAPI `/devices/bind` | legacy only | `one-client-manager.test.mjs` | `partial` |
+| R-009 | userId 隔离 | `storage.js/authz.js` | entity registry | — | `user-isolation.test.mjs` | `partial` |
+| R-010 | device access/refresh/proof | 无 | OpenAPI security schemes | — | — | `specified` |
+| R-011 | 完整 bootstrap | legacy snapshot | `SYNC_STATE_MACHINE §3` | — | — | `specified` |
+| R-012 | 双向 push | 无 | OpenAPI `/sync/push` | — | — | `specified` |
+| R-013 | change cursor | 无 | `SYNC_STATE_MACHINE §8` | — | — | `specified` |
+| R-014 | opId 幂等 | 无 | `SYNC_STATE_MACHINE §6` | — | sync vector only | `specified` |
+| R-015 | field conflict | notes/snippet revision | `SYNC_STATE_MACHINE §7-9` | — | sync vector only | `specified` |
+| R-016 | tombstone/delete传播 | `notes-service` 部分 | `SYNC_STATE_MACHINE §10` | — | Note server tests only | `partial` |
+| R-017 | secret envelope | `secret-crypto.js` at-rest | `DATA_AND_MIGRATION §5` | — | AAD vector only | `specified` |
+| R-018 | 自动间隔 + 立即同步 | `one-client-manager clampInterval` | `SCREEN_CATALOG S45` | legacy partial | `one-client-manager.test.mjs` 部分 | `partial` |
+| R-019 | 冲突中心 | 无 | `SCREEN_CATALOG S45` | — | — | `specified` |
+| R-020 | Connection 完整 CRUD | `resource-service/server/storage` | `ZEPHYR_PARITY §5` | — | Zephyr server tests | `partial` |
+| R-021 | ACL/分享 | `authz.js/sharing-service.js` | `ZEPHYR_PARITY §4` | — | `authz.test.mjs` | `partial` |
+| R-022 | SSH | `server.js ssh2` + tests | `ZEPHYR_PARITY §6.1` | — | native tests — | `missing` |
+| R-023 | Telnet | `telnet-transport.js` + tests | `ZEPHYR_PARITY §6.2` | — | native tests — | `missing` |
+| R-024 | RDP | Web/WASM + cert/route tests | `ZEPHYR_PARITY §6.3` | — | native tests — | `blocked` |
+| R-025 | VNC | noVNC/WebSocket | `ZEPHYR_PARITY §6.4` | — | native tests — | `blocked` |
+| R-026 | 终端 IME/快捷键/dock | WTerm mobile contract | `SCREEN_CATALOG S21` | — | native UI tests — | `specified` |
+| R-027 | SFTP 文件/预览/编辑 | server SFTP APIs | `SCREEN_CATALOG S31` | — | native tests — | `missing` |
+| R-028 | 笔记完整能力 | `notes-service.js` | `SCREEN_CATALOG S32` | — | server tests only | `partial` |
+| R-029 | Snippet | `ai-snippet-tools.js` | `SCREEN_CATALOG S33` | — | server tests only | `blocked-normalization` |
+| R-030 | 工作区恢复 | `workspace-service.js` | `ZEPHYR_PARITY §7.3` | — | server tests only | `partial` |
+| R-031 | Deep Link | `deeplink-service.js` | `ZEPHYR_PARITY §7.4` | — | server tests only | `partial` |
+| R-032 | 批量执行 | `/api/remote-execute` | `SCREEN_CATALOG S41` | — | server tests only | `partial` |
+| R-033 | Docker/监控/日志 | AI/SSH tools | `SCREEN_CATALOG S42` | — | server tests only | `partial` |
+| R-034 | Proxy/Key/Jump | `resource-service.js` | `SCREEN_CATALOG S43` | — | server tests only | `partial` |
+| R-035 | AI 使用能力 | AI runtime/services | `SCREEN_CATALOG S44` | — | server tests only | `partial` |
+| R-036 | Activity | `storage.queryActivities` | entity registry | — | server tests only | `partial` |
+| R-037 | 服务器设置 | settings APIs | `SCREEN_CATALOG S48` | — | — | `specified` |
+| R-038 | 备份导出 | `/api/data/export` | `SCREEN_CATALOG S49` | legacy Web | `zephyr-one-backup-restore` server/Web | `partial` |
+| R-039 | 备份导入回滚 | `/api/data/import` | `DATA_AND_MIGRATION §8` | legacy Web | server/Web E2E | `partial` |
+| R-040 | Client Token CRUD | `file-agent-manager.js` | `SCREEN_CATALOG S46` | legacy Web | token/server tests | `partial` |
+| R-041 | Token secret 互备 | 当前 metadata only | entity registry | — | — | `blocked-migration` |
+| R-042 | 敏感操作密码/TOTP | `verifySensitiveAccess` | OpenAPI sensitive verify | legacy direct secret | — | `partial` |
+| R-043 | ZFT2 v2 | `file-transfer-protocol.js` | `ZEPHYR_PARITY §10.2` | — | Node/Dart only | `partial` |
+| R-044 | Android SAF bridge | Flutter Agent 参考 | `SCREEN_CATALOG S47` | — | — | `missing` |
+| R-045 | iOS scoped bridge | 无正式实现 | `SCREEN_CATALOG S47` | — | — | `missing` |
+| R-046 | RDP 只读目录 | 产品字段/Agent capability | `ZEPHYR_PARITY §6.3` | — | — | `specified` |
+| R-047 | 四色 App icon | branding sources/manifest | `DEVELOPMENT §6.6` | partial assets | — | `partial` |
+| R-048 | Tauri → native migration | legacy `zephyr_one` | `DATA_AND_MIGRATION §7` | — | — | `specified` |
+| R-049 | structured error registry | mixed server errors | `contracts/error-registry.json` | — | schema only | `specified` |
+| R-050 | 需求覆盖发布门 | 本文件 | `IMPLEMENTATION_STATUS.md` | — | CI validator pending | `specified` |
+
+## 发布判定算法
+
+[KNOWN] 以下任一成立则失败：
+
+1. 必需行状态不是 `implemented`。
+2. `One code` 或 `One tests` 为空。
+3. Android/iOS 只有一端实现。
+4. server test 通过但没有 native 解码/UI/真机测试。
+5. entity registry 有 `blocked` 或未分类字段。
+6. OpenAPI 与真实路由漂移。
+7. 产品排除项在 screen catalog 或原生导航重新出现。
+
+[INFERRED] CI 应解析本表或后续等价 YAML；每个 R-ID 绑定 Android test、iOS test、server test、artifact evidence。Markdown 是人读视图，机器真源后续可生成 `traceability.json`，但两者不能手工双写。

--- a/FREEZE/zephyr one for mobile/ZEPHYR_PARITY.md
+++ b/FREEZE/zephyr one for mobile/ZEPHYR_PARITY.md
@@ -1,0 +1,313 @@
+# Zephyr → Zephyr One 原生能力继承规范
+
+> [KNOWN] 基线：`Lanlan13-14/zephyr-ssh` `main@3a61d2f`（2026-08-08）。
+>
+> [KNOWN] 产品范围仍由 [`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md) 约束；本文只规定 Zephyr 已有解决方案怎样进入原生 Zephyr One。
+>
+> [INFERRED] 置信度：HIGH。标记为“新建”的部分是实现合同，不代表当前代码已经存在。
+
+## 1. 继承原则
+
+### 1.1 必须继承什么
+
+- [KNOWN] **业务语义继承**：字段、默认值、校验、revision、ACL、敏感验证、错误码、删除规则、审计、备份格式和协议字节必须来自 Zephyr 的现有 service，而不是由移动端另造一套。
+- [KNOWN] **服务端业务入口继承**：移动同步 push 必须调用 `ResourceService`、`NotesService`、`UserSettingsService`、`WorkspaceService`、`AiProviderService`、Token/备份 service；不得直接更新业务表。
+- [KNOWN] **安全边界继承**：共享资源的 `use` 不等于 `revealSecret`；管理员只获得治理视图，不自动获得其他用户秘密或连接使用权。
+- [KNOWN] **兼容协议继承**：ZFT2 v2 的 20 字节大端帧、操作码、flags、大小限制和错误帧保持逐字节兼容。
+- [KNOWN] **测试继承**：Zephyr 已有服务级测试先作为 One 合同测试基线，再增加 Android/iOS 解码、UI 和真机测试。
+
+### 1.2 不能机械搬什么
+
+- [KNOWN] `public/*.html`、DOM、iframe、Web xterm、`sessionStorage/localStorage` 和浏览器 Cookie 不是原生 UI 方案；不得用整页 WebView 包装现有页面冒充原生实现。
+- [KNOWN] 当前 `/api/one/sync/pull` 是整包 pull-only；它没有 push、change cursor、幂等、冲突和墓碑，不能作为正式原生同步协议。
+- [KNOWN] 当前 `agent-tokens.json` v2 含 Token 明文；正式 mobile v1 必须迁移到加密存储和 revision/change-log。
+- [KNOWN] 当前 Connection/Proxy/SSH Key/JumpHost 多数是硬删除；完整双向同步必须在业务 service 前增加 tombstone/change hook，不能复制硬删除行为。
+- [KNOWN] 当前服务端错误有三种形状：纯 `{error}`、顶层 `{error,code,retryable}`、嵌套 `{ok:false,error:{...}}`；原生客户端必须通过 mobile adapter 收敛为一个错误 envelope。
+- [INFERRED] Web 端视觉布局只提供信息层级和行为参考；原生端使用 Compose/SwiftUI 组件、系统 sheet、系统键盘、系统文件选择器和无障碍语义。
+
+## 2. Zephyr 事实源和 One 落点
+
+| 领域 | Zephyr 事实源 | 已有规则 | Zephyr One 原生落点 |
+| --- | --- | --- | --- |
+| 身份与会话 | `server.js`、`session-store.js` | [KNOWN] SID 随机生成，DB 只存 SHA-256；idle + absolute TTL；撤销覆盖缓存 | [INFERRED] SID 只用于绑定/管理 API，存 Keystore/Keychain；绑定后数据面改用短期 device access + proof |
+| 登录策略 | `server.js /api/auth/login`、`/totp/verify` | [KNOWN] IP/CAPTCHA/锁定/默认密码/TOTP/停用均由主端判定 | [KNOWN] One 不配置这些策略；原生登录展示稳定 code，CAPTCHA 用系统认证会话 |
+| 敏感验证 | `verifySensitiveAccess` | [KNOWN] 开 TOTP 时只收当前 TOTP；未开 TOTP 时收当前密码 | [INFERRED] `/mobile/v1/sensitive/verify` 包装为短时、单次、action+targets 绑定 grant |
+| ACL | `authz.js` | [KNOWN] 13 个 capability、owner 全权、admin 仅 metadata view、无权时防枚举 | [KNOWN] 原生 UI 按 capability 隐藏/禁用操作；服务端继续最终裁决 |
+| 连接 | `storage.js`、`resource-service.js`、`server.js` | [KNOWN] owner-aware CRUD、依赖 ACL、revision、secret masking | [KNOWN] 原生连接库/编辑器完整复刻字段与默认值；本地 mirror 不能放明文 secret |
+| 笔记 | `notes-service.js` | [KNOWN] expectedRevision、软删/恢复/永久删除、分组/标签/关联、AI read/write 分权 | [KNOWN] 原生 Markdown 工作区复用相同限制和错误码 |
+| 工作区 | `workspace-service.js` | [KNOWN] 256 KiB、每用户 20 个、90 日清理、secret scrub、恢复时重新检查 ACL | [KNOWN] 手机保存会话顺序/最小化/选中项；不自动重放命令或输入 |
+| 深链 | `deeplink-service.js` | [KNOWN] ssh/telnet/jms、60 秒、用户绑定、一次消费、credential 加密 | [KNOWN] App/Universal Link 解析后使用同一 draft/consume 语义 |
+| 设置 | `user-settings-service.js` | [KNOWN] 系统强制 > 用户 override > 管理员默认 > built-in；普通用户白名单写入 | [KNOWN] One 只展示有移动用途 key；未知/排除 key opaque 保留 |
+| AI Provider | `ai-provider-service.js` | [KNOWN] owner/共享、provider 类型、模型可见性、API Key 加密 | [KNOWN] 原生 AI UI 复用主端 runtime API 与 provider 权限，不在客户端绕过模型许可 |
+| Snippet | `ai-snippet-tools.js`、`user_settings.snippets` | [KNOWN] 500 条、revision、名称/命令/分组长度限制 | [INFERRED] 服务端先正规化为可单项同步实体；原生端不整包覆盖 snippets 数组 |
+| 活动 | `storage.js activities` | [KNOWN] 账号过滤、最多 500 查询、结构化 category/outcome/target 等字段 | [KNOWN] 首页活动二级页；append-only，同 eventId 去重 |
+| 备份恢复 | `/api/data/export`、`/api/data/import` | [KNOWN] WAL checkpoint、DB+manifest+数据密钥、ZIP 后 AES-GCM、导入前本地 DB 回滚副本 | [KNOWN] One 原生文件导出/导入 UI；执行仍在主端；保留 super-admin 与登录密码门 |
+| Client Token | `file-agent-manager.js` | [KNOWN] 多 Token、创建/改名/查看/旋转/删除/重置、关联 Agent 立即断开 | [INFERRED] 迁移进 SQLite 加密表，增加 ownerUserId/revision/tombstone/change hook；One 可完整互备 secret |
+| 文件桥接 | `file-agent-manager.js`、`file-transfer-protocol.js` | [KNOWN] ZFT2 v2、1–16 inflight、最大 1 MiB payload、取消和错误帧 | [KNOWN] Android/iOS 实现相同字节协议；用户可见名称统一为“文件同步/文件桥接” |
+| 终端移动输入 | `FREEZE/WTERM_MOBILE_VIEWPORT_CONTRACT.md` | [KNOWN] 单一滚动写入口、composition 不滚、IME 几何和 cursor 约束 | [INFERRED] 原生终端 core 继承行为不继承 DOM；Compose/SwiftUI 只有一个 SurfaceController |
+
+## 3. 身份、会话与绑定
+
+### 3.1 登录状态机
+
+```text
+ENTER_SERVER
+  → FETCH_CAPABILITIES
+  → ENTER_CREDENTIALS
+  → POST /api/auth/login { returnSid:true }
+      ├─ requireTotp=true → ENTER_TOTP → POST /api/auth/totp/verify
+      ├─ captcha_required → SYSTEM_AUTH_SESSION → callback → retry
+      ├─ must_change_password → SYSTEM_BROWSER_REQUIRED_ACTION
+      ├─ account_locked/suspended → BLOCKED
+      └─ sid → TOKEN_SELECTION
+  → DEVICE_KEY_GENERATION
+  → POST /api/mobile/v1/devices/bind
+  → BOOTSTRAP
+```
+
+- [KNOWN] 原生请求必须带 `X-Zephyr-One-Client: 1` 或 `returnSid: true`；主端才会在 JSON 中返回 SID。
+- [KNOWN] SID 不写普通 preferences，不进入日志、analytics、crash metadata 或同步实体。
+- [KNOWN] `userId` 是账号归属权威；username 只是显示和旧 Token owner 兼容键。
+- [KNOWN] 主端零 Client Token 时绑定返回 `token_required`，One 只显示去主端创建 Token 的引导和“重新检查”，不得自动创建。
+- [INFERRED] 绑定成功后服务端返回 access credential、single-use refresh credential、registry hash；refresh 每次成功都旋转，旧值再用返回 `refresh_replayed`。
+
+### 3.2 会话继承
+
+- [KNOWN] Zephyr SID 使用 idle TTL 与 absolute TTL，普通/remember TTL 由服务端配置决定；移动端不得假设固定天数。
+- [KNOWN] 密码重置、账号停用、管理员撤销和 logout 会撤销服务端 session。
+- [INFERRED] One 收到 `app_session_expired` 时停止管理操作；已绑定数据面可否继续由 device 状态决定，不能把 SID 过期误判为设备必然撤销。
+- [INFERRED] One 收到 `client_revoked/token_missing/account_unavailable` 时立即停止上传、锁住未下发的 secret、保留本地非敏感镜像并进入重新绑定页。
+
+## 4. ACL 与共享
+
+### 4.1 固定 capability
+
+```text
+discover, view, use, observe, control, execute,
+fileRead, fileWrite, edit, share, delete, revealSecret, administer
+```
+
+- [KNOWN] Owner 拥有全部 capability。
+- [KNOWN] Admin 对他人私有资源默认只有 metadata `view`，没有 `discover/use/revealSecret`。
+- [KNOWN] `shared_users/shared_admins/shared_all` 只隐式授予 `discover/view/use/observe`。
+- [KNOWN] 显式 ACL grant 可授予 capability 并设置 expiresAt；撤销和过期立即生效。
+- [KNOWN] 不存在和不可发现资源对普通调用者统一为 `resource_not_found_or_inaccessible`，防止枚举。
+
+### 4.2 原生 UI 规则
+
+| capability | One UI |
+| --- | --- |
+| `discover` | [KNOWN] 资源进入列表 |
+| `view` | [KNOWN] 可打开只读详情 |
+| `use` | [KNOWN] 可连接/调用；仍不显示 secret |
+| `observe` | [KNOWN] 可观察会话状态 |
+| `control` | [KNOWN] 可发送交互控制 |
+| `execute` | [KNOWN] 可进入批量命令目标集合 |
+| `fileRead/fileWrite` | [KNOWN] SFTP/文件桥接分别启用读取/写入操作 |
+| `edit` | [KNOWN] 显示保存操作，否则表单只读 |
+| `share` | [KNOWN] 显示共享 sheet |
+| `delete` | [KNOWN] 显示删除操作 |
+| `revealSecret` | [KNOWN] 允许发起敏感验证后查看；没有时永不向设备下发 owner secret |
+| `administer` | [KNOWN] 只用于有产品用途的治理操作，不等于 secret 权限 |
+
+- [KNOWN] 客户端禁用只是体验；每次服务端操作仍重新计算 capability。
+- [KNOWN] 连接依赖的 SSH Key、Proxy、JumpHost、Jump Connection 在保存和使用时都重新检查；共享 Connection 不隐式共享依赖。
+- [KNOWN] 工作区恢复、离线缓存重新联网和 ACL change feed 应用后都重新裁剪资源能力。
+
+## 5. 连接模型完整继承
+
+### 5.1 通用字段和默认值
+
+| 字段 | Zephyr 规则 | One 规则 |
+| --- | --- | --- |
+| `id` | [KNOWN] 随机 UUID | [KNOWN] 原样同步，不以 host 生成 |
+| `protocol` | [KNOWN] SSH/TELNET/RDP/VNC | [KNOWN] 原样；未知枚举只读保留 |
+| `port` | [KNOWN] 22/23/3389/5900 | [KNOWN] 协议切换时仅未手改端口跟随默认 |
+| `name` | [KNOWN] 持久连接必填；临时连接可从协议+host 生成 | [KNOWN] 相同 |
+| `host` | [KNOWN] 必填 | [KNOWN] 前后空白去除，服务端最终校验 |
+| `username` | [KNOWN] SSH 必填，其他协议可空 | [KNOWN] 相同 |
+| `password/privateKey` | [KNOWN] 加密保存，列表只回 `******` + has 标记 | [KNOWN] SecretStore 引用；masked 值永不回写覆盖 |
+| `tags` | [KNOWN] 字符串数组 | [KNOWN] 去空值，保持顺序和未知 Unicode |
+| `connectionMode` | [KNOWN] direct/proxy/jump | [KNOWN] 切换模式清除不相关 dependency id |
+| `jumpHostIds` | [KNOWN] 去重有序数组；兼容旧 `jumpHostId` | [KNOWN] 编辑器以有序多级链展示 |
+| `revision` | [KNOWN] 从 1 开始，编辑递增 | [KNOWN] 每次 push 带 baseRevision |
+| `ephemeral` | [KNOWN] 一次性连接不进库列表，默认 6 小时清理 | [KNOWN] 设备本地会话字段，不进入账号镜像 |
+| `encoding` | [KNOWN] 默认 UTF-8；Telnet 可 GBK/Big5/Latin-1 | [KNOWN] 原样 |
+
+### 5.2 RDP 字段
+
+| 字段 | 允许值/默认值 |
+| --- | --- |
+| `rdpSoundMode` | [KNOWN] `local / remote / off`，默认 `local` |
+| `rdpClipboard` | [KNOWN] boolean，默认 `true` |
+| `rdpMicrophone/rdpCamera/rdpStorage/rdpLocation` | [KNOWN] boolean，默认 `false` |
+| `rdpResolution` | [KNOWN] `auto / 1080p / 2K / 4K / 8K`，默认 `1080p` |
+| `rdpQuality` | [KNOWN] `balanced / performance / quality`，默认 `balanced` |
+| `rdpFps` | [KNOWN] `30 / 45 / 60 / 120 / 144`，默认 `30` |
+| `rdpTouchMode` | [KNOWN] `direct / relative`，默认 `direct` |
+| `rdpTouchSensitivity` | [KNOWN] `0.5…3.0`，默认 `1.5` |
+| `rdpDomain` | [KNOWN] Windows domain 字符串 |
+| `rdpPipeline` | [KNOWN] 当前 Web 强制 `worker-gpu-v2` | [INFERRED] One 原生端把它当 opaque Web 字段，不用它选择 native renderer |
+
+### 5.3 保存语义
+
+- [KNOWN] `password/privateKey/passphrase/apiKey/token` 的 masked 占位符绝不视为新秘密。
+- [KNOWN] Connection 创建/编辑必须先检查依赖是否存在且当前用户有 `use`。
+- [KNOWN] 删除资源同时撤销该资源全部 ACL。
+- [INFERRED] 正式 mobile v1 删除先写业务 tombstone 和 change log，再由 retention job 物理清理；依赖资源删除前服务端返回引用列表。
+- [KNOWN] `lastConnectedAt` 是服务端/本机活动字段，不参与用户字段冲突。
+
+## 6. 协议会话继承
+
+### 6.1 SSH/SFTP
+
+- [KNOWN] 认证来源按连接内联 private key/password 与 `sshKeyId` 解析；key passphrase 可作为对应私钥口令。
+- [KNOWN] route 支持 direct、SOCKS5/HTTP CONNECT proxy、SSH jump chain；每层依赖必须有 `use`。
+- [KNOWN] host key 变化不能静默接受；One 显示算法、SHA-256 fingerprint、host、port。
+- [INFERRED] One 的 native SSH engine 必须暴露 `connect/openPty/resize/write/openSftp/close` 小接口；UI 不接触协议 packet。
+- [KNOWN] SFTP 的 `fileRead/fileWrite` capability 独立；只读共享不得因为 `use` 而写文件。
+
+### 6.2 Telnet
+
+- [KNOWN] 默认端口 23，支持 IAC、NAWS、TTYPE、BINARY、ECHO、SGA。
+- [KNOWN] 用户名/密码用于 in-band auto-login；Telnet 清除 SSH private key/sshKeyId，但仍可通过 proxy/jump 走 TCP route。
+- [KNOWN] 支持 UTF-8、GBK、Big5、Latin-1；UI 始终显示明文协议风险。
+- [INFERRED] 原生 Telnet parser 直接移植 Zephyr 状态机和测试向量，不把 WebSocket `/ssh` 当原生数据面。
+
+### 6.3 RDP
+
+- [KNOWN] Zephyr 已有证书探测、首次信任/变化阻断、声音、剪贴板、输入、触控和文件映射语义。
+- [INFERRED] One 使用 native RDP core；Compose/SwiftUI 只承载 Surface/UIView、手势、系统通道权限和状态。
+- [KNOWN] 麦克风、摄像头、位置、目录权限按会话实际请求懒申请；拒绝单个通道不应让整个会话失败。
+- [INFERRED] 只读 drive 必须在 provider 层拒绝 open-write、write、truncate、mkdir、rename、delete；只设置 UI `readOnly` 不构成安全实现。
+
+### 6.4 VNC
+
+- [KNOWN] Zephyr 产品语义包含认证、像素格式、增量 framebuffer、剪贴板、输入和重连。
+- [INFERRED] One 复用 native RFB core；不支持的 security type 返回稳定错误，不自动降级到未知弱模式。
+
+## 7. 笔记、Snippet、工作区与 Deep Link
+
+### 7.1 笔记
+
+- [KNOWN] 标题最长 200 字符；正文最多 1 MiB UTF-8；标签最多 100；关联连接最多 100；bulk 最多 200。
+- [KNOWN] 更新必须带 `expectedRevision`；不匹配返回 `note_revision_conflict`。
+- [KNOWN] 普通删除进入回收站；恢复 revision +1；永久删除默认只允许回收站内项目。
+- [KNOWN] AI 读取与 AI 编辑是两个独立开关；AI 编辑隐含读取，关闭读取同时关闭编辑。
+- [KNOWN] 分组重命名只改精确路径，不递归改子路径；删除分组把笔记移到未分组。
+- [KNOWN] Markdown 导出文件名清洗；原生预览不能执行 HTML script。
+
+### 7.2 Snippet
+
+- [KNOWN] 最多 500 条；name 1–60；command 1–20000；group 最多 40；id 最多 120。
+- [KNOWN] update/delete 需要 expectedRevision；冲突返回 `revision_conflict`。
+- [INFERRED] mobile v1 把每条 snippet 正规化为独立 change/tombstone，禁止用整个 `user_settings.snippets` 数组 last-write-wins。
+- [KNOWN] `autoRun` 在执行前仍服从目标 Connection 的 `execute` capability 和危险操作确认。
+
+### 7.3 工作区
+
+- [KNOWN] 单条 state JSON 最大 256 KiB；每用户最多 20 个；默认 90 天清理。
+- [KNOWN] state 递归删除 password/privateKey/passphrase/apiKey/token/totpSecret/credential 等字段。
+- [KNOWN] restore 对每个 connectionId 重新检查当前 ACL，并返回 `accessible/reason/capabilities`。
+- [KNOWN] restore 永远 `autoReplay:false`；不自动重发终端输入、命令或 AI 工具调用。
+- [INFERRED] One 的 `clientId` 是设备本地布局槽，不作为认证，不跨设备覆盖；可移植会话定义单独同步。
+
+### 7.4 Deep Link
+
+- [KNOWN] URI 最长 8 KiB；JMS 解码 JSON 最大 16 KiB；端口范围 1–65535。
+- [KNOWN] 支持 `ssh://`、`telnet://`、`jms://`；JMS `sftp` 映射为 SSH + `autoOpenSftp`。
+- [KNOWN] 临时 credential 只存加密 blob，token 只存 SHA-256，默认 60 秒，绑定 userId，正式消费一次后擦除。
+- [KNOWN] 测试连接可在过期前复用 token，但不延长 TTL，也不消费。
+
+## 8. 设置与服务器管理
+
+### 8.1 One 可操作设置
+
+- [KNOWN] 用户设置继承合并顺序：系统强制 > 用户 override > 管理员默认 > built-in。
+- [KNOWN] One 可编辑移动有用途字段：主题、四色 scheme、终端背景/字体、终端窗口偏好、笔记偏好、移动工作区偏好、AI 面板/名称、Snippet。
+- [KNOWN] One 不提供账号安全、SMTP、CAPTCHA/IP 策略、备案、自定义 CSS/JS 编辑入口。
+- [KNOWN] 未知或排除字段存在于快照时只能 opaque preservation；One 的 fieldMask 不得包含它们。
+
+### 8.2 保留的服务器设置
+
+- [KNOWN] “服务器设置必须保留”不等于复制全部 Web 部署后台。
+- [INFERRED] 工具 → 服务器 → 设置只展示当前账号在 Zephyr 中有权限且对移动操作有用途的 section：appearance、notes、AI runtime 开关/模型可用性、运行状态和兼容信息。
+- [KNOWN] API 继续使用 `requireAdmin/requireSuperAdmin`；普通账号看到 capability/role 不足状态，不伪装保存成功。
+- [KNOWN] security/mail/captcha/beian 不进入 One 页面，即使调用者是 super-admin。
+
+### 8.3 备份恢复
+
+- [KNOWN] 导出执行 WAL checkpoint，包内包含 `zephyr.db`、manifest 和文件型 ML-KEM 数据密钥；外层使用 AES-256-GCM `ZEPHYR3` 格式。
+- [KNOWN] 导入要求 super-admin 和当前登录密码；错误密码、缺 DB、错误加密包均不得改现有数据。
+- [KNOWN] 导入前复制 `zephyr-before-import-<time>.db`；DB 或密钥恢复失败时回滚旧 DB 和旧 key，再 reopen storage。
+- [INFERRED] 原生 One 使用系统 document exporter/importer；大文件上传显示字节进度，App 切后台时保持可恢复 job 状态，不在内存复制多份 archive。
+
+## 9. AI 能力继承
+
+- [KNOWN] Provider 类型固定为 `openai/openai-compatible/anthropic/gemini/ollama`。
+- [KNOWN] Provider 可 private、共享给 users/admins、共享给选定用户；共享使用不下发 API Key。
+- [KNOWN] 模型必须在 provider owner 允许的模型集合且未隐藏；否则 `model_not_allowed/model_hidden`。
+- [KNOWN] AI 工具继续经过 Zephyr capability registry、确认策略、ACL 和 notes AI read/write 开关；One 不在客户端复制一套弱化鉴权。
+- [KNOWN] AI Session/run/messages/usage/events 直接使用主端 runtime API；离线时只读本地已同步会话和草稿，不假装模型可用。
+- [INFERRED] 在 mobile v1 纳入 AI conversation/message 前，必须先把当前 runtime 的 canonical schema、revision、附件 manifest 和删除规则落进 `entity-registry.json`；状态为 blocked 时不得宣称完整镜像。
+- [KNOWN] AI Env 的值是 secret；列表只显示 `hasValue`，查看/同步进入设备 envelope 和 SecretStore。
+
+## 10. Client Token 与文件同步
+
+### 10.1 Token
+
+- [KNOWN] Token name 最长 80；secret 长度限制 16–256，当前默认 50；tokenId 稳定，旋转改变 secret 而不改逻辑 id。
+- [KNOWN] 查看、旋转、删除、重置全部必须走密码/TOTP敏感验证。
+- [KNOWN] 旋转/删除后使用该 tokenId 的旧 Agent 和 One 设备立即断开；其他 Token 不受影响。
+- [INFERRED] 正式表以 immutable `owner_user_id` 归属；旧 `ownerId=username` 只作迁移输入。
+- [INFERRED] `agent-tokens.json` 导入事务完成后改名为只读迁移备份，不能继续双写明文 JSON。
+
+### 10.2 ZFT2
+
+- [KNOWN] magic=`ZFT2`，version=2，header=20 bytes，所有整数大端。
+- [KNOWN] flags：error=`0x0001`，response=`0x0002`。
+- [KNOWN] metadata 最大 256 KiB；payload 最大 1 MiB；实际 chunk 由双方 capability 取最小值。
+- [KNOWN] 操作码：OPEN 01、READ 02、WRITE 03、CLOSE 04、STAT 05、LIST 06、MKDIR 07、DELETE 08、RENAME 09、TRUNCATE 0A、CANCEL 0B、PING 0C。
+- [KNOWN] `maxInflight` 限制 1–16；默认 8；disconnect 关闭所有 handle 并拒绝 pending request。
+- [KNOWN] readOnly provider 必须拒绝所有写语义；客户端 UI 禁用不代替 provider 检查。
+
+## 11. 错误与客户端动作
+
+- [KNOWN] 机器错误真源为 [`contracts/error-registry.json`](contracts/error-registry.json)。
+- [KNOWN] 新响应统一为：
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "note_revision_conflict",
+    "message": "笔记已被其他人更新，请重新加载",
+    "retryable": false,
+    "details": {},
+    "requestId": "srv_..."
+  }
+}
+```
+
+- [KNOWN] One 只根据 `code` 分支；`message` 可直接展示但不参与逻辑。
+- [KNOWN] 401 只自动 refresh 一次；403 不无限重试；409 进入冲突/重新 bootstrap；429 遵守 `Retry-After`；网络/5xx 指数退避并加 jitter。
+- [INFERRED] mobile adapter 保留旧 `error` 字符串字段给 Web 兼容，但 native SDK 只暴露统一 `MobileError`。
+
+## 12. 不得偏离的测试继承
+
+| Zephyr 测试事实 | One 必须增加的对等测试 |
+| --- | --- |
+| [KNOWN] `authz.test.mjs` 覆盖 owner/admin/陌生人/过期 grant/防枚举 | [INFERRED] Android/iOS capability decoder + 逐操作 UI gate + 服务端拒绝回归 |
+| [KNOWN] `auth-hardening.test.mjs` 覆盖账号锁定、TOTP 尝试耗尽、reset token | [INFERRED] 原生登录状态机不会绕过或无限重试 |
+| [KNOWN] `one-client-manager.test.mjs` 覆盖 token 前置、撤销、interval clamp | [INFERRED] mobile v1 bind/refresh/proof/replay/registry tests |
+| [KNOWN] `notes-deeplink.test.mjs` 覆盖 revision/软删/一次性 token/工作区 ACL | [INFERRED] 同 fixture 由 Kotlin/Swift 解码并跑离线 round-trip |
+| [KNOWN] `file-transfer-protocol` 测试覆盖 magic/length/flags | [INFERRED] Node/Kotlin/Swift golden frame 逐字节一致 + fuzz |
+| [KNOWN] `zephyr-one-backup-restore.test.mjs` 覆盖真实导出、错误密码、正确恢复 | [INFERRED] Android/iOS 系统文件选择、上传中断恢复、服务重启后状态 |
+| [KNOWN] Telnet tests 覆盖 default port、proxy/jump、GBK、auto-login、reattach | [INFERRED] native parser/route/IME 真机矩阵 |
+| [KNOWN] 移动终端测试覆盖 CJK composition、IME event path、scroll policy | [INFERRED] Compose/SwiftUI surface controller instrumentation/UI tests |
+
+## 13. 完成定义
+
+- [KNOWN] “已搬到 One”必须同时满足：字段合同、服务调用、原生页面、离线行为、同步分类、错误码、Android 自动测试、iOS 自动测试、至少一台真机验收。
+- [KNOWN] 只有 README 描述、只有页面、只有 pull snapshot、只有 masked metadata 或只有 Android 单端均不算完成。
+- [INFERRED] 需求到实现的逐项状态以 [`TRACEABILITY.md`](TRACEABILITY.md) 为发布门，当前真实状态以 [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) 为准。

--- a/FREEZE/zephyr one for mobile/ZEPHYR_PARITY.md
+++ b/FREEZE/zephyr one for mobile/ZEPHYR_PARITY.md
@@ -1,6 +1,6 @@
 # Zephyr → Zephyr One 原生能力继承规范
 
-> [KNOWN] 基线：`Lanlan13-14/zephyr-ssh` `main@3a61d2f`（2026-08-08）。
+> [KNOWN] 基线：`Lanlan13-14/zephyr-ssh` `main@8dd5b98`（2026-08-08）。
 >
 > [KNOWN] 产品范围仍由 [`PRODUCT_REQUIREMENTS.md`](PRODUCT_REQUIREMENTS.md) 约束；本文只规定 Zephyr 已有解决方案怎样进入原生 Zephyr One。
 >
@@ -111,8 +111,11 @@ fileRead, fileWrite, edit, share, delete, revealSecret, administer
 | `administer` | [KNOWN] 只用于有产品用途的治理操作，不等于 secret 权限 |
 
 - [KNOWN] 客户端禁用只是体验；每次服务端操作仍重新计算 capability。
-- [KNOWN] 连接依赖的 SSH Key、Proxy、JumpHost、Jump Connection 在保存和使用时都重新检查；共享 Connection 不隐式共享依赖。
-- [KNOWN] 工作区恢复、离线缓存重新联网和 ACL change feed 应用后都重新裁剪资源能力。
+- [KNOWN] 只有 `ownerUserId == boundUserId` 的实体与其 ACL 进入 One mirror；shared-to-me 列表、正文、grant 和内容每次在线向主端请求，不进 change feed、DB、FTS、offline cache 或 backup。
+- [KNOWN] 连接依赖的 SSH Key、Proxy、JumpHost、Jump Connection 在保存和使用时都由主端重新检查；共享 Connection 不隐式共享依赖，也不向 One 列表下发 dependency secret。
+- [KNOWN] 共享 `use` 默认由主端 relay；direct native session 仅按 [`SHARED_RESOURCE_RESIDENCY.md`](SHARED_RESOURCE_RESIDENCY.md) 接收一次、短时、device/session/resource/purpose 绑定的 encrypted use envelope。
+- [KNOWN] `revealSecret` 仍不作为共享使用的隐含能力；共享资源 owner 可强制 relay，One 不得静默降级。
+- [KNOWN] owned 工作区恢复、离线缓存重新联网和 owned ACL change feed 应用后重新裁剪资源能力；shared-to-me 不存在离线恢复。
 
 ## 5. 连接模型完整继承
 

--- a/FREEZE/zephyr one for mobile/contracts/ai-capability-baseline.json
+++ b/FREEZE/zephyr one for mobile/contracts/ai-capability-baseline.json
@@ -1,0 +1,3776 @@
+{
+  "version": 1,
+  "sourceCommit": "8dd5b98",
+  "source": "ai-agent-service.listToolCatalog(all mobile-relevant permissions)",
+  "invariant": "Zephyr One must expose an equivalent native/server bridge for every model-visible tool; unknown additions block release.",
+  "permissionFixture": {
+    "browser": true,
+    "webSearch": true,
+    "webFetch": true,
+    "memory": true,
+    "env": true,
+    "notesRead": true,
+    "notesWrite": true,
+    "remoteExecute": true,
+    "fileRead": true,
+    "fileWrite": true
+  },
+  "count": 116,
+  "tools": [
+    {
+      "toolId": "agent_file_delete_v1",
+      "capabilityId": "agent.files_write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          },
+          "recursive": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "agentId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_file_list_v1",
+      "capabilityId": "agent.files_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "agentId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_file_mkdir_v1",
+      "capabilityId": "agent.files_write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "agentId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_file_read_text_v1",
+      "capabilityId": "agent.files_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          },
+          "maxBytes": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 262144
+          },
+          "encoding": {
+            "type": "string",
+            "enum": [
+              "utf8",
+              "utf-8"
+            ]
+          }
+        },
+        "required": [
+          "agentId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_file_rename_v1",
+      "capabilityId": "agent.files_write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "oldPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          },
+          "newPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "agentId",
+          "oldPath",
+          "newPath"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_file_stat_v1",
+      "capabilityId": "agent.files_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "agentId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_file_write_text_v1",
+      "capabilityId": "agent.files_write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          },
+          "content": {
+            "type": "string",
+            "maxLength": 262144
+          },
+          "encoding": {
+            "type": "string",
+            "enum": [
+              "utf8",
+              "utf-8"
+            ]
+          },
+          "append": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "agentId",
+          "path",
+          "content"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_get_v1",
+      "capabilityId": "agent.get",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "agentId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "agent_list_v1",
+      "capabilityId": "agent.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_click_v1",
+      "capabilityId": "browser.click",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "elementRef": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "domRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "elementRef",
+          "domRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_close",
+      "capabilityId": "browser.close",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_inspect_v1",
+      "capabilityId": "browser.inspect",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "max": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_key",
+      "capabilityId": "browser.key",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_navigate",
+      "capabilityId": "browser.navigate",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "session": {
+            "type": "string"
+          },
+          "waitMs": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_screenshot",
+      "capabilityId": "browser.observe",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string"
+          },
+          "fullPage": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_scroll",
+      "capabilityId": "browser.viewport",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "up",
+              "down"
+            ]
+          },
+          "amount": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_text",
+      "capabilityId": "browser.observe",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string"
+          },
+          "maxChars": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_type_v1",
+      "capabilityId": "browser.type",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "elementRef": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "domRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 20000
+          },
+          "clear": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "elementRef",
+          "domRevision",
+          "text"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "browser_wait",
+      "capabilityId": "browser.observe",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "type": "string"
+          },
+          "ms": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "capability_search",
+      "capabilityId": "capability.search",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_create_v1",
+      "capabilityId": "connection.create",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "protocol": {
+            "type": "string",
+            "enum": [
+              "SSH",
+              "TELNET",
+              "RDP",
+              "VNC"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "port": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "sshKeyId": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "sshKeySecretRef": {
+            "type": "string",
+            "maxLength": 4000
+          },
+          "remark": {
+            "type": "string",
+            "maxLength": 20000
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 120
+            },
+            "maxItems": 50
+          },
+          "connectionMode": {
+            "type": "string",
+            "enum": [
+              "direct",
+              "proxy",
+              "jump"
+            ]
+          },
+          "proxyId": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "jumpHostIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 120
+            },
+            "maxItems": 12
+          },
+          "encoding": {
+            "type": "string",
+            "maxLength": 80
+          }
+        },
+        "required": [
+          "name",
+          "protocol",
+          "host"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_delete_v1",
+      "capabilityId": "connection.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "connectionId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_get_v1",
+      "capabilityId": "connection.get",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_list_v1",
+      "capabilityId": "connection.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "protocol": {
+            "type": "string",
+            "enum": [
+              "SSH",
+              "TELNET",
+              "RDP",
+              "VNC"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_open_v1",
+      "capabilityId": "connection.open",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_rename_v1",
+      "capabilityId": "connection.rename",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "connectionId",
+          "name",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_test_v1",
+      "capabilityId": "connection.test",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "timeoutSeconds": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 30
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "connection_update_v1",
+      "capabilityId": "connection.update",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "protocol": {
+            "type": "string",
+            "enum": [
+              "SSH",
+              "TELNET",
+              "RDP",
+              "VNC"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "host": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "port": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "sshKeyId": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "sshKeySecretRef": {
+            "type": "string",
+            "maxLength": 4000
+          },
+          "remark": {
+            "type": "string",
+            "maxLength": 20000
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 120
+            },
+            "maxItems": 50
+          },
+          "connectionMode": {
+            "type": "string",
+            "enum": [
+              "direct",
+              "proxy",
+              "jump"
+            ]
+          },
+          "proxyId": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "jumpHostIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 120
+            },
+            "maxItems": 12
+          },
+          "encoding": {
+            "type": "string",
+            "maxLength": 80
+          }
+        },
+        "required": [
+          "connectionId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_container_action_v1",
+      "capabilityId": "docker.mutate",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "start",
+              "stop",
+              "restart",
+              "remove",
+              "pause",
+              "unpause"
+            ]
+          },
+          "container": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "force": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "connectionId",
+          "action",
+          "container"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_images_v1",
+      "capabilityId": "docker.inspect",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 500
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_logs_v1",
+      "capabilityId": "docker.inspect",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "container": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "tail": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 2000
+          },
+          "timestamps": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "connectionId",
+          "container"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_mirrors_get_v1",
+      "capabilityId": "docker.inspect",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_mirrors_set_v1",
+      "capabilityId": "docker.mutate",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "mirrors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 300
+            },
+            "maxItems": 20
+          },
+          "restart": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "connectionId",
+          "mirrors"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_ps_v1",
+      "capabilityId": "docker.inspect",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "all": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 500
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_pull_v1",
+      "capabilityId": "docker.mutate",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "image": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "timeoutSeconds": {
+            "type": "number",
+            "minimum": 10,
+            "maximum": 600
+          }
+        },
+        "required": [
+          "connectionId",
+          "image"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "docker_status_v1",
+      "capabilityId": "docker.inspect",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "env_delete_v1",
+      "capabilityId": "env.write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "env_set_v1",
+      "capabilityId": "env.write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 20000
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500
+          },
+          "visibleToAi": {
+            "type": "boolean"
+          },
+          "valueVisibleToAi": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "fetch_url",
+      "capabilityId": "web.fetch",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "maxChars": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "get_env_var",
+      "capabilityId": "env.get",
+      "risk": "R4",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "jump_host_create_v1",
+      "capabilityId": "jumphost.create",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          }
+        },
+        "required": [
+          "name",
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "jump_host_delete_v1",
+      "capabilityId": "jumphost.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "jumpHostId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "jumpHostId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "jump_host_get_v1",
+      "capabilityId": "jumphost.get",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "jumpHostId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "jumpHostId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "jump_host_list_v1",
+      "capabilityId": "jumphost.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "jump_host_update_v1",
+      "capabilityId": "jumphost.update",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "jumpHostId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          }
+        },
+        "required": [
+          "jumpHostId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "list_env_vars",
+      "capabilityId": "env.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "memory_save",
+      "capabilityId": "memory.write",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "projects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "connectionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "memory_search",
+      "capabilityId": "memory.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "connectionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "maxResults": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_bulk_v1",
+      "capabilityId": "notes.groups",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "noteIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "maxItems": 200
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "trash",
+              "restore",
+              "purge"
+            ]
+          }
+        },
+        "required": [
+          "noteIds",
+          "action"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_create",
+      "capabilityId": "notes.write",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "group": {
+            "type": "string"
+          },
+          "connectionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allowAiRead": {
+            "type": "boolean"
+          },
+          "allowAiWrite": {
+            "type": "boolean"
+          },
+          "allowAi": {
+            "type": "boolean",
+            "description": "兼容字段：同时设置读取与编辑"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_delete",
+      "capabilityId": "notes.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "noteId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "noteId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_get",
+      "capabilityId": "notes.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "noteId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "noteId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_group_delete_v1",
+      "capabilityId": "notes.groups",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "groupPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "groupPath"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_group_rename_v1",
+      "capabilityId": "notes.groups",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "oldPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "newPath": {
+            "type": "string",
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "oldPath",
+          "newPath"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_groups_v1",
+      "capabilityId": "notes.groups_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_list",
+      "capabilityId": "notes.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "group": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "connectionId": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "trash": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_purge_v1",
+      "capabilityId": "notes.groups",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "noteId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "noteId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_restore_v1",
+      "capabilityId": "notes.groups",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "noteId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "noteId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_search",
+      "capabilityId": "notes.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "connectionId": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "note_update",
+      "capabilityId": "notes.write",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "noteId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "group": {
+            "type": "string"
+          },
+          "connectionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allowAiRead": {
+            "type": "boolean"
+          },
+          "allowAiWrite": {
+            "type": "boolean"
+          },
+          "allowAi": {
+            "type": "boolean"
+          },
+          "expectedRevision": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "noteId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "plan_delete",
+      "capabilityId": "plan.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "planId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "plan_task",
+      "capabilityId": "plan.create",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "risk": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "steps"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "plan_update",
+      "capabilityId": "plan.update",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "planned",
+              "running",
+              "paused",
+              "completed",
+              "failed",
+              "cancelled"
+            ]
+          },
+          "pause": {
+            "type": "boolean"
+          },
+          "resume": {
+            "type": "boolean"
+          },
+          "retryFailed": {
+            "type": "boolean"
+          },
+          "note": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "index": {
+                  "type": "number"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "running",
+                    "paused",
+                    "completed",
+                    "failed",
+                    "skipped",
+                    "retrying"
+                  ]
+                },
+                "note": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "planId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "proxy_create_v1",
+      "capabilityId": "proxy.create",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "host": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "port": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "socks5",
+              "http"
+            ]
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 120
+          }
+        },
+        "required": [
+          "name",
+          "host",
+          "port"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "proxy_delete_v1",
+      "capabilityId": "proxy.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "proxyId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "proxyId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "proxy_get_v1",
+      "capabilityId": "proxy.get",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "proxyId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "proxyId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "proxy_list_v1",
+      "capabilityId": "proxy.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "socks5",
+              "http"
+            ]
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "proxy_update_v1",
+      "capabilityId": "proxy.update",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "proxyId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "host": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "port": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "socks5",
+              "http"
+            ]
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 120
+          }
+        },
+        "required": [
+          "proxyId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_desktop_action_v1",
+      "capabilityId": "remotedesktop.action",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tabId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "toolbar",
+              "send_text",
+              "mouse"
+            ]
+          },
+          "captureId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "control": {
+            "type": "string",
+            "enum": [
+              "quality",
+              "fit",
+              "zoom",
+              "clipboard",
+              "keyboard",
+              "shortcuts",
+              "joystick",
+              "drag",
+              "ctrl_alt_del",
+              "reconnect",
+              "disconnect",
+              "clipboard_send",
+              "clipboard_read_local",
+              "clipboard_copy_remote",
+              "shortcut",
+              "text",
+              "mouse_click"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 20000
+          },
+          "sequence": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "paste": {
+            "type": "boolean"
+          },
+          "qualityMode": {
+            "type": "string",
+            "enum": [
+              "balanced",
+              "performance",
+              "quality"
+            ]
+          },
+          "fitMode": {
+            "type": "string",
+            "enum": [
+              "fit",
+              "1:1",
+              "16:9",
+              "4:3",
+              "original",
+              "drag"
+            ]
+          },
+          "zoomPercent": {
+            "type": "number",
+            "minimum": 25,
+            "maximum": 400
+          },
+          "x": {
+            "type": "number",
+            "minimum": 0
+          },
+          "y": {
+            "type": "number",
+            "minimum": 0
+          },
+          "button": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 3
+          },
+          "waitMs": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 15000
+          },
+          "maxWidth": {
+            "type": "number",
+            "minimum": 320,
+            "maximum": 1600
+          },
+          "screenshotWidth": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 16000
+          },
+          "screenshotHeight": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 16000
+          },
+          "originalWidth": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 16000
+          },
+          "originalHeight": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 16000
+          }
+        },
+        "required": [
+          "tabId",
+          "action",
+          "captureId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_desktop_capture_v1",
+      "capabilityId": "remotedesktop.capture",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tabId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "maxWidth": {
+            "type": "number",
+            "minimum": 320,
+            "maximum": 1600
+          },
+          "afterCaptureId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "requireFresh": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_desktop_cert_decide_v1",
+      "capabilityId": "remotedesktop.cert_decide",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tabId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "decision": {
+            "type": "string",
+            "enum": [
+              "accept",
+              "reject"
+            ]
+          },
+          "remember": {
+            "type": "boolean"
+          },
+          "connectionId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "expectedFingerprint": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "waitMs": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 15000
+          }
+        },
+        "required": [
+          "tabId",
+          "decision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_desktop_cert_status_v1",
+      "capabilityId": "remotedesktop.cert_status",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tabId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "connectionId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "requireLive": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_desktop_verify_v1",
+      "capabilityId": "remotedesktop.verify",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tabId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "beforeCaptureId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "afterCaptureId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "actionId": {
+            "type": "string",
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "tabId",
+          "beforeCaptureId",
+          "afterCaptureId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_execute",
+      "capabilityId": "ssh.execute",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "command": {
+            "type": "string"
+          },
+          "timeoutSeconds": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "connectionIds",
+          "command"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_file_rollback",
+      "capabilityId": "ssh.file_rollback",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "snapshotId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "snapshotId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_file_snapshot_list",
+      "capabilityId": "ssh.file_snapshots",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_read_file",
+      "capabilityId": "ssh.file_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "maxBytes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "connectionId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "remote_write_file",
+      "capabilityId": "ssh.file_write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string",
+            "enum": [
+              "utf8",
+              "base64"
+            ]
+          },
+          "append": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "connectionId",
+          "path",
+          "content"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "resource_share_delete_v1",
+      "capabilityId": "resource.share",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "connection",
+              "proxy",
+              "sshKey",
+              "jumpHost",
+              "note"
+            ]
+          },
+          "resourceId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "subjectId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "resourceType",
+          "resourceId",
+          "subjectId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "resource_share_list_v1",
+      "capabilityId": "resource.share_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "connection",
+              "proxy",
+              "sshKey",
+              "jumpHost",
+              "note"
+            ]
+          },
+          "resourceId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "required": [
+          "resourceType",
+          "resourceId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "resource_share_put_v1",
+      "capabilityId": "resource.share",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "connection",
+              "proxy",
+              "sshKey",
+              "jumpHost",
+              "note"
+            ]
+          },
+          "resourceId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "shares": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "subjectId": {
+                  "type": "string"
+                },
+                "tier": {
+                  "type": "string"
+                },
+                "capabilities": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "expiresAt": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "subjectId"
+              ],
+              "additionalProperties": false
+            },
+            "maxItems": 200
+          }
+        },
+        "required": [
+          "resourceType",
+          "resourceId",
+          "shares"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "resource_shared_with_me_v1",
+      "capabilityId": "resource.share_read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "connection",
+              "proxy",
+              "sshKey",
+              "jumpHost",
+              "note"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "secret_ref_list_v1",
+      "capabilityId": "secretref.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "ssh_key",
+              "proxy"
+            ]
+          },
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "session_exec_v1",
+      "capabilityId": "sandbox.exec",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 8192
+            },
+            "maxItems": 128
+          },
+          "cwd": {
+            "type": "string",
+            "maxLength": 512,
+            "description": "相对会话根，默认 workspace"
+          },
+          "timeoutMs": {
+            "type": "number",
+            "minimum": 1000,
+            "maximum": 300000
+          },
+          "network": {
+            "type": "boolean",
+            "description": "默认 false；uv/npm/go mod 拉包时需 true+策略"
+          }
+        },
+        "required": [
+          "command"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "session_sandbox_status_v1",
+      "capabilityId": "sandbox.status",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "sftp_chmod_v1",
+      "capabilityId": "sftp.write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          },
+          "mode": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 6,
+            "description": "octal mode like 644 or 0755"
+          }
+        },
+        "required": [
+          "connectionId",
+          "path",
+          "mode"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "sftp_delete_v1",
+      "capabilityId": "sftp.write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          },
+          "recursive": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "connectionId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "sftp_list_v1",
+      "capabilityId": "sftp.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 4000
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "sftp_mkdir_v1",
+      "capabilityId": "sftp.write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          },
+          "recursive": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "connectionId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "sftp_rename_v1",
+      "capabilityId": "sftp.write",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "oldPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          },
+          "newPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          }
+        },
+        "required": [
+          "connectionId",
+          "oldPath",
+          "newPath"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "sftp_stat_v1",
+      "capabilityId": "sftp.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          }
+        },
+        "required": [
+          "connectionId",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "snippet_create_v1",
+      "capabilityId": "snippet.create",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20000
+          },
+          "group": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "autoRun": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "command"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "snippet_delete_v1",
+      "capabilityId": "snippet.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "snippetId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "snippetId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "snippet_get_v1",
+      "capabilityId": "snippet.get",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "snippetId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "snippetId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "snippet_list_v1",
+      "capabilityId": "snippet.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "group": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "autoRun": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 500
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "snippet_update_v1",
+      "capabilityId": "snippet.update",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "snippetId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20000
+          },
+          "group": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "autoRun": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "snippetId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ssh_key_delete_v1",
+      "capabilityId": "sshkey.delete",
+      "risk": "R3",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sshKeyId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "sshKeyId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ssh_key_get_v1",
+      "capabilityId": "sshkey.get",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sshKeyId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "sshKeyId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ssh_key_list_v1",
+      "capabilityId": "sshkey.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 200
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ssh_key_rename_v1",
+      "capabilityId": "sshkey.rename",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sshKeyId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "sshKeyId",
+          "name",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ssh_key_update_metadata_v1",
+      "capabilityId": "sshkey.metadata_update",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sshKeyId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "remark": {
+            "type": "string",
+            "maxLength": 20000
+          },
+          "expectedRevision": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "sshKeyId",
+          "expectedRevision"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ssh_key_validate_v1",
+      "capabilityId": "sshkey.validate",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sshKeyId": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "sshKeyId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "subagent_fleet_v1",
+      "capabilityId": "subagent.fleet",
+      "risk": "R2",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tasks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "prompt": {
+                  "type": "string"
+                },
+                "profileId": {
+                  "type": "string"
+                },
+                "connectionId": {
+                  "type": "string"
+                },
+                "tabId": {
+                  "type": "string"
+                },
+                "workspacePath": {
+                  "type": "string"
+                },
+                "resourceClaims": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              },
+              "required": [
+                "prompt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "tasks"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "subagent_list_profiles_v1",
+      "capabilityId": "subagent.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "subagent_parallel_v1",
+      "capabilityId": "subagent.parallel",
+      "risk": "R1",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "profileId": {
+            "type": "string"
+          },
+          "tasks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "prompt": {
+                  "type": "string"
+                },
+                "profileId": {
+                  "type": "string"
+                },
+                "connectionId": {
+                  "type": "string"
+                },
+                "connectionIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "prompt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "tasks"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "subagent_task_v1",
+      "capabilityId": "subagent.task",
+      "risk": "R1",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "profileId": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "connectionId": {
+            "type": "string"
+          },
+          "connectionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tabId": {
+            "type": "string"
+          },
+          "workspacePath": {
+            "type": "string"
+          },
+          "maxSteps": {
+            "type": "number"
+          },
+          "resourceClaims": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "readOnly": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "terminal_read_v1",
+      "capabilityId": "terminal.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160,
+            "description": "可省略；默认使用当前活跃 SSH/TELNET 会话。也可传真实 sessionId、tabId、唯一 connectionId 或连接名。"
+          },
+          "maxChars": {
+            "type": "number",
+            "minimum": 1000,
+            "maximum": 120000
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "terminal_send_v1",
+      "capabilityId": "terminal.send",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160,
+            "description": "可省略；默认使用当前活跃 SSH/TELNET 会话。也可传真实 sessionId、tabId、唯一 connectionId 或连接名。"
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20000
+          },
+          "appendNewline": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "terminal_wait_v1",
+      "capabilityId": "terminal.wait",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160,
+            "description": "可省略；默认使用当前活跃 SSH/TELNET 会话。也可传真实 sessionId、tabId、唯一 connectionId 或连接名。"
+          },
+          "pattern": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "regex": {
+            "type": "boolean"
+          },
+          "caseSensitive": {
+            "type": "boolean"
+          },
+          "timeoutMs": {
+            "type": "number",
+            "minimum": 100,
+            "maximum": 120000
+          },
+          "pollMs": {
+            "type": "number",
+            "minimum": 50,
+            "maximum": 2000
+          },
+          "maxChars": {
+            "type": "number",
+            "minimum": 1000,
+            "maximum": 120000
+          }
+        },
+        "required": [
+          "pattern"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "ui_action",
+      "capabilityId": "ui.act",
+      "risk": "R2",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "switch_view",
+              "open_add_connection",
+              "open_edit_connection",
+              "terminal_fullscreen",
+              "terminal_exit_fullscreen",
+              "terminal_window_action",
+              "terminal_toolbar",
+              "terminal_send_input",
+              "remote_desktop_toolbar",
+              "remote_desktop_send_text",
+              "remote_desktop_mouse",
+              "toast"
+            ]
+          },
+          "view": {
+            "type": "string",
+            "enum": [
+              "dashboard",
+              "terminal",
+              "remote",
+              "settings"
+            ]
+          },
+          "settingsSection": {
+            "type": "string",
+            "enum": [
+              "ai",
+              "appearance",
+              "terminal",
+              "network",
+              "profile",
+              "snippets"
+            ]
+          },
+          "connectionId": {
+            "type": "string"
+          },
+          "tabId": {
+            "type": "string"
+          },
+          "windowAction": {
+            "type": "string",
+            "enum": [
+              "fullscreen",
+              "exit-fullscreen",
+              "left-half",
+              "right-half",
+              "right-top",
+              "right-bottom",
+              "left-two-thirds",
+              "right-two-thirds",
+              "minimize",
+              "close",
+              "reconnect-mobile"
+            ]
+          },
+          "control": {
+            "type": "string",
+            "enum": [
+              "file",
+              "info",
+              "docker",
+              "snippet",
+              "shortcut",
+              "copy",
+              "paste",
+              "theme",
+              "wterm-theme",
+              "reconnect",
+              "disconnect",
+              "quality",
+              "fit",
+              "zoom",
+              "clipboard",
+              "keyboard",
+              "shortcuts",
+              "joystick",
+              "drag",
+              "ctrl_alt_del",
+              "clipboard_send",
+              "clipboard_read_local",
+              "clipboard_copy_remote"
+            ]
+          },
+          "desktopControl": {
+            "type": "string",
+            "enum": [
+              "quality",
+              "fit",
+              "zoom",
+              "clipboard",
+              "keyboard",
+              "shortcuts",
+              "joystick",
+              "drag",
+              "ctrl_alt_del",
+              "reconnect",
+              "disconnect",
+              "clipboard_send",
+              "clipboard_read_local",
+              "clipboard_copy_remote",
+              "shortcut",
+              "text",
+              "mouse_click"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "run": {
+            "type": "boolean"
+          },
+          "maxChars": {
+            "type": "number"
+          },
+          "maxWidth": {
+            "type": "number"
+          },
+          "qualityMode": {
+            "type": "string",
+            "enum": [
+              "balanced",
+              "performance",
+              "quality"
+            ]
+          },
+          "fitMode": {
+            "type": "string",
+            "enum": [
+              "fit",
+              "1:1",
+              "16:9",
+              "4:3",
+              "original",
+              "drag"
+            ]
+          },
+          "zoomPercent": {
+            "type": "number"
+          },
+          "sequence": {
+            "type": "string"
+          },
+          "paste": {
+            "type": "boolean"
+          },
+          "x": {
+            "type": "number"
+          },
+          "y": {
+            "type": "number"
+          },
+          "button": {
+            "type": "number"
+          },
+          "coordinateSpace": {
+            "type": "string",
+            "enum": [
+              "remote",
+              "screenshot"
+            ]
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "user_attachment_read_v1",
+      "capabilityId": "workspace.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "attachmentId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "user_attachment_view_v1",
+      "capabilityId": "workspace.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachmentId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "web_search",
+      "capabilityId": "web.search",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "maxResults": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "workspace_list_v1",
+      "capabilityId": "workspace.list",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "dir": {
+            "type": "string",
+            "description": "相对路径，如 uploads 或 workspace/notes"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "workspace_read_v1",
+      "capabilityId": "workspace.read",
+      "risk": "R0",
+      "confirmation": "never",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "toolId": "workspace_write_v1",
+      "capabilityId": "workspace.write",
+      "risk": "R1",
+      "confirmation": "always",
+      "playbookId": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ],
+        "additionalProperties": false
+      }
+    }
+  ]
+}

--- a/FREEZE/zephyr one for mobile/contracts/entity-registry.json
+++ b/FREEZE/zephyr one for mobile/contracts/entity-registry.json
@@ -1,0 +1,747 @@
+{
+  "version": 1,
+  "sourceCommit": "3a61d2f",
+  "classification": [
+    "editableSync",
+    "opaquePreserve",
+    "deviceLocal",
+    "serverOnly"
+  ],
+  "invariants": [
+    "[KNOWN] owner identity uses immutable userId; username is display/compatibility data.",
+    "[KNOWN] shared use does not imply revealSecret; dependency ACL is rechecked at use time.",
+    "[KNOWN] unknown fields are retained but never emitted in a One-authored fieldMask.",
+    "[INFERRED] every editable field must have a field-revision entry before mobile v1 release."
+  ],
+  "entities": [
+    {
+      "type": "connection",
+      "source": "storage.js connections + resource-service.js",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 40,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "host",
+        "port",
+        "protocol",
+        "username",
+        "remark",
+        "tags",
+        "connectionMode",
+        "proxyId",
+        "jumpHostId",
+        "jumpHostIds",
+        "sshKeyId",
+        "rdpSoundMode",
+        "rdpClipboard",
+        "rdpMicrophone",
+        "rdpCamera",
+        "rdpStorage",
+        "rdpLocation",
+        "rdpResolution",
+        "rdpQuality",
+        "rdpFps",
+        "rdpTouchMode",
+        "rdpTouchSensitivity",
+        "rdpDomain",
+        "encoding",
+        "visibility"
+      ],
+      "secretFields": [
+        "password",
+        "privateKey"
+      ],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "createdByUserId",
+        "revision",
+        "createdAt",
+        "updatedAt",
+        "lastConnectedAt"
+      ],
+      "opaquePreserveFields": [
+        "rdpPipeline"
+      ],
+      "deviceLocalFields": [
+        "ephemeral"
+      ],
+      "capabilities": [
+        "discover",
+        "view",
+        "use",
+        "observe",
+        "control",
+        "execute",
+        "fileRead",
+        "fileWrite",
+        "edit",
+        "share",
+        "delete",
+        "revealSecret"
+      ],
+      "status": "source-ready-needs-tombstone-hook"
+    },
+    {
+      "type": "proxy",
+      "source": "storage.js proxies + resource-service.js",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 10,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "host",
+        "port",
+        "type",
+        "username",
+        "visibility"
+      ],
+      "secretFields": [
+        "password"
+      ],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "capabilities": [
+        "discover",
+        "view",
+        "use",
+        "edit",
+        "share",
+        "delete",
+        "revealSecret"
+      ],
+      "status": "source-ready-needs-tombstone-hook"
+    },
+    {
+      "type": "sshKey",
+      "source": "storage.js ssh_keys + resource-service.js",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 10,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "remark",
+        "visibility"
+      ],
+      "secretFields": [
+        "privateKey",
+        "passphrase"
+      ],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "capabilities": [
+        "discover",
+        "view",
+        "use",
+        "edit",
+        "share",
+        "delete",
+        "revealSecret"
+      ],
+      "status": "source-ready-needs-tombstone-hook"
+    },
+    {
+      "type": "jumpHost",
+      "source": "storage.js jump_hosts + resource-service.js",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 20,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "connectionId",
+        "visibility"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "capabilities": [
+        "discover",
+        "view",
+        "use",
+        "edit",
+        "share",
+        "delete"
+      ],
+      "status": "source-ready-needs-tombstone-hook"
+    },
+    {
+      "type": "note",
+      "source": "storage.js notes + notes-service.js",
+      "idField": "noteId",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "soft-delete-then-tombstone",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "title",
+        "content",
+        "groupPath",
+        "tags",
+        "linkedConnectionIds",
+        "sortOrder",
+        "shareWithUsers",
+        "shareWithAdmins",
+        "allowAiRead",
+        "allowAiWrite",
+        "visibility"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt",
+        "deletedAt"
+      ],
+      "opaquePreserveFields": [
+        "allowAi"
+      ],
+      "deviceLocalFields": [],
+      "limits": {
+        "titleChars": 200,
+        "contentBytes": 1048576,
+        "tags": 100,
+        "links": 100,
+        "bulk": 200
+      },
+      "status": "source-ready-soft-delete-exists"
+    },
+    {
+      "type": "snippet",
+      "source": "user_settings.snippets + ai-snippet-tools.js",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "command",
+        "group",
+        "autoRun"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "limits": {
+        "count": 500,
+        "nameChars": 60,
+        "commandChars": 20000,
+        "groupChars": 40
+      },
+      "status": "requires-normalization-out-of-settings-bag"
+    },
+    {
+      "type": "aiProvider",
+      "source": "ai-provider-service.js ai_providers",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 10,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "type",
+        "baseUrl",
+        "defaultModel",
+        "models",
+        "config",
+        "visibility",
+        "shareWithUsers",
+        "shareWithAdmins",
+        "sharedUserIds",
+        "enabled"
+      ],
+      "secretFields": [
+        "apiKey"
+      ],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "status": "requires-revision-and-change-hook"
+    },
+    {
+      "type": "aiMemory",
+      "source": "settings.ai.memories",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "title",
+        "content",
+        "scope",
+        "project",
+        "projects",
+        "tags",
+        "connectionIds"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "limits": {
+        "count": 2000
+      },
+      "status": "requires-normalization-out-of-global-settings"
+    },
+    {
+      "type": "aiSkill",
+      "source": "settings.ai.skills",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "description",
+        "prompt",
+        "enabled"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "limits": {
+        "count": 200
+      },
+      "status": "requires-normalization-out-of-global-settings"
+    },
+    {
+      "type": "aiEnv",
+      "source": "settings.ai.envVars",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 20,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "enabled",
+        "visibleToAi"
+      ],
+      "secretFields": [
+        "value"
+      ],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "limits": {
+        "count": 200
+      },
+      "status": "requires-normalization-out-of-global-settings"
+    },
+    {
+      "type": "aiConversation",
+      "source": "AI runtime session service",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "title",
+        "providerId",
+        "model",
+        "archived"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [
+        "runtimeMetadata"
+      ],
+      "deviceLocalFields": [
+        "activeRunId"
+      ],
+      "status": "blocked-no-canonical-server-schema"
+    },
+    {
+      "type": "aiMessage",
+      "source": "AI runtime session service",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 60,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "conversationId",
+        "role",
+        "content",
+        "attachments"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [
+        "toolEvents",
+        "usage"
+      ],
+      "deviceLocalFields": [
+        "streamState"
+      ],
+      "status": "blocked-no-canonical-server-schema"
+    },
+    {
+      "type": "oneUserSettings",
+      "source": "user-settings-service.js user_settings",
+      "idField": "sectionKey",
+      "ownerField": "userId",
+      "revisionField": "revision",
+      "deleteMode": "reset-to-default",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "appearance.theme",
+        "appearance.autoThemeEnabled",
+        "appearance.colorScheme",
+        "appearance.customThemeMode",
+        "appearance.customColors",
+        "appearance.terminalBackground",
+        "appearance.terminalFontColor",
+        "appearance.terminalFontColors",
+        "appearance.rdp",
+        "terminal.maxWindows",
+        "terminal.minimizedKeepAlive",
+        "terminal.smartbarOrder",
+        "terminal.shortcutPlatform",
+        "terminal.allowLigatures",
+        "notes.enabled",
+        "notes.editorMode",
+        "notes.fontSize",
+        "workspace.defaultView",
+        "workspace.sessionPersistence",
+        "ai.panelLayout",
+        "ai.assistantName"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "userId",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [
+        "appearance.customCss",
+        "mail.notifyLogin"
+      ],
+      "deviceLocalFields": [],
+      "status": "requires-per-key-revision"
+    },
+    {
+      "type": "serverSettings",
+      "source": "storage.js settings + /api/settings sections",
+      "idField": "sectionKey",
+      "ownerField": "serverId",
+      "revisionField": "revision",
+      "deleteMode": "reset-to-default",
+      "dependencyOrder": 50,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "appearance",
+        "notes",
+        "ai.enabled",
+        "ai.permissions",
+        "ai.context",
+        "ai.memory.enabled",
+        "ai.memory.maxItems"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "serverId",
+        "revision",
+        "updatedAt",
+        "requiredRole"
+      ],
+      "opaquePreserveFields": [
+        "security",
+        "mail",
+        "captcha",
+        "beian",
+        "appearance.customCss",
+        "appearance.customJs"
+      ],
+      "deviceLocalFields": [],
+      "status": "role-gated-adapter-required-ai-provider-memory-skill-env-are-separate-entities"
+    },
+    {
+      "type": "backupMetadata",
+      "source": "/api/data/export + /api/data/import",
+      "idField": "backupId",
+      "ownerField": "serverId",
+      "revisionField": "revision",
+      "deleteMode": "job-retention",
+      "dependencyOrder": 70,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "label",
+        "retentionHint"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "serverId",
+        "revision",
+        "createdAt",
+        "size",
+        "sha256",
+        "appVersion",
+        "encryptionAlgorithm",
+        "jobStatus"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [
+        "localDownloadUri"
+      ],
+      "status": "requires-job-and-metadata-layer"
+    },
+    {
+      "type": "activityEvent",
+      "source": "storage.js activities",
+      "idField": "id",
+      "ownerField": "userId",
+      "revisionField": null,
+      "deleteMode": "append-only",
+      "dependencyOrder": 80,
+      "minimumClientVersion": 1,
+      "editableFields": [],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "id",
+        "userId",
+        "time",
+        "message",
+        "type",
+        "sourceIp",
+        "durationMs",
+        "category",
+        "outcome",
+        "actor",
+        "protocol",
+        "target",
+        "connectionId"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "status": "source-ready-add-change-hook"
+    },
+    {
+      "type": "resourceAcl",
+      "source": "authz.js resource_acl",
+      "idField": "grantKey",
+      "ownerField": "resourceOwnerUserId",
+      "revisionField": "revision",
+      "deleteMode": "revocation-tombstone",
+      "dependencyOrder": 30,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "subjectType",
+        "subjectId",
+        "capabilities",
+        "expiresAt"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "grantedByUserId",
+        "createdAt",
+        "revokedAt",
+        "revision"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "capabilityValues": [
+        "discover",
+        "view",
+        "use",
+        "observe",
+        "control",
+        "execute",
+        "fileRead",
+        "fileWrite",
+        "edit",
+        "share",
+        "delete",
+        "revealSecret",
+        "administer"
+      ],
+      "status": "source-ready-add-revision-and-change-hook"
+    },
+    {
+      "type": "clientToken",
+      "source": "file-agent-manager.js agent-tokens.json v2",
+      "idField": "id",
+      "ownerField": "ownerUserId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 0,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name"
+      ],
+      "secretFields": [
+        "token"
+      ],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "revision",
+        "createdAt",
+        "updatedAt",
+        "lastUsedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [],
+      "limits": {
+        "nameChars": 80,
+        "tokenCharsMin": 16,
+        "tokenCharsMax": 256
+      },
+      "status": "blocked-migrate-plaintext-json-to-encrypted-sqlite"
+    },
+    {
+      "type": "workspaceState",
+      "source": "workspace-service.js workspaces",
+      "idField": "workspaceId",
+      "ownerField": "userId",
+      "revisionField": "revision",
+      "deleteMode": "tombstone",
+      "dependencyOrder": 80,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "name",
+        "state"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "userId",
+        "revision",
+        "updatedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [
+        "clientId"
+      ],
+      "limits": {
+        "stateBytes": 262144,
+        "countPerUser": 20,
+        "retentionDays": 90
+      },
+      "status": "source-ready-mobile-state-adapter-required"
+    },
+    {
+      "type": "fileSyncConfig",
+      "source": "one-client-manager.js one_clients",
+      "idField": "clientId",
+      "ownerField": "ownerUserId",
+      "revisionField": "syncRevision",
+      "deleteMode": "revoke",
+      "dependencyOrder": 0,
+      "minimumClientVersion": 1,
+      "editableFields": [
+        "deviceName",
+        "enabled",
+        "automaticEnabled",
+        "syncIntervalSec",
+        "networkPolicy"
+      ],
+      "secretFields": [],
+      "serverAuthorityFields": [
+        "ownerUserId",
+        "tokenId",
+        "platform",
+        "appVersion",
+        "lastSyncAt",
+        "lastSeenAt",
+        "createdAt",
+        "revokedAt"
+      ],
+      "opaquePreserveFields": [],
+      "deviceLocalFields": [
+        "lastLocalAttemptAt",
+        "localError"
+      ],
+      "limits": {
+        "intervalSecondsMin": 30,
+        "intervalSecondsMax": 86400
+      },
+      "status": "source-partial-needs-automatic-flag-and-v1-credentials"
+    }
+  ],
+  "excludedEditableScopes": [
+    "accountSecurity",
+    "smtp",
+    "captcha",
+    "ipPolicy",
+    "beian",
+    "customCssJs",
+    "multiUserAdmin"
+  ]
+}

--- a/FREEZE/zephyr one for mobile/contracts/entity-registry.json
+++ b/FREEZE/zephyr one for mobile/contracts/entity-registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "sourceCommit": "3a61d2f",
+  "sourceCommit": "8dd5b98",
   "classification": [
     "editableSync",
     "opaquePreserve",

--- a/FREEZE/zephyr one for mobile/contracts/error-registry.json
+++ b/FREEZE/zephyr one for mobile/contracts/error-registry.json
@@ -17,46 +17,11 @@
   ],
   "errors": [
     {
-      "code": "invalid_request",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "fix_input",
-      "source": "新 mobile v1"
-    },
-    {
-      "code": "unsupported_protocol_version",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "upgrade_app",
-      "source": "新 mobile v1"
-    },
-    {
-      "code": "registry_mismatch",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "upgrade_or_refresh_registry",
-      "source": "新 mobile v1"
-    },
-    {
-      "code": "app_session_expired",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "sign_in",
-      "source": "server.js requireUser"
-    },
-    {
-      "code": "invalid_credentials",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "correct_credentials",
-      "source": "server.js auth"
-    },
-    {
-      "code": "must_change_password",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "open_system_browser",
-      "source": "server.js requireUser"
+      "code": "account_locked",
+      "httpStatus": 429,
+      "retryable": true,
+      "clientAction": "wait_then_retry",
+      "source": "server.js login"
     },
     {
       "code": "account_suspended",
@@ -66,104 +31,6 @@
       "source": "authz.js/server.js"
     },
     {
-      "code": "account_locked",
-      "httpStatus": 429,
-      "retryable": true,
-      "clientAction": "wait_then_retry",
-      "source": "server.js login"
-    },
-    {
-      "code": "login_guard_blocked",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "show_server_policy",
-      "source": "server.js TOTP"
-    },
-    {
-      "code": "captcha_required",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "open_auth_session",
-      "source": "mobile adapter"
-    },
-    {
-      "code": "totp_required",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "enter_totp",
-      "source": "server.js login result"
-    },
-    {
-      "code": "totp_invalid",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "retry_totp",
-      "source": "mobile adapter"
-    },
-    {
-      "code": "totp_temp_exhausted",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "restart_sign_in",
-      "source": "server.js TOTP"
-    },
-    {
-      "code": "token_required",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "create_token_on_server",
-      "source": "one-client-manager.js"
-    },
-    {
-      "code": "token_not_found",
-      "httpStatus": 404,
-      "retryable": false,
-      "clientAction": "select_valid_token",
-      "source": "one-client-manager.js"
-    },
-    {
-      "code": "token_missing",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "rebind",
-      "source": "one-client-manager.js"
-    },
-    {
-      "code": "token_rotated",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "rebind",
-      "source": "mobile v1"
-    },
-    {
-      "code": "client_owned_by_other",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "regenerate_device_id",
-      "source": "one-client-manager.js"
-    },
-    {
-      "code": "client_not_found",
-      "httpStatus": 404,
-      "retryable": false,
-      "clientAction": "bind_device",
-      "source": "one-client-manager.js"
-    },
-    {
-      "code": "client_disabled",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "enable_on_server",
-      "source": "one-client-manager.js"
-    },
-    {
-      "code": "client_revoked",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "rebind",
-      "source": "one-client-manager.js"
-    },
-    {
       "code": "account_unavailable",
       "httpStatus": 403,
       "retryable": false,
@@ -171,214 +38,11 @@
       "source": "one-client-manager.js"
     },
     {
-      "code": "device_proof_invalid",
+      "code": "app_session_expired",
       "httpStatus": 401,
       "retryable": false,
-      "clientAction": "refresh_or_rebind",
-      "source": "mobile v1"
-    },
-    {
-      "code": "refresh_replayed",
-      "httpStatus": 401,
-      "retryable": false,
-      "clientAction": "rebind",
-      "source": "mobile v1"
-    },
-    {
-      "code": "sensitive_verification_required",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "verify_sensitive_action",
-      "source": "mobile v1"
-    },
-    {
-      "code": "sensitive_verification_failed",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "retry_sensitive_action",
-      "source": "server.js verifySensitiveAccess"
-    },
-    {
-      "code": "sensitive_grant_expired",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "verify_sensitive_action",
-      "source": "mobile v1"
-    },
-    {
-      "code": "sensitive_grant_consumed",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "verify_sensitive_action",
-      "source": "mobile v1"
-    },
-    {
-      "code": "resource_not_found_or_inaccessible",
-      "httpStatus": 404,
-      "retryable": false,
-      "clientAction": "remove_or_refresh",
-      "source": "authz.js"
-    },
-    {
-      "code": "forbidden_resource_use",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "show_permission",
-      "source": "authz.js"
-    },
-    {
-      "code": "forbidden_resource_edit",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "show_permission",
-      "source": "authz.js"
-    },
-    {
-      "code": "forbidden_resource_delete",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "show_permission",
-      "source": "authz.js"
-    },
-    {
-      "code": "forbidden_resource_revealSecret",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "show_permission",
-      "source": "authz.js"
-    },
-    {
-      "code": "forbidden_dependency_proxy",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "repair_route",
-      "source": "resource-service.js"
-    },
-    {
-      "code": "forbidden_dependency_sshKey",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "repair_route",
-      "source": "resource-service.js"
-    },
-    {
-      "code": "forbidden_dependency_jumpHost",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "repair_route",
-      "source": "resource-service.js"
-    },
-    {
-      "code": "forbidden_dependency_jumpConnection",
-      "httpStatus": 403,
-      "retryable": false,
-      "clientAction": "repair_route",
-      "source": "resource-service.js"
-    },
-    {
-      "code": "invalid_dependency",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "repair_route",
-      "source": "resource-service.js"
-    },
-    {
-      "code": "revision_required",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "refresh_entity",
-      "source": "notes-service.js"
-    },
-    {
-      "code": "revision_conflict",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "open_conflict",
-      "source": "ai-snippet-tools.js/mobile v1"
-    },
-    {
-      "code": "note_revision_conflict",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "open_conflict",
-      "source": "notes-service.js"
-    },
-    {
-      "code": "workspace_revision_conflict",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "open_conflict",
-      "source": "workspace-service.js"
-    },
-    {
-      "code": "sync_conflict",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "open_conflict",
-      "source": "mobile v1"
-    },
-    {
-      "code": "dependency_missing",
-      "httpStatus": 409,
-      "retryable": true,
-      "clientAction": "retry_after_dependency",
-      "source": "mobile v1"
-    },
-    {
-      "code": "duplicate_operation",
-      "httpStatus": 200,
-      "retryable": false,
-      "clientAction": "accept_original_result",
-      "source": "mobile v1"
-    },
-    {
-      "code": "cursor_invalid",
-      "httpStatus": 409,
-      "retryable": false,
-      "clientAction": "restart_bootstrap",
-      "source": "mobile v1"
-    },
-    {
-      "code": "cursor_expired",
-      "httpStatus": 410,
-      "retryable": false,
-      "clientAction": "restart_bootstrap",
-      "source": "mobile v1"
-    },
-    {
-      "code": "bootstrap_expired",
-      "httpStatus": 410,
-      "retryable": false,
-      "clientAction": "restart_bootstrap",
-      "source": "mobile v1"
-    },
-    {
-      "code": "unsupported_scope",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "drop_operation_and_report",
-      "source": "mobile v1"
-    },
-    {
-      "code": "unknown_entity_type",
-      "httpStatus": 400,
-      "retryable": false,
-      "clientAction": "upgrade_or_drop_operation",
-      "source": "mobile v1"
-    },
-    {
-      "code": "payload_too_large",
-      "httpStatus": 413,
-      "retryable": false,
-      "clientAction": "split_payload",
-      "source": "file-transfer-protocol.js/mobile v1"
-    },
-    {
-      "code": "metadata_too_large",
-      "httpStatus": 413,
-      "retryable": false,
-      "clientAction": "split_payload",
-      "source": "file-transfer-protocol.js"
+      "clientAction": "sign_in",
+      "source": "server.js requireUser"
     },
     {
       "code": "blob_hash_mismatch",
@@ -395,10 +59,269 @@
       "source": "mobile v1"
     },
     {
+      "code": "bootstrap_expired",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "restart_bootstrap",
+      "source": "mobile v1"
+    },
+    {
+      "code": "captcha_required",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "open_auth_session",
+      "source": "mobile adapter"
+    },
+    {
+      "code": "client_disabled",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "enable_on_server",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "client_not_found",
+      "httpStatus": 404,
+      "retryable": false,
+      "clientAction": "bind_device",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "client_owned_by_other",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "regenerate_device_id",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "client_revoked",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "cursor_expired",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "restart_bootstrap",
+      "source": "mobile v1"
+    },
+    {
+      "code": "cursor_invalid",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "restart_bootstrap",
+      "source": "mobile v1"
+    },
+    {
+      "code": "dependency_missing",
+      "httpStatus": 409,
+      "retryable": true,
+      "clientAction": "retry_after_dependency",
+      "source": "mobile v1"
+    },
+    {
+      "code": "device_proof_invalid",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "refresh_or_rebind",
+      "source": "mobile v1"
+    },
+    {
+      "code": "duplicate_operation",
+      "httpStatus": 200,
+      "retryable": false,
+      "clientAction": "accept_original_result",
+      "source": "mobile v1"
+    },
+    {
+      "code": "forbidden_dependency_jumpConnection",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_dependency_jumpHost",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_dependency_proxy",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_dependency_sshKey",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_resource_delete",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_edit",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_revealSecret",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_use",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "internal_error",
+      "httpStatus": 500,
+      "retryable": true,
+      "clientAction": "backoff_then_report",
+      "source": "handleServiceError"
+    },
+    {
+      "code": "invalid_credentials",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "correct_credentials",
+      "source": "server.js auth"
+    },
+    {
+      "code": "invalid_dependency",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "invalid_request",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "fix_input",
+      "source": "新 mobile v1"
+    },
+    {
+      "code": "login_guard_blocked",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_server_policy",
+      "source": "server.js TOTP"
+    },
+    {
+      "code": "metadata_too_large",
+      "httpStatus": 413,
+      "retryable": false,
+      "clientAction": "split_payload",
+      "source": "file-transfer-protocol.js"
+    },
+    {
+      "code": "must_change_password",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "open_system_browser",
+      "source": "server.js requireUser"
+    },
+    {
+      "code": "note_revision_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "notes-service.js"
+    },
+    {
+      "code": "payload_too_large",
+      "httpStatus": 413,
+      "retryable": false,
+      "clientAction": "split_payload",
+      "source": "file-transfer-protocol.js/mobile v1"
+    },
+    {
       "code": "rate_limited",
       "httpStatus": 429,
       "retryable": true,
       "clientAction": "respect_retry_after",
+      "source": "mobile v1"
+    },
+    {
+      "code": "refresh_replayed",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "mobile v1"
+    },
+    {
+      "code": "registry_mismatch",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "upgrade_or_refresh_registry",
+      "source": "新 mobile v1"
+    },
+    {
+      "code": "resource_not_found_or_inaccessible",
+      "httpStatus": 404,
+      "retryable": false,
+      "clientAction": "remove_or_refresh",
+      "source": "authz.js"
+    },
+    {
+      "code": "revision_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "ai-snippet-tools.js/mobile v1"
+    },
+    {
+      "code": "revision_required",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "refresh_entity",
+      "source": "notes-service.js"
+    },
+    {
+      "code": "sensitive_grant_consumed",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "verify_sensitive_action",
+      "source": "mobile v1"
+    },
+    {
+      "code": "sensitive_grant_expired",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "verify_sensitive_action",
+      "source": "mobile v1"
+    },
+    {
+      "code": "sensitive_verification_failed",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "retry_sensitive_action",
+      "source": "server.js verifySensitiveAccess"
+    },
+    {
+      "code": "sensitive_verification_required",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "verify_sensitive_action",
       "source": "mobile v1"
     },
     {
@@ -409,11 +332,142 @@
       "source": "mobile v1"
     },
     {
-      "code": "internal_error",
-      "httpStatus": 500,
+      "code": "shared_content_export_forbidden",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "disableExport"
+    },
+    {
+      "code": "shared_direct_forbidden",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "offerRelay"
+    },
+    {
+      "code": "shared_grant_expired",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "dismissShared"
+    },
+    {
+      "code": "shared_grant_revoked",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "dismissShared"
+    },
+    {
+      "code": "shared_online_required",
+      "httpStatus": 503,
       "retryable": true,
-      "clientAction": "backoff_then_report",
-      "source": "handleServiceError"
+      "clientAction": "retry"
+    },
+    {
+      "code": "shared_relay_unavailable",
+      "httpStatus": 503,
+      "retryable": true,
+      "clientAction": "retryRelayOnly"
+    },
+    {
+      "code": "shared_residency_violation",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "abortSyncAndPurgeShared"
+    },
+    {
+      "code": "shared_session_consumed",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "mintFreshSessionEnvelope"
+    },
+    {
+      "code": "shared_session_expired",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "reopenSharedSession"
+    },
+    {
+      "code": "sync_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "mobile v1"
+    },
+    {
+      "code": "token_missing",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "token_not_found",
+      "httpStatus": 404,
+      "retryable": false,
+      "clientAction": "select_valid_token",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "token_required",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "create_token_on_server",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "token_rotated",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "mobile v1"
+    },
+    {
+      "code": "totp_invalid",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "retry_totp",
+      "source": "mobile adapter"
+    },
+    {
+      "code": "totp_required",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "enter_totp",
+      "source": "server.js login result"
+    },
+    {
+      "code": "totp_temp_exhausted",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "restart_sign_in",
+      "source": "server.js TOTP"
+    },
+    {
+      "code": "unknown_entity_type",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "upgrade_or_drop_operation",
+      "source": "mobile v1"
+    },
+    {
+      "code": "unsupported_protocol_version",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "upgrade_app",
+      "source": "新 mobile v1"
+    },
+    {
+      "code": "unsupported_scope",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "drop_operation_and_report",
+      "source": "mobile v1"
+    },
+    {
+      "code": "workspace_revision_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "workspace-service.js"
     }
   ]
 }

--- a/FREEZE/zephyr one for mobile/contracts/error-registry.json
+++ b/FREEZE/zephyr one for mobile/contracts/error-registry.json
@@ -1,0 +1,419 @@
+{
+  "version": 1,
+  "responseShape": {
+    "ok": false,
+    "error": {
+      "code": "string",
+      "message": "localized string",
+      "retryable": "boolean",
+      "details": "object|null",
+      "requestId": "string"
+    }
+  },
+  "rules": [
+    "[KNOWN] 客户端只按 code 分支，不解析 message。",
+    "[KNOWN] 429 必须遵守 Retry-After；401 最多自动 refresh 一次；403 不无限重试。",
+    "[INFERRED] 新 mobile v1 一律使用统一嵌套 error；旧接口由 adapter 正规化。"
+  ],
+  "errors": [
+    {
+      "code": "invalid_request",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "fix_input",
+      "source": "新 mobile v1"
+    },
+    {
+      "code": "unsupported_protocol_version",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "upgrade_app",
+      "source": "新 mobile v1"
+    },
+    {
+      "code": "registry_mismatch",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "upgrade_or_refresh_registry",
+      "source": "新 mobile v1"
+    },
+    {
+      "code": "app_session_expired",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "sign_in",
+      "source": "server.js requireUser"
+    },
+    {
+      "code": "invalid_credentials",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "correct_credentials",
+      "source": "server.js auth"
+    },
+    {
+      "code": "must_change_password",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "open_system_browser",
+      "source": "server.js requireUser"
+    },
+    {
+      "code": "account_suspended",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "contact_admin",
+      "source": "authz.js/server.js"
+    },
+    {
+      "code": "account_locked",
+      "httpStatus": 429,
+      "retryable": true,
+      "clientAction": "wait_then_retry",
+      "source": "server.js login"
+    },
+    {
+      "code": "login_guard_blocked",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_server_policy",
+      "source": "server.js TOTP"
+    },
+    {
+      "code": "captcha_required",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "open_auth_session",
+      "source": "mobile adapter"
+    },
+    {
+      "code": "totp_required",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "enter_totp",
+      "source": "server.js login result"
+    },
+    {
+      "code": "totp_invalid",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "retry_totp",
+      "source": "mobile adapter"
+    },
+    {
+      "code": "totp_temp_exhausted",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "restart_sign_in",
+      "source": "server.js TOTP"
+    },
+    {
+      "code": "token_required",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "create_token_on_server",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "token_not_found",
+      "httpStatus": 404,
+      "retryable": false,
+      "clientAction": "select_valid_token",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "token_missing",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "token_rotated",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "mobile v1"
+    },
+    {
+      "code": "client_owned_by_other",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "regenerate_device_id",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "client_not_found",
+      "httpStatus": 404,
+      "retryable": false,
+      "clientAction": "bind_device",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "client_disabled",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "enable_on_server",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "client_revoked",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "account_unavailable",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "contact_admin",
+      "source": "one-client-manager.js"
+    },
+    {
+      "code": "device_proof_invalid",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "refresh_or_rebind",
+      "source": "mobile v1"
+    },
+    {
+      "code": "refresh_replayed",
+      "httpStatus": 401,
+      "retryable": false,
+      "clientAction": "rebind",
+      "source": "mobile v1"
+    },
+    {
+      "code": "sensitive_verification_required",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "verify_sensitive_action",
+      "source": "mobile v1"
+    },
+    {
+      "code": "sensitive_verification_failed",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "retry_sensitive_action",
+      "source": "server.js verifySensitiveAccess"
+    },
+    {
+      "code": "sensitive_grant_expired",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "verify_sensitive_action",
+      "source": "mobile v1"
+    },
+    {
+      "code": "sensitive_grant_consumed",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "verify_sensitive_action",
+      "source": "mobile v1"
+    },
+    {
+      "code": "resource_not_found_or_inaccessible",
+      "httpStatus": 404,
+      "retryable": false,
+      "clientAction": "remove_or_refresh",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_use",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_edit",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_delete",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_resource_revealSecret",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "show_permission",
+      "source": "authz.js"
+    },
+    {
+      "code": "forbidden_dependency_proxy",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_dependency_sshKey",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_dependency_jumpHost",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "forbidden_dependency_jumpConnection",
+      "httpStatus": 403,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "invalid_dependency",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "repair_route",
+      "source": "resource-service.js"
+    },
+    {
+      "code": "revision_required",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "refresh_entity",
+      "source": "notes-service.js"
+    },
+    {
+      "code": "revision_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "ai-snippet-tools.js/mobile v1"
+    },
+    {
+      "code": "note_revision_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "notes-service.js"
+    },
+    {
+      "code": "workspace_revision_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "workspace-service.js"
+    },
+    {
+      "code": "sync_conflict",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "open_conflict",
+      "source": "mobile v1"
+    },
+    {
+      "code": "dependency_missing",
+      "httpStatus": 409,
+      "retryable": true,
+      "clientAction": "retry_after_dependency",
+      "source": "mobile v1"
+    },
+    {
+      "code": "duplicate_operation",
+      "httpStatus": 200,
+      "retryable": false,
+      "clientAction": "accept_original_result",
+      "source": "mobile v1"
+    },
+    {
+      "code": "cursor_invalid",
+      "httpStatus": 409,
+      "retryable": false,
+      "clientAction": "restart_bootstrap",
+      "source": "mobile v1"
+    },
+    {
+      "code": "cursor_expired",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "restart_bootstrap",
+      "source": "mobile v1"
+    },
+    {
+      "code": "bootstrap_expired",
+      "httpStatus": 410,
+      "retryable": false,
+      "clientAction": "restart_bootstrap",
+      "source": "mobile v1"
+    },
+    {
+      "code": "unsupported_scope",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "drop_operation_and_report",
+      "source": "mobile v1"
+    },
+    {
+      "code": "unknown_entity_type",
+      "httpStatus": 400,
+      "retryable": false,
+      "clientAction": "upgrade_or_drop_operation",
+      "source": "mobile v1"
+    },
+    {
+      "code": "payload_too_large",
+      "httpStatus": 413,
+      "retryable": false,
+      "clientAction": "split_payload",
+      "source": "file-transfer-protocol.js/mobile v1"
+    },
+    {
+      "code": "metadata_too_large",
+      "httpStatus": 413,
+      "retryable": false,
+      "clientAction": "split_payload",
+      "source": "file-transfer-protocol.js"
+    },
+    {
+      "code": "blob_hash_mismatch",
+      "httpStatus": 422,
+      "retryable": true,
+      "clientAction": "restart_blob",
+      "source": "mobile v1"
+    },
+    {
+      "code": "blob_missing_chunk",
+      "httpStatus": 409,
+      "retryable": true,
+      "clientAction": "resume_blob",
+      "source": "mobile v1"
+    },
+    {
+      "code": "rate_limited",
+      "httpStatus": 429,
+      "retryable": true,
+      "clientAction": "respect_retry_after",
+      "source": "mobile v1"
+    },
+    {
+      "code": "server_unavailable",
+      "httpStatus": 503,
+      "retryable": true,
+      "clientAction": "backoff",
+      "source": "mobile v1"
+    },
+    {
+      "code": "internal_error",
+      "httpStatus": 500,
+      "retryable": true,
+      "clientAction": "backoff_then_report",
+      "source": "handleServiceError"
+    }
+  ]
+}

--- a/FREEZE/zephyr one for mobile/contracts/openapi-mobile-v1.json
+++ b/FREEZE/zephyr one for mobile/contracts/openapi-mobile-v1.json
@@ -1,0 +1,2592 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Zephyr One Mobile API",
+    "version": "1.0.0",
+    "description": "Zephyr business rules exposed to native Android/iOS clients. Existing routes are marked implemented; mobile sync routes are required server extensions.",
+    "license": {
+      "name": "GNU General Public License v3.0",
+      "identifier": "GPL-3.0-only"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{host}",
+      "variables": {
+        "host": {
+          "default": "zephyr.example.com"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "Auth",
+      "description": "Zephyr account authentication inherited by One."
+    },
+    {
+      "name": "Devices",
+      "description": "One device binding and lifecycle."
+    },
+    {
+      "name": "Sync",
+      "description": "Bidirectional mobile mirror protocol."
+    },
+    {
+      "name": "Sensitive",
+      "description": "Password or TOTP verification grants."
+    },
+    {
+      "name": "FileBridge",
+      "description": "ZFT2 file bridge leases."
+    }
+  ],
+  "paths": {
+    "/api/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Use Zephyr login policy and request a native SID",
+        "operationId": "postApiAuthLogin",
+        "x-zephyr-implementation": "implemented-3a61d2f",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/totp/verify": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Complete Zephyr TOTP and request a native SID",
+        "operationId": "postApiAuthTotpVerify",
+        "x-zephyr-implementation": "implemented-3a61d2f",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TotpRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/capabilities": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Negotiate protocol, registry and limits",
+        "operationId": "getApiMobileV1Capabilities",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Capabilities"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/mobile/v1/devices/bind": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Bind authenticated account plus existing Client Token to device",
+        "operationId": "postApiMobileV1DevicesBind",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BindResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BindRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/devices/refresh": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Rotate short-lived access and single-use refresh credentials",
+        "operationId": "postApiMobileV1DevicesRefresh",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BindResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DeviceAccess": []
+          },
+          {
+            "DeviceProof": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/devices": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "List current account One devices",
+        "operationId": "getApiMobileV1Devices",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "devices": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Device"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          }
+        ]
+      }
+    },
+    "/api/mobile/v1/devices/{deviceId}": {
+      "patch": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Update device name, enabled state and automatic interval",
+        "operationId": "patchApiMobileV1DevicesDeviceid",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Device"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Consume a scoped sensitive grant and revoke device",
+        "operationId": "deleteApiMobileV1DevicesDeviceid",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Zephyr-Sensitive-Grant",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/mobile/v1/sync/bootstrap": {
+      "get": {
+        "tags": [
+          "Sync"
+        ],
+        "summary": "Read a stable, paged account snapshot",
+        "operationId": "getApiMobileV1SyncBootstrap",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BootstrapPage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DeviceAccess": []
+          },
+          {
+            "DeviceProof": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pageToken",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            }
+          }
+        ]
+      }
+    },
+    "/api/mobile/v1/sync/changes": {
+      "get": {
+        "tags": [
+          "Sync"
+        ],
+        "summary": "Read coalesced changes after cursor",
+        "operationId": "getApiMobileV1SyncChanges",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangePage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DeviceAccess": []
+          },
+          {
+            "DeviceProof": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            }
+          }
+        ]
+      }
+    },
+    "/api/mobile/v1/sync/push": {
+      "post": {
+        "tags": [
+          "Sync"
+        ],
+        "summary": "Apply idempotent optimistic operations through Zephyr business services",
+        "operationId": "postApiMobileV1SyncPush",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DeviceAccess": []
+          },
+          {
+            "DeviceProof": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/sync/ack": {
+      "post": {
+        "tags": [
+          "Sync"
+        ],
+        "summary": "Persist highest fully applied cursor",
+        "operationId": "postApiMobileV1SyncAck",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DeviceAccess": []
+          },
+          {
+            "DeviceProof": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "cursor"
+                ],
+                "properties": {
+                  "cursor": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/sync/now": {
+      "post": {
+        "tags": [
+          "Sync"
+        ],
+        "summary": "Record manual trigger and optionally wake target device",
+        "operationId": "postApiMobileV1SyncNow",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          },
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/sync/status": {
+      "get": {
+        "tags": [
+          "Sync"
+        ],
+        "summary": "Return truthful server-side sync state",
+        "operationId": "getApiMobileV1SyncStatus",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          },
+          {
+            "DeviceAccess": []
+          }
+        ]
+      }
+    },
+    "/api/mobile/v1/sensitive/verify": {
+      "post": {
+        "tags": [
+          "Sensitive"
+        ],
+        "summary": "Exchange password or TOTP for one-action, one-target grant",
+        "operationId": "postApiMobileV1SensitiveVerify",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SensitiveGrant"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ZephyrSid": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SensitiveVerifyRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mobile/v1/file-bridge/lease": {
+      "post": {
+        "tags": [
+          "FileBridge"
+        ],
+        "summary": "Mint short-lived user/device/share-bound ZFT2 lease",
+        "operationId": "postApiMobileV1File-BridgeLease",
+        "x-zephyr-implementation": "required-server-extension",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DeviceAccess": []
+          },
+          {
+            "DeviceProof": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "shareProfileIds"
+                ],
+                "properties": {
+                  "shareProfileIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ZephyrSid": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Zephyr-Sid",
+        "description": "Existing SQLite-backed Zephyr app session returned only to native clients."
+      },
+      "DeviceAccess": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "opaque",
+        "description": "Short-lived mobile access credential. Refresh credential is never used as bearer access."
+      },
+      "DeviceProof": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Zephyr-Device-Proof",
+        "description": "ES256 proof over method, path, body hash, timestamp and server nonce."
+      }
+    },
+    "schemas": {
+      "ErrorEnvelope": {
+        "title": "MobileErrorEnvelope",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "error"
+        ],
+        "properties": {
+          "ok": {
+            "const": false
+          },
+          "error": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "code",
+              "message",
+              "retryable",
+              "requestId"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "minLength": 1
+              },
+              "message": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "details": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      },
+      "LoginRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "username",
+          "password",
+          "returnSid"
+        ],
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "captchaToken": {
+            "type": "string"
+          },
+          "remember": {
+            "type": "boolean",
+            "default": false
+          },
+          "returnSid": {
+            "const": true
+          }
+        }
+      },
+      "LoginResponse": {
+        "type": "object",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "requireTotp": {
+            "type": "boolean"
+          },
+          "tempToken": {
+            "type": "string"
+          },
+          "sid": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "userId": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            }
+          },
+          "mustChangePassword": {
+            "type": "boolean"
+          }
+        }
+      },
+      "TotpRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "tempToken",
+          "code",
+          "returnSid"
+        ],
+        "properties": {
+          "tempToken": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[0-9]{6,8}$"
+          },
+          "returnSid": {
+            "const": true
+          }
+        }
+      },
+      "DeviceKeys": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "encryption",
+          "signing"
+        ],
+        "properties": {
+          "encryption": {
+            "type": "object",
+            "required": [
+              "alg",
+              "publicKey"
+            ],
+            "properties": {
+              "alg": {
+                "const": "ML-KEM-768"
+              },
+              "publicKey": {
+                "type": "string",
+                "contentEncoding": "base64"
+              }
+            }
+          },
+          "signing": {
+            "type": "object",
+            "required": [
+              "alg",
+              "jwk"
+            ],
+            "properties": {
+              "alg": {
+                "const": "ES256"
+              },
+              "jwk": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "Device": {
+        "type": "object",
+        "required": [
+          "deviceId",
+          "ownerUserId",
+          "deviceName",
+          "platform",
+          "appVersion",
+          "tokenId",
+          "enabled",
+          "automaticEnabled",
+          "syncIntervalSec",
+          "createdAt"
+        ],
+        "properties": {
+          "deviceId": {
+            "type": "string"
+          },
+          "ownerUserId": {
+            "type": "string"
+          },
+          "deviceName": {
+            "type": "string"
+          },
+          "platform": {
+            "enum": [
+              "android",
+              "ios"
+            ]
+          },
+          "appVersion": {
+            "type": "string"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "automaticEnabled": {
+            "type": "boolean"
+          },
+          "syncIntervalSec": {
+            "type": "integer",
+            "minimum": 30,
+            "maximum": 86400
+          },
+          "lastSyncAt": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "lastSeenAt": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "integer"
+          },
+          "revokedAt": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        }
+      },
+      "BindRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "deviceId",
+          "deviceName",
+          "platform",
+          "appVersion",
+          "tokenId",
+          "keys",
+          "syncIntervalSec"
+        ],
+        "properties": {
+          "deviceId": {
+            "type": "string",
+            "minLength": 16,
+            "maxLength": 80
+          },
+          "deviceName": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "platform": {
+            "enum": [
+              "android",
+              "ios"
+            ]
+          },
+          "appVersion": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "keys": {
+            "$ref": "#/components/schemas/DeviceKeys"
+          },
+          "syncIntervalSec": {
+            "type": "integer",
+            "minimum": 30,
+            "maximum": 86400
+          }
+        }
+      },
+      "BindResponse": {
+        "type": "object",
+        "required": [
+          "ok",
+          "device",
+          "accessCredential",
+          "refreshCredential",
+          "registryHash"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "device": {
+            "$ref": "#/components/schemas/Device"
+          },
+          "accessCredential": {
+            "type": "string"
+          },
+          "accessExpiresAt": {
+            "type": "integer"
+          },
+          "refreshCredential": {
+            "type": "string"
+          },
+          "registryHash": {
+            "type": "string"
+          },
+          "bootstrapRequired": {
+            "const": true
+          }
+        }
+      },
+      "SyncOperation": {
+        "title": "SyncOperation",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "opId",
+          "entityType",
+          "entityId",
+          "action",
+          "baseRevision",
+          "fieldMask",
+          "payload"
+        ],
+        "properties": {
+          "opId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "entityType": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "entityId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "action": {
+            "enum": [
+              "upsert",
+              "delete",
+              "restore"
+            ]
+          },
+          "baseRevision": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "clientModifiedAt": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "fieldMask": {
+            "type": "array",
+            "maxItems": 256,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z][A-Za-z0-9_.\\[\\]-]*$"
+            }
+          },
+          "payload": {
+            "type": "object"
+          },
+          "secretEnvelopes": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SecretEnvelope"
+            }
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "upsert"
+                }
+              },
+              "required": [
+                "action"
+              ]
+            },
+            "then": {
+              "properties": {
+                "fieldMask": {
+                  "type": "array",
+                  "minItems": 1
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "enum": [
+                    "delete",
+                    "restore"
+                  ]
+                }
+              },
+              "required": [
+                "action"
+              ]
+            },
+            "then": {
+              "properties": {
+                "fieldMask": {
+                  "type": "array",
+                  "maxItems": 0
+                },
+                "payload": {
+                  "type": "object",
+                  "maxProperties": 0
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SyncChange": {
+        "title": "SyncChange",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "changeSeq",
+          "entityType",
+          "entityId",
+          "action",
+          "revision",
+          "changedAt"
+        ],
+        "properties": {
+          "changeSeq": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "action": {
+            "enum": [
+              "upsert",
+              "delete"
+            ]
+          },
+          "revision": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "actorDeviceId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "changedAt": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "fieldMask": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "payload": {
+            "type": "object"
+          },
+          "secretEnvelopes": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SecretEnvelope"
+            }
+          },
+          "tombstone": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "upsert"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "payload": true,
+                "fieldMask": true
+              },
+              "required": [
+                "payload",
+                "fieldMask"
+              ]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "delete"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "tombstone": true
+              },
+              "required": [
+                "tombstone"
+              ]
+            }
+          }
+        ]
+      },
+      "PushRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "protocolVersion",
+          "deviceId",
+          "batchId",
+          "baseCursor",
+          "registryHash",
+          "operations"
+        ],
+        "properties": {
+          "protocolVersion": {
+            "const": 1
+          },
+          "deviceId": {
+            "type": "string"
+          },
+          "batchId": {
+            "type": "string"
+          },
+          "baseCursor": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "registryHash": {
+            "type": "string"
+          },
+          "operations": {
+            "type": "array",
+            "maxItems": 200,
+            "items": {
+              "$ref": "#/components/schemas/SyncOperation"
+            }
+          }
+        }
+      },
+      "PushResult": {
+        "type": "object",
+        "required": [
+          "opId",
+          "status"
+        ],
+        "properties": {
+          "opId": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "accepted",
+              "duplicate",
+              "conflict",
+              "rejected",
+              "dependency_missing"
+            ]
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "integer"
+          },
+          "changeSeq": {
+            "type": "integer"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ErrorEnvelope"
+          },
+          "conflict": {
+            "type": "object"
+          }
+        }
+      },
+      "PushResponse": {
+        "type": "object",
+        "required": [
+          "ok",
+          "batchId",
+          "serverCursor",
+          "results",
+          "changesAvailable"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "batchId": {
+            "type": "string"
+          },
+          "serverCursor": {
+            "type": "integer"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PushResult"
+            }
+          },
+          "changesAvailable": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ChangePage": {
+        "type": "object",
+        "required": [
+          "ok",
+          "fromCursor",
+          "nextCursor",
+          "hasMore",
+          "changes"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "fromCursor": {
+            "type": "integer"
+          },
+          "nextCursor": {
+            "type": "integer"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SyncChange"
+            }
+          }
+        }
+      },
+      "BootstrapPage": {
+        "type": "object",
+        "required": [
+          "ok",
+          "bootstrapId",
+          "snapshotCursor",
+          "nextPageToken",
+          "complete",
+          "entities"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "bootstrapId": {
+            "type": "string"
+          },
+          "snapshotCursor": {
+            "type": "integer"
+          },
+          "nextPageToken": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SyncChange"
+            }
+          }
+        }
+      },
+      "Capabilities": {
+        "type": "object",
+        "required": [
+          "ok",
+          "protocolVersions",
+          "registryHash",
+          "limits",
+          "auth"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "protocolVersions": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "registryHash": {
+            "type": "string"
+          },
+          "minimumAppVersions": {
+            "type": "object"
+          },
+          "limits": {
+            "type": "object"
+          },
+          "auth": {
+            "type": "object"
+          },
+          "features": {
+            "type": "object"
+          }
+        }
+      },
+      "SensitiveVerifyRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "action",
+          "secret",
+          "targetIds"
+        ],
+        "properties": {
+          "action": {
+            "enum": [
+              "device.revoke",
+              "token.reveal",
+              "token.rotate",
+              "token.delete",
+              "token.resetAll",
+              "backup.import"
+            ]
+          },
+          "secret": {
+            "type": "string"
+          },
+          "targetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200
+          }
+        }
+      },
+      "SensitiveGrant": {
+        "type": "object",
+        "required": [
+          "ok",
+          "grant",
+          "expiresAt",
+          "action",
+          "targetHash"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "grant": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "integer"
+          },
+          "action": {
+            "type": "string"
+          },
+          "targetHash": {
+            "type": "string"
+          }
+        }
+      },
+      "SyncStatus": {
+        "type": "object",
+        "required": [
+          "ok",
+          "state",
+          "lastAttemptAt",
+          "lastSuccessAt",
+          "cursor",
+          "pendingCount",
+          "conflictCount"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "state": {
+            "type": "string"
+          },
+          "lastAttemptAt": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "lastSuccessAt": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cursor": {
+            "type": "integer"
+          },
+          "pendingCount": {
+            "type": "integer"
+          },
+          "conflictCount": {
+            "type": "integer"
+          },
+          "lastError": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ErrorEnvelope"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "SecretEnvelope": {
+        "title": "MobileSecretEnvelopeV1",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "v",
+          "alg",
+          "kem",
+          "aead",
+          "ct",
+          "iv",
+          "tag",
+          "data",
+          "aad",
+          "keyVersion",
+          "entityRevision"
+        ],
+        "properties": {
+          "v": {
+            "const": 1
+          },
+          "alg": {
+            "const": "ML-KEM-768+HKDF-SHA256+AES-256-GCM"
+          },
+          "kem": {
+            "const": "ML-KEM-768"
+          },
+          "aead": {
+            "const": "AES-256-GCM"
+          },
+          "ct": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "iv": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "tag": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "data": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "aad": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "keyVersion": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "entityRevision": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/FREEZE/zephyr one for mobile/contracts/openapi-mobile-v1.json
+++ b/FREEZE/zephyr one for mobile/contracts/openapi-mobile-v1.json
@@ -39,6 +39,10 @@
     {
       "name": "FileBridge",
       "description": "ZFT2 file bridge leases."
+    },
+    {
+      "name": "Shared",
+      "description": "Online-only zero-residency shared resource access and sessions."
     }
   ],
   "paths": {
@@ -49,7 +53,7 @@
         ],
         "summary": "Use Zephyr login policy and request a native SID",
         "operationId": "postApiAuthLogin",
-        "x-zephyr-implementation": "implemented-3a61d2f",
+        "x-zephyr-implementation": "implemented-8dd5b98",
         "responses": {
           "200": {
             "description": "Success",
@@ -142,7 +146,7 @@
         ],
         "summary": "Complete Zephyr TOTP and request a native SID",
         "operationId": "postApiAuthTotpVerify",
-        "x-zephyr-implementation": "implemented-3a61d2f",
+        "x-zephyr-implementation": "implemented-8dd5b98",
         "responses": {
           "200": {
             "description": "Success",
@@ -1653,6 +1657,897 @@
           }
         }
       }
+    },
+    "/api/mobile/v1/shared": {
+      "get": {
+        "tags": [
+          "Shared"
+        ],
+        "summary": "List online shared-to-me references without local residency",
+        "operationId": "listSharedResources",
+        "x-zephyr-implementation": "required-server-extension",
+        "security": [
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always no-store, private",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "items"
+                  ],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SharedResourceSummary"
+                      }
+                    },
+                    "nextPageToken": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "x-zephyr-no-store": true,
+        "x-zephyr-shared-residency": "online-only"
+      }
+    },
+    "/api/mobile/v1/shared/{resourceType}/{resourceId}": {
+      "get": {
+        "tags": [
+          "Shared"
+        ],
+        "summary": "Read one shared resource online after real-time ACL check",
+        "operationId": "getSharedResource",
+        "x-zephyr-implementation": "required-server-extension",
+        "security": [
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always no-store, private",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-zephyr-no-store": true,
+        "x-zephyr-shared-residency": "online-only"
+      }
+    },
+    "/api/mobile/v1/shared/{resourceType}/{resourceId}/invoke": {
+      "post": {
+        "tags": [
+          "Shared"
+        ],
+        "summary": "Invoke canonical server operation without delivering control-plane secrets",
+        "operationId": "invokeSharedResource",
+        "x-zephyr-implementation": "required-server-extension",
+        "security": [
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always no-store, private",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedInvokeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SharedInvokeRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-zephyr-no-store": true,
+        "x-zephyr-shared-residency": "online-only"
+      }
+    },
+    "/api/mobile/v1/shared/sessions/{sessionId}/refresh": {
+      "post": {
+        "tags": [
+          "Shared"
+        ],
+        "summary": "Reauthorize live session and mint a fresh nonce-bound envelope if permitted",
+        "operationId": "refreshSharedSession",
+        "x-zephyr-implementation": "required-server-extension",
+        "security": [
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always no-store, private",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "clientSessionNonce"
+                ],
+                "properties": {
+                  "clientSessionNonce": {
+                    "type": "string",
+                    "minLength": 22
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-zephyr-no-store": true,
+        "x-zephyr-shared-residency": "online-only"
+      }
+    },
+    "/api/mobile/v1/shared/sessions/{sessionId}": {
+      "delete": {
+        "tags": [
+          "Shared"
+        ],
+        "summary": "Terminate shared session and revoke relay/envelope grant",
+        "operationId": "deleteSharedSession",
+        "x-zephyr-implementation": "required-server-extension",
+        "security": [
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always no-store, private",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-zephyr-no-store": true,
+        "x-zephyr-shared-residency": "online-only"
+      }
+    },
+    "/api/mobile/v1/shared/connections/{connectionId}/sessions": {
+      "post": {
+        "tags": [
+          "Shared"
+        ],
+        "summary": "Open relay-strict or single-use direct shared connection session",
+        "operationId": "postApiMobileV1SharedConnectionsConnectionidSessions",
+        "x-zephyr-implementation": "required-server-extension",
+        "security": [
+          {
+            "DeviceAccess": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always no-store, private",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Structured error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SharedSessionRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-zephyr-no-store": true,
+        "x-zephyr-shared-residency": "online-only"
+      }
     }
   },
   "components": {
@@ -2584,6 +3479,292 @@
           "entityRevision": {
             "type": "integer",
             "minimum": 1
+          }
+        }
+      },
+      "SharedUseEnvelope": {
+        "title": "SharedUseEnvelopeV1",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "v",
+          "alg",
+          "kem",
+          "aead",
+          "ct",
+          "iv",
+          "tag",
+          "data",
+          "aad",
+          "keyVersion",
+          "resourceRevision",
+          "sessionId",
+          "resourceId",
+          "purpose",
+          "expiresAt",
+          "clientNonce"
+        ],
+        "properties": {
+          "v": {
+            "const": 1
+          },
+          "alg": {
+            "const": "ML-KEM-768+HKDF-SHA256+AES-256-GCM"
+          },
+          "kem": {
+            "const": "ML-KEM-768"
+          },
+          "aead": {
+            "const": "AES-256-GCM"
+          },
+          "ct": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "iv": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "tag": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "data": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "aad": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "keyVersion": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "resourceRevision": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "sessionId": {
+            "type": "string",
+            "minLength": 16,
+            "maxLength": 120
+          },
+          "resourceId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "purpose": {
+            "enum": [
+              "ssh",
+              "telnet",
+              "rdp",
+              "vnc"
+            ]
+          },
+          "expiresAt": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "clientNonce": {
+            "type": "string",
+            "minLength": 22,
+            "maxLength": 120
+          }
+        }
+      },
+      "SharedResourceSummary": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "resourceType",
+          "resourceId",
+          "displayName",
+          "ownerDisplayName",
+          "capabilities",
+          "revision"
+        ],
+        "properties": {
+          "resourceType": {
+            "enum": [
+              "connection",
+              "proxy",
+              "sshKey",
+              "jumpHost",
+              "note",
+              "file",
+              "docker"
+            ]
+          },
+          "resourceId": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "ownerDisplayName": {
+            "type": "string"
+          },
+          "capabilities": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "revision": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "expiresAt": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        }
+      },
+      "SharedSessionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "mode",
+          "clientSessionNonce",
+          "requestedChannels",
+          "deviceKeyVersion"
+        ],
+        "properties": {
+          "mode": {
+            "enum": [
+              "direct-ephemeral",
+              "relay-strict"
+            ]
+          },
+          "clientSessionNonce": {
+            "type": "string",
+            "minLength": 22,
+            "maxLength": 120
+          },
+          "requestedChannels": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": [
+                "terminal",
+                "clipboard",
+                "audio",
+                "drive",
+                "microphone",
+                "camera",
+                "location"
+              ]
+            }
+          },
+          "deviceKeyVersion": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "SharedSessionResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sessionId",
+          "mode",
+          "expiresAt",
+          "capabilities"
+        ],
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "mode": {
+            "enum": [
+              "direct-ephemeral",
+              "relay-strict"
+            ]
+          },
+          "expiresAt": {
+            "type": "integer"
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "useEnvelope": {
+            "$ref": "#/components/schemas/SharedUseEnvelope"
+          },
+          "relay": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "websocketUrl": {
+                "type": "string"
+              },
+              "protocol": {
+                "type": "string"
+              },
+              "credential": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "SharedInvokeRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "operation",
+          "arguments"
+        ],
+        "properties": {
+          "operation": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "arguments": {
+            "type": "object"
+          },
+          "expectedRevision": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1
+          },
+          "runId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "SharedInvokeResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "revision",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "revision": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "result": {},
+          "auditId": {
+            "type": "string"
           }
         }
       }

--- a/FREEZE/zephyr one for mobile/contracts/schemas/error.schema.json
+++ b/FREEZE/zephyr one for mobile/contracts/schemas/error.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zephyr.local/contracts/error.schema.json",
+  "title": "MobileErrorEnvelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "error"
+  ],
+  "properties": {
+    "ok": {
+      "const": false
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "retryable",
+        "requestId"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "details": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "requestId": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/FREEZE/zephyr one for mobile/contracts/schemas/secret-envelope.schema.json
+++ b/FREEZE/zephyr one for mobile/contracts/schemas/secret-envelope.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zephyr.local/contracts/secret-envelope.schema.json",
+  "title": "MobileSecretEnvelopeV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "v",
+    "alg",
+    "kem",
+    "aead",
+    "ct",
+    "iv",
+    "tag",
+    "data",
+    "aad",
+    "keyVersion",
+    "entityRevision"
+  ],
+  "properties": {
+    "v": {
+      "const": 1
+    },
+    "alg": {
+      "const": "ML-KEM-768+HKDF-SHA256+AES-256-GCM"
+    },
+    "kem": {
+      "const": "ML-KEM-768"
+    },
+    "aead": {
+      "const": "AES-256-GCM"
+    },
+    "ct": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "iv": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "tag": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "data": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "aad": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "keyVersion": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "entityRevision": {
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/FREEZE/zephyr one for mobile/contracts/schemas/shared-use-envelope.schema.json
+++ b/FREEZE/zephyr one for mobile/contracts/schemas/shared-use-envelope.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zephyr.local/contracts/shared-use-envelope.schema.json",
+  "title": "SharedUseEnvelopeV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "v",
+    "alg",
+    "kem",
+    "aead",
+    "ct",
+    "iv",
+    "tag",
+    "data",
+    "aad",
+    "keyVersion",
+    "resourceRevision",
+    "sessionId",
+    "resourceId",
+    "purpose",
+    "expiresAt",
+    "clientNonce"
+  ],
+  "properties": {
+    "v": {
+      "const": 1
+    },
+    "alg": {
+      "const": "ML-KEM-768+HKDF-SHA256+AES-256-GCM"
+    },
+    "kem": {
+      "const": "ML-KEM-768"
+    },
+    "aead": {
+      "const": "AES-256-GCM"
+    },
+    "ct": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "iv": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "tag": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "data": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "aad": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "keyVersion": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "resourceRevision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "sessionId": {
+      "type": "string",
+      "minLength": 16,
+      "maxLength": 120
+    },
+    "resourceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160
+    },
+    "purpose": {
+      "enum": [
+        "ssh",
+        "telnet",
+        "rdp",
+        "vnc"
+      ]
+    },
+    "expiresAt": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "clientNonce": {
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 120
+    }
+  }
+}

--- a/FREEZE/zephyr one for mobile/contracts/schemas/sync-change.schema.json
+++ b/FREEZE/zephyr one for mobile/contracts/schemas/sync-change.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zephyr.local/contracts/sync-change.schema.json",
+  "title": "SyncChange",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "changeSeq",
+    "entityType",
+    "entityId",
+    "action",
+    "revision",
+    "changedAt"
+  ],
+  "properties": {
+    "changeSeq": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "entityType": {
+      "type": "string"
+    },
+    "entityId": {
+      "type": "string"
+    },
+    "action": {
+      "enum": [
+        "upsert",
+        "delete"
+      ]
+    },
+    "revision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "actorDeviceId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "changedAt": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "fieldMask": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "payload": {
+      "type": "object"
+    },
+    "secretEnvelopes": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "secret-envelope.schema.json"
+      }
+    },
+    "tombstone": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "upsert"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": true,
+          "fieldMask": true
+        },
+        "required": [
+          "payload",
+          "fieldMask"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "delete"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "tombstone": true
+        },
+        "required": [
+          "tombstone"
+        ]
+      }
+    }
+  ]
+}

--- a/FREEZE/zephyr one for mobile/contracts/schemas/sync-operation.schema.json
+++ b/FREEZE/zephyr one for mobile/contracts/schemas/sync-operation.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zephyr.local/contracts/sync-operation.schema.json",
+  "title": "SyncOperation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "opId",
+    "entityType",
+    "entityId",
+    "action",
+    "baseRevision",
+    "fieldMask",
+    "payload"
+  ],
+  "properties": {
+    "opId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "entityType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "entityId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160
+    },
+    "action": {
+      "enum": [
+        "upsert",
+        "delete",
+        "restore"
+      ]
+    },
+    "baseRevision": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "clientModifiedAt": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "fieldMask": {
+      "type": "array",
+      "maxItems": 256,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z][A-Za-z0-9_.\\[\\]-]*$"
+      }
+    },
+    "payload": {
+      "type": "object"
+    },
+    "secretEnvelopes": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "secret-envelope.schema.json"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "upsert"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "then": {
+        "properties": {
+          "fieldMask": {
+            "type": "array",
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "enum": [
+              "delete",
+              "restore"
+            ]
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "then": {
+        "properties": {
+          "fieldMask": {
+            "type": "array",
+            "maxItems": 0
+          },
+          "payload": {
+            "type": "object",
+            "maxProperties": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/FREEZE/zephyr one for mobile/contracts/test-vectors/shared-use-v1.json
+++ b/FREEZE/zephyr one for mobile/contracts/test-vectors/shared-use-v1.json
@@ -1,0 +1,129 @@
+{
+  "version": 1,
+  "aad": {
+    "fields": [
+      "prefix",
+      "serverId",
+      "userId",
+      "deviceId",
+      "sessionId",
+      "resourceId",
+      "resourceRevision",
+      "purpose",
+      "expiresAt",
+      "clientNonce"
+    ],
+    "separator": "NUL (0x00)",
+    "values": [
+      "shared-use-v1",
+      "srv-1",
+      "usr-2",
+      "dev-1",
+      "sess-1",
+      "conn-7",
+      "9",
+      "ssh",
+      "1786093230000",
+      "nonce-1234567890abcdef"
+    ],
+    "base64": "c2hhcmVkLXVzZS12MQBzcnYtMQB1c3ItMgBkZXYtMQBzZXNzLTEAY29ubi03ADkAc3NoADE3ODYwOTMyMzAwMDAAbm9uY2UtMTIzNDU2Nzg5MGFiY2RlZg==",
+    "hex": "7368617265642d7573652d7631007372762d31007573722d32006465762d3100736573732d3100636f6e6e2d370039007373680031373836303933323330303030006e6f6e63652d31323334353637383930616263646566"
+  },
+  "negativeCases": [
+    {
+      "id": "wrong-device",
+      "mutate": "deviceId",
+      "expect": "aead_auth_failed"
+    },
+    {
+      "id": "wrong-session",
+      "mutate": "sessionId",
+      "expect": "aead_auth_failed"
+    },
+    {
+      "id": "wrong-resource",
+      "mutate": "resourceId",
+      "expect": "aead_auth_failed"
+    },
+    {
+      "id": "wrong-purpose",
+      "mutate": "purpose",
+      "expect": "aead_auth_failed"
+    },
+    {
+      "id": "expired",
+      "mutate": "expiresAt",
+      "expect": "shared_session_expired"
+    },
+    {
+      "id": "replay",
+      "mutate": "none_second_consume",
+      "expect": "shared_session_consumed"
+    }
+  ],
+  "envelopes": {
+    "acceptedSsh": {
+      "v": 1,
+      "alg": "ML-KEM-768+HKDF-SHA256+AES-256-GCM",
+      "kem": "ML-KEM-768",
+      "aead": "AES-256-GCM",
+      "ct": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+      "iv": "AAECAwQFBgcICQoL",
+      "tag": "AAECAwQFBgcICQoLDA0ODw==",
+      "data": "eyJ1c2VybmFtZSI6Im9wcyIsInBhc3N3b3JkIjoiPHNlYWxlZD4ifQ==",
+      "aad": "c2hhcmVkLXVzZS12MQBzcnYtMQB1c3ItMgBkZXYtMQBzZXNzLTEAY29ubi03ADkAc3NoADE3ODYwOTMyMzAwMDAAbm9uY2UtMTIzNDU2Nzg5MGFiY2RlZg==",
+      "keyVersion": 1,
+      "resourceRevision": 9,
+      "sessionId": "sess-1-0123456789abcdef",
+      "resourceId": "conn-7",
+      "purpose": "ssh",
+      "expiresAt": 1786093230000,
+      "clientNonce": "nonce-1234567890abcdef"
+    },
+    "invalidPurpose": {
+      "v": 1,
+      "alg": "ML-KEM-768+HKDF-SHA256+AES-256-GCM",
+      "kem": "ML-KEM-768",
+      "aead": "AES-256-GCM",
+      "ct": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+      "iv": "AAECAwQFBgcICQoL",
+      "tag": "AAECAwQFBgcICQoLDA0ODw==",
+      "data": "eyJ1c2VybmFtZSI6Im9wcyIsInBhc3N3b3JkIjoiPHNlYWxlZD4ifQ==",
+      "aad": "c2hhcmVkLXVzZS12MQBzcnYtMQB1c3ItMgBkZXYtMQBzZXNzLTEAY29ubi03ADkAc3NoADE3ODYwOTMyMzAwMDAAbm9uY2UtMTIzNDU2Nzg5MGFiY2RlZg==",
+      "keyVersion": 1,
+      "resourceRevision": 9,
+      "sessionId": "sess-1-0123456789abcdef",
+      "resourceId": "conn-7",
+      "purpose": "sftp",
+      "expiresAt": 1786093230000,
+      "clientNonce": "nonce-1234567890abcdef"
+    },
+    "forbiddenControlPlaneField": {
+      "v": 1,
+      "alg": "ML-KEM-768+HKDF-SHA256+AES-256-GCM",
+      "kem": "ML-KEM-768",
+      "aead": "AES-256-GCM",
+      "ct": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+      "iv": "AAECAwQFBgcICQoL",
+      "tag": "AAECAwQFBgcICQoLDA0ODw==",
+      "data": "eyJ1c2VybmFtZSI6Im9wcyIsInBhc3N3b3JkIjoiPHNlYWxlZD4ifQ==",
+      "aad": "c2hhcmVkLXVzZS12MQBzcnYtMQB1c3ItMgBkZXYtMQBzZXNzLTEAY29ubi03ADkAc3NoADE3ODYwOTMyMzAwMDAAbm9uY2UtMTIzNDU2Nzg5MGFiY2RlZg==",
+      "keyVersion": 1,
+      "resourceRevision": 9,
+      "sessionId": "sess-1-0123456789abcdef",
+      "resourceId": "conn-7",
+      "purpose": "ssh",
+      "expiresAt": 1786093230000,
+      "clientNonce": "nonce-1234567890abcdef",
+      "clientToken": "must-never-appear"
+    }
+  },
+  "forbiddenPayloadKeys": [
+    "clientToken",
+    "aiProviderApiKey",
+    "aiEnvValue",
+    "serverDataKey",
+    "ownerSid",
+    "refreshCredential"
+  ]
+}

--- a/FREEZE/zephyr one for mobile/contracts/test-vectors/sync-v1.json
+++ b/FREEZE/zephyr one for mobile/contracts/test-vectors/sync-v1.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "aad": {
+    "fields": [
+      "prefix",
+      "serverId",
+      "userId",
+      "deviceId",
+      "entityType",
+      "entityId",
+      "fieldName",
+      "entityRevision",
+      "keyVersion"
+    ],
+    "separator": "NUL (0x00)",
+    "utf8Text": "zephyr-mobile-secret-v1\\0srv-1\\0usr-1\\0dev-1\\0connection\\0conn-1\\0password\\08\\01",
+    "hex": "7a65706879722d6d6f62696c652d7365637265742d7631007372762d31007573722d31006465762d3100636f6e6e656374696f6e00636f6e6e2d310070617373776f726400380031"
+  },
+  "operations": {
+    "acceptedUpsert": {
+      "opId": "op-1",
+      "entityType": "connection",
+      "entityId": "conn-1",
+      "action": "upsert",
+      "baseRevision": 7,
+      "clientModifiedAt": 1786093200000,
+      "fieldMask": [
+        "name",
+        "rdpQuality"
+      ],
+      "payload": {
+        "name": "Office RDP",
+        "rdpQuality": "balanced"
+      }
+    },
+    "invalidMissingMask": {
+      "opId": "op-invalid",
+      "entityType": "connection",
+      "entityId": "conn-1",
+      "action": "upsert",
+      "baseRevision": 7,
+      "payload": {
+        "name": "Must fail schema validation"
+      }
+    }
+  },
+  "syncCases": [
+    {
+      "id": "duplicate-op",
+      "given": "same deviceId/opId repeated",
+      "expect": "same stored result and no second business write"
+    },
+    {
+      "id": "non-overlap",
+      "given": "baseRevision 7; local mask name; server changed remark at revision 8",
+      "expect": "accept and create revision 9"
+    },
+    {
+      "id": "overlap",
+      "given": "baseRevision 7; local mask name; server changed name at revision 8",
+      "expect": "sync_conflict"
+    },
+    {
+      "id": "delete-edit",
+      "given": "server tombstone newer than local edit",
+      "expect": "delete wins; explicit restore creates new revision"
+    },
+    {
+      "id": "crash-page",
+      "given": "crash after entity page transaction before cursor commit",
+      "expect": "page replays without duplicate side effects"
+    },
+    {
+      "id": "unknown-field",
+      "given": "server payload has futureField unknown to client",
+      "expect": "opaque retention; client fieldMask never names futureField"
+    }
+  ]
+}

--- a/tests/zephyr-one-mobile-spec-contract.test.mjs
+++ b/tests/zephyr-one-mobile-spec-contract.test.mjs
@@ -1,0 +1,182 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const mobile = path.join(root, 'FREEZE', 'zephyr one for mobile');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+const json = (relative) => JSON.parse(read(relative));
+
+const requiredDocs = [
+  'README.md', 'PRODUCT_REQUIREMENTS.md', 'DEVELOPMENT.md',
+  'ZEPHYR_PARITY.md', 'SCREEN_CATALOG.md', 'SYNC_STATE_MACHINE.md',
+  'DATA_AND_MIGRATION.md', 'NATIVE_ENGINE_DECISIONS.md',
+  'TRACEABILITY.md', 'IMPLEMENTATION_STATUS.md',
+];
+const requiredContracts = [
+  'contracts/openapi-mobile-v1.json',
+  'contracts/entity-registry.json',
+  'contracts/error-registry.json',
+  'contracts/schemas/error.schema.json',
+  'contracts/schemas/sync-operation.schema.json',
+  'contracts/schemas/sync-change.schema.json',
+  'contracts/schemas/secret-envelope.schema.json',
+  'contracts/test-vectors/sync-v1.json',
+];
+
+test('native mobile spec has all narrative and machine artifacts', () => {
+  for (const relative of [...requiredDocs, ...requiredContracts]) {
+    const file = path.join(mobile, relative);
+    assert.ok(fs.existsSync(file), `missing ${relative}`);
+    assert.ok(fs.statSync(file).size > 100, `empty ${relative}`);
+  }
+});
+
+test('README is a project dashboard and links every executable spec', () => {
+  const text = read('README.md');
+  for (const relative of [...requiredDocs.slice(1), ...requiredContracts]) {
+    assert.match(text, new RegExp(relative.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `README missing ${relative}`);
+  }
+  assert.match(text, /没有新的 Kotlin\/Swift 原生项目/);
+  assert.match(text, /pull-only/);
+  assert.match(text, /工具 → 服务器/);
+});
+
+test('OpenAPI covers auth, binding, bidirectional sync and sensitive grants', () => {
+  const api = json('contracts/openapi-mobile-v1.json');
+  assert.equal(api.openapi, '3.1.0');
+  const expected = [
+    '/api/auth/login', '/api/auth/totp/verify',
+    '/api/mobile/v1/capabilities', '/api/mobile/v1/devices/bind',
+    '/api/mobile/v1/devices/refresh', '/api/mobile/v1/sync/bootstrap',
+    '/api/mobile/v1/sync/changes', '/api/mobile/v1/sync/push',
+    '/api/mobile/v1/sync/ack', '/api/mobile/v1/sync/status',
+    '/api/mobile/v1/sensitive/verify', '/api/mobile/v1/file-bridge/lease',
+  ];
+  for (const route of expected) assert.ok(api.paths[route], `OpenAPI missing ${route}`);
+  assert.equal(api.paths['/api/auth/login'].post['x-zephyr-implementation'], 'implemented-3a61d2f');
+  assert.equal(api.paths['/api/mobile/v1/sync/push'].post['x-zephyr-implementation'], 'required-server-extension');
+});
+
+test('entity registry covers every product-required mirror family', () => {
+  const registry = json('contracts/entity-registry.json');
+  const byType = new Map(registry.entities.map((entity) => [entity.type, entity]));
+  const expected = [
+    'connection', 'proxy', 'sshKey', 'jumpHost', 'note', 'snippet',
+    'aiProvider', 'aiMemory', 'aiSkill', 'aiEnv', 'aiConversation', 'aiMessage',
+    'oneUserSettings', 'serverSettings', 'backupMetadata', 'activityEvent',
+    'resourceAcl', 'clientToken', 'workspaceState', 'fileSyncConfig',
+  ];
+  for (const type of expected) assert.ok(byType.has(type), `registry missing ${type}`);
+  assert.deepEqual(byType.get('connection').secretFields, ['password', 'privateKey']);
+  assert.ok(byType.get('clientToken').status.includes('blocked'));
+  assert.ok(byType.get('aiConversation').status.includes('blocked'));
+  assert.ok(registry.excludedEditableScopes.includes('accountSecurity'));
+  assert.ok(registry.excludedEditableScopes.includes('smtp'));
+});
+
+test('every entity field has exactly one storage/sync classification', () => {
+  const registry = json('contracts/entity-registry.json');
+  const buckets = ['editableFields', 'secretFields', 'serverAuthorityFields', 'opaquePreserveFields', 'deviceLocalFields'];
+  for (const entity of registry.entities) {
+    const owner = new Map();
+    for (const bucket of buckets) {
+      assert.ok(Array.isArray(entity[bucket]), `${entity.type}.${bucket} must be array`);
+      for (const field of entity[bucket]) {
+        assert.ok(!owner.has(field), `${entity.type}.${field} in ${owner.get(field)} and ${bucket}`);
+        owner.set(field, bucket);
+      }
+    }
+  }
+});
+
+test('error registry is unique and carries deterministic client action', () => {
+  const registry = json('contracts/error-registry.json');
+  const seen = new Set();
+  for (const error of registry.errors) {
+    assert.ok(!seen.has(error.code), `duplicate error ${error.code}`);
+    seen.add(error.code);
+    assert.ok(Number.isInteger(error.httpStatus));
+    assert.equal(typeof error.retryable, 'boolean');
+    assert.ok(error.clientAction);
+  }
+  for (const code of ['app_session_expired', 'token_required', 'sync_conflict', 'cursor_expired', 'sensitive_grant_consumed', 'rate_limited']) {
+    assert.ok(seen.has(code), `missing error ${code}`);
+  }
+});
+
+test('secret schema and AAD vector freeze byte-level interoperability', () => {
+  const schema = json('contracts/schemas/secret-envelope.schema.json');
+  const vector = json('contracts/test-vectors/sync-v1.json');
+  assert.equal(schema.properties.alg.const, 'ML-KEM-768+HKDF-SHA256+AES-256-GCM');
+  assert.deepEqual(schema.required, ['v', 'alg', 'kem', 'aead', 'ct', 'iv', 'tag', 'data', 'aad', 'keyVersion', 'entityRevision']);
+  const bytes = Buffer.from(vector.aad.hex, 'hex');
+  const expected = Buffer.from(vector.aad.utf8Text.replaceAll('\\0', '\0'), 'utf8');
+  assert.deepEqual(bytes, expected);
+  assert.equal(bytes.filter((byte) => byte === 0).length, vector.aad.fields.length - 1);
+});
+
+test('sync state machine resolves bootstrap ordering and crash recovery', () => {
+  const text = read('SYNC_STATE_MACHINE.md');
+  assert.match(text, /BOOTSTRAP_PAGE until complete/);
+  assert.match(text, /CATCH_UP_PULL from snapshotCursor/);
+  assert.match(text, /PUSH_PENDING collected during bootstrap/);
+  assert.match(text, /PULL_CHANGES again/);
+  assert.match(text, /同 opId 重放 100 次/);
+  assert.match(text, /mobile_entity_field_revisions/);
+  assert.match(text, /cursor 与一页业务变更处于同一事务/);
+});
+
+test('screen catalog places retained server settings and backup restore', () => {
+  const text = read('SCREEN_CATALOG.md');
+  assert.match(text, /工具 → 服务器 → 设置/);
+  assert.match(text, /工具 → 服务器 → 备份与恢复/);
+  assert.match(text, /S48 服务器设置/);
+  assert.match(text, /S49 备份与恢复/);
+  assert.doesNotMatch(text, /账号安全[^\n]*一级内容/);
+});
+
+test('parity spec inherits Zephyr facts without inheriting Web UI', () => {
+  const text = read('ZEPHYR_PARITY.md');
+  for (const source of ['authz.js', 'resource-service.js', 'notes-service.js', 'workspace-service.js', 'deeplink-service.js', 'file-transfer-protocol.js']) {
+    assert.match(text, new RegExp(source.replace('.', '\\.')));
+  }
+  assert.match(text, /不能机械搬/);
+  assert.match(text, /WebView/);
+  assert.match(text, /readOnly.*provider/s);
+});
+
+test('implementation status does not falsely claim native code exists', () => {
+  const status = read('IMPLEMENTATION_STATUS.md');
+  assert.match(status, /Android Kotlin\/Compose[^\n]*`missing`/);
+  assert.match(status, /iOS Swift\/SwiftUI[^\n]*`missing`/);
+  assert.match(status, /mobile v1 server API[^\n]*`missing`/);
+  assert.match(status, /完整双向同步[^\n]*`specified`/);
+});
+
+test('JSON Schemas compile strictly and reject the negative operation vector', () => {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  const schemas = [
+    'contracts/schemas/error.schema.json',
+    'contracts/schemas/secret-envelope.schema.json',
+    'contracts/schemas/sync-operation.schema.json',
+    'contracts/schemas/sync-change.schema.json',
+  ].map(json);
+  for (const schema of schemas) ajv.addSchema(schema);
+  for (const schema of schemas) assert.equal(typeof ajv.getSchema(schema.$id), 'function', `failed to compile ${schema.$id}`);
+  const validate = ajv.getSchema('https://zephyr.local/contracts/sync-operation.schema.json');
+  const vectors = json('contracts/test-vectors/sync-v1.json');
+  assert.equal(validate(vectors.operations.acceptedUpsert), true, JSON.stringify(validate.errors));
+  assert.equal(validate(vectors.operations.invalidMissingMask), false, 'negative vector unexpectedly passed');
+});
+
+test('legacy One and current server still visibly lack mobile v1 implementation', () => {
+  const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
+  const one = fs.readFileSync(path.join(root, 'one-client-manager.js'), 'utf8');
+  assert.doesNotMatch(server, /app\.(?:get|post|patch|delete)\('\/api\/mobile\/v1/);
+  assert.match(one, /\/api\/one\/sync\/pull/);
+  assert.match(one, /Build a user-scoped sync snapshot/);
+});

--- a/tests/zephyr-one-mobile-spec-contract.test.mjs
+++ b/tests/zephyr-one-mobile-spec-contract.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Ajv2020 from 'ajv/dist/2020.js';
+import aiAgent from '../ai-agent-service.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const mobile = path.join(root, 'FREEZE', 'zephyr one for mobile');
@@ -14,17 +15,23 @@ const requiredDocs = [
   'README.md', 'PRODUCT_REQUIREMENTS.md', 'DEVELOPMENT.md',
   'ZEPHYR_PARITY.md', 'SCREEN_CATALOG.md', 'SYNC_STATE_MACHINE.md',
   'DATA_AND_MIGRATION.md', 'NATIVE_ENGINE_DECISIONS.md',
+  'MOBILE_EXPERIENCE.md', 'TERMINAL_EXPERIENCE.md',
+  'REMOTE_DESKTOP_EXPERIENCE.md', 'AI_FLOATING_WORKSPACE.md',
+  'SHARED_RESOURCE_RESIDENCY.md',
   'TRACEABILITY.md', 'IMPLEMENTATION_STATUS.md',
 ];
 const requiredContracts = [
   'contracts/openapi-mobile-v1.json',
+  'contracts/ai-capability-baseline.json',
   'contracts/entity-registry.json',
   'contracts/error-registry.json',
   'contracts/schemas/error.schema.json',
   'contracts/schemas/sync-operation.schema.json',
   'contracts/schemas/sync-change.schema.json',
   'contracts/schemas/secret-envelope.schema.json',
+  'contracts/schemas/shared-use-envelope.schema.json',
   'contracts/test-vectors/sync-v1.json',
+  'contracts/test-vectors/shared-use-v1.json',
 ];
 
 test('native mobile spec has all narrative and machine artifacts', () => {
@@ -57,8 +64,30 @@ test('OpenAPI covers auth, binding, bidirectional sync and sensitive grants', ()
     '/api/mobile/v1/sensitive/verify', '/api/mobile/v1/file-bridge/lease',
   ];
   for (const route of expected) assert.ok(api.paths[route], `OpenAPI missing ${route}`);
-  assert.equal(api.paths['/api/auth/login'].post['x-zephyr-implementation'], 'implemented-3a61d2f');
-  assert.equal(api.paths['/api/mobile/v1/sync/push'].post['x-zephyr-implementation'], 'required-server-extension');
+
+  // Routes marked implemented must (a) carry an implemented-<sha> marker and
+  // (b) actually exist in server.js. Freezing one SHA string only breaks on
+  // every rebase while proving nothing about the real server.
+  const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
+  const implemented = Object.entries(api.paths).filter(([, item]) => Object.values(item)
+    .some((op) => op && typeof op === 'object' && String(op['x-zephyr-implementation'] || '').startsWith('implemented-')));
+  assert.ok(implemented.length >= 2, 'pre-existing Zephyr auth routes must be marked implemented');
+  for (const [route, item] of implemented) {
+    for (const [method, op] of Object.entries(item)) {
+      if (!op || typeof op !== 'object' || !op['x-zephyr-implementation']) continue;
+      assert.match(op['x-zephyr-implementation'], /^implemented-[0-9a-f]{7,40}$/, `${route} marker must pin a commit`);
+      assert.ok(server.includes(`app.${method}('${route}'`), `${route} claims implemented but is absent from server.js`);
+    }
+  }
+
+  // Everything under /api/mobile/v1 is still an unbuilt server extension.
+  for (const [route, item] of Object.entries(api.paths)) {
+    if (!route.startsWith('/api/mobile/v1')) continue;
+    for (const [method, op] of Object.entries(item)) {
+      if (!op || typeof op !== 'object' || !op.responses) continue;
+      assert.equal(op['x-zephyr-implementation'], 'required-server-extension', `${method} ${route} must not claim implemented`);
+    }
+  }
 });
 
 test('entity registry covers every product-required mirror family', () => {
@@ -171,6 +200,164 @@ test('JSON Schemas compile strictly and reject the negative operation vector', (
   const vectors = json('contracts/test-vectors/sync-v1.json');
   assert.equal(validate(vectors.operations.acceptedUpsert), true, JSON.stringify(validate.errors));
   assert.equal(validate(vectors.operations.invalidMissingMask), false, 'negative vector unexpectedly passed');
+});
+
+test('mobile experience freezes custom Android back and universal iOS swipe back', () => {
+  const product = read('PRODUCT_REQUIREMENTS.md');
+  const experience = read('MOBILE_EXPERIENCE.md');
+  assert.match(product, /完整移动端原生客户端/);
+  assert.match(product, /系统 back progress\/commit\/cancel/);
+  assert.match(product, /所有 push 进入的普通页面/);
+  assert.match(experience, /默认应用内 predictive-back/);
+  assert.match(experience, /根 Activity 返回系统主页\/跨任务时交还系统动画/);
+  assert.match(experience, /interactivePopGestureRecognizer/);
+  assert.match(experience, /每个 push route/);
+  assert.match(experience, /物理左边缘/);
+});
+
+test('terminal and remote desktop specs preserve complete mobile interaction', () => {
+  const terminal = read('TERMINAL_EXPERIENCE.md');
+  const remote = read('REMOTE_DESKTOP_EXPERIENCE.md');
+  const engines = read('NATIVE_ENGINE_DECISIONS.md');
+  for (const term of ['Termux', 'scrollback', 'selection', 'extra keys', 'PTY resize', 'hardware keyboard']) assert.match(terminal, new RegExp(term));
+  for (const term of ['Direct touch', 'Trackpad', 'FreeRDP', 'VNC', 'clipboard', '弱网']) assert.match(remote, new RegExp(term));
+  assert.match(engines, /FreeRDP.*Apache-2\.0/s);
+  assert.doesNotMatch(engines, /FreeRDP 使用 LGPL/);
+  assert.match(engines, /SwiftTerm/);
+  assert.match(engines, /LibVNCClient/);
+});
+
+test('Zephyr AI is a visible floating workspace with complete live catalog parity', () => {
+  const product = read('PRODUCT_REQUIREMENTS.md');
+  const ai = read('AI_FLOATING_WORKSPACE.md');
+  const screens = read('SCREEN_CATALOG.md');
+  assert.match(product, /原生浮窗\/detent\/side panel/);
+  assert.match(product, /全部 model-visible AI capability\/tool/);
+  assert.match(ai, /116 个模型可见 tool/);
+  assert.match(ai, /peek \/ half \/ expanded/);
+  assert.match(ai, /observation → proposed action → confirmation → execution → verification/);
+  assert.match(ai, /NativeSurfaceBridge/);
+  assert.match(ai, /terminal_read_v1 \/ terminal_send_v1 \/ terminal_wait_v1/);
+  assert.match(ai, /capture\/action\/verify\/cert/);
+  assert.match(ai, /CI 与 Zephyr catalog 动态 diff/);
+  assert.match(screens, /S44 AI 浮动 Workspace/);
+  assert.match(screens, /底层 connection\/terminal\/RDP\/VNC/);
+});
+
+test('AI mobile baseline exactly matches the live Zephyr model-visible catalog', () => {
+  const baseline = json('contracts/ai-capability-baseline.json');
+  const live = aiAgent.listToolCatalog({ permissions: baseline.permissionFixture }).map((tool) => ({
+    toolId: tool.name,
+    capabilityId: tool.capabilityId,
+    risk: tool.risk,
+    confirmation: tool.confirmation,
+    playbookId: tool.playbookId || null,
+    parameters: tool.parameters,
+  })).sort((a, b) => a.toolId.localeCompare(b.toolId));
+  assert.equal(baseline.count, baseline.tools.length);
+  assert.equal(baseline.count, 116, 'update the reviewed mobile AI parity baseline when Zephyr changes');
+  assert.deepEqual(baseline.tools, live);
+});
+
+test('shared-to-me resources are excluded from the mobile mirror and served online only', () => {
+  const product = read('PRODUCT_REQUIREMENTS.md');
+  const residency = read('SHARED_RESOURCE_RESIDENCY.md');
+  const parity = read('ZEPHYR_PARITY.md');
+  const api = json('contracts/openapi-mobile-v1.json');
+
+  // Product contract must scope sync to owned entities and forbid shared persistence.
+  assert.match(product, /当前绑定账号\*\*自己拥有\*\*的数据进入 One 完整双向镜像/);
+  assert.match(product, /分享给当前账号的资源不属于其镜像/);
+  assert.match(product, /每次查看\/使用都在线请求 Zephyr 并实时重验权限/);
+  assert.match(product, /其他用户共享给当前账号的资源全部排除在镜像之外/);
+
+  // Control-plane secrets must never be delivered to the device.
+  for (const forbidden of ['Client Token', 'AI Provider', 'Env secret']) {
+    assert.match(residency, new RegExp(forbidden), `residency spec must forbid ${forbidden}`);
+  }
+  // The honest security statement must survive: encryption is not a proof of non-delivery.
+  assert.match(residency, /best-effort memory zeroization/);
+  assert.match(residency, /不能被描述为数学上保证秘密从未出现在设备/);
+  assert.match(residency, /native direct connection 与“秘密不进入设备”不能同时成立/);
+  assert.match(residency, /relay-strict/);
+  assert.doesNotMatch(residency, /保证秘密从未到达设备/);
+
+  // Sync boundary is enforced on both sides, not only in the UI.
+  assert.match(residency, /ownerUserId == authenticated userId/);
+  assert.match(residency, /shared_residency_violation/);
+  assert.match(parity, /shared-to-me/);
+
+  // Online-only shared endpoints exist and are separated from the sync feed.
+  const paths = Object.keys(api.paths);
+  for (const expected of [
+    '/api/mobile/v1/shared',
+    '/api/mobile/v1/shared/{resourceType}/{resourceId}',
+    '/api/mobile/v1/shared/{resourceType}/{resourceId}/invoke',
+    '/api/mobile/v1/shared/connections/{connectionId}/sessions',
+    '/api/mobile/v1/shared/sessions/{sessionId}/refresh',
+    '/api/mobile/v1/shared/sessions/{sessionId}',
+  ]) {
+    assert.ok(paths.includes(expected), `OpenAPI missing ${expected}`);
+  }
+  const listGet = api.paths['/api/mobile/v1/shared'].get;
+  assert.equal(listGet['x-zephyr-no-store'], true, 'shared list must be declared no-store');
+  const sessionPost = api.paths['/api/mobile/v1/shared/connections/{connectionId}/sessions'].post;
+  assert.equal(sessionPost['x-zephyr-no-store'], true, 'shared session mint must be declared no-store');
+});
+
+test('shared use envelope schema binds device, session, resource and purpose', () => {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  const schema = json('contracts/schemas/shared-use-envelope.schema.json');
+  ajv.addSchema(schema);
+  const validate = ajv.getSchema(schema.$id);
+  assert.equal(typeof validate, 'function', 'shared use envelope schema failed to compile');
+
+  const vectors = json('contracts/test-vectors/shared-use-v1.json');
+  assert.equal(validate(vectors.envelopes.acceptedSsh), true, JSON.stringify(validate.errors));
+  assert.equal(validate(vectors.envelopes.invalidPurpose), false, 'sftp purpose must be rejected by the session envelope');
+  assert.equal(validate(vectors.envelopes.forbiddenControlPlaneField), false, 'control-plane fields must be rejected');
+
+  // AAD must bind every scope field; a shared envelope reused elsewhere has to fail.
+  const aad = Buffer.from(vectors.aad.base64, 'base64');
+  assert.equal(aad.toString('hex'), vectors.aad.hex, 'aad hex and base64 disagree');
+  assert.deepEqual(aad.toString('utf8').split('\0'), vectors.aad.values);
+  for (const field of ['deviceId', 'sessionId', 'resourceId', 'purpose', 'expiresAt', 'clientNonce']) {
+    assert.ok(vectors.aad.fields.includes(field), `aad must bind ${field}`);
+  }
+  const negatives = new Set(vectors.negativeCases.map((item) => item.id));
+  for (const id of ['wrong-device', 'wrong-session', 'wrong-resource', 'wrong-purpose', 'expired', 'replay']) {
+    assert.ok(negatives.has(id), `missing negative case ${id}`);
+  }
+
+  // Control-plane secrets are named explicitly so a future payload change trips the test.
+  for (const key of ['clientToken', 'aiProviderApiKey', 'aiEnvValue', 'serverDataKey', 'ownerSid', 'refreshCredential']) {
+    assert.ok(vectors.forbiddenPayloadKeys.includes(key), `forbidden payload key list must contain ${key}`);
+    assert.equal(Object.prototype.hasOwnProperty.call(schema.properties, key), false, `${key} must not be a schema property`);
+  }
+});
+
+test('shared residency errors are registered with deterministic client actions', () => {
+  const registry = json('contracts/error-registry.json');
+  const byCode = new Map(registry.errors.map((item) => [item.code, item]));
+  const expected = {
+    shared_online_required: 503,
+    shared_grant_expired: 410,
+    shared_grant_revoked: 410,
+    shared_residency_violation: 409,
+    shared_direct_forbidden: 403,
+    shared_session_expired: 410,
+    shared_session_consumed: 409,
+    shared_relay_unavailable: 503,
+    shared_content_export_forbidden: 403,
+  };
+  for (const [code, status] of Object.entries(expected)) {
+    const entry = byCode.get(code);
+    assert.ok(entry, `error registry missing ${code}`);
+    assert.equal(entry.httpStatus, status, `${code} http status drift`);
+    assert.ok(entry.clientAction && entry.clientAction.length > 2, `${code} needs a client action`);
+  }
+  assert.equal(byCode.get('shared_residency_violation').clientAction, 'abortSyncAndPurgeShared');
+  assert.equal(byCode.get('shared_session_consumed').clientAction, 'mintFreshSessionEnvelope');
 });
 
 test('legacy One and current server still visibly lack mobile v1 implementation', () => {


### PR DESCRIPTION
将 Zephyr 现有认证、ACL、资源、笔记、工作区、AI、备份、Client Token、ZFT2 与终端行为映射为 Zephyr One 原生实施合同。新增 OpenAPI 3.1、实体/错误 registry、JSON Schema、AAD/sync vectors、同步状态机、DDL/迁移、逐屏规格、协议引擎 ADR、实现状态与追踪矩阵。新增 13 项合同测试；Redocly 校验通过。全量 Node 对照：工作树 1104 pass/191 fail，基线 1092 pass/191 fail，规范化失败集合完全一致，新增 13 项全绿。明确未假装已完成：mobile v1、Kotlin/Swift 原生代码仍未实现；AI conversation/message schema 与 Client Token 加密 SQLite 迁移仍为阻断。