### PR TITLE
fix(mobile): switch Android launcher icon with theme

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/AndroidManifest.xml
+++ b/zephyr_one/mobile/android/app/src/main/AndroidManifest.xml
@@ -57,12 +57,62 @@
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode|density|smallestScreenSize"
             android:launchMode="singleTask"
             android:theme="@style/Theme.ZephyrOne"
-            android:windowSoftInputMode="adjustNothing">
+            android:windowSoftInputMode="adjustNothing" />
+
+        <!-- Android resolves a launcher's icon from its launcher component. The application icon
+             itself cannot be swapped at runtime, so each theme owns one alias targeting the same
+             singleTask activity. LauncherIconController keeps exactly one alias enabled. -->
+        <activity-alias
+            android:name=".app.FrostLauncher"
+            android:targetActivity=".app.MainActivity"
+            android:enabled="true"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
+
+        <activity-alias
+            android:name=".app.LavaLauncher"
+            android:targetActivity=".app.MainActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher_lava"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity-alias
+            android:name=".app.AsagiLauncher"
+            android:targetActivity=".app.MainActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher_asagi"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity-alias
+            android:name=".app.CyberLauncher"
+            android:targetActivity=".app.MainActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher_cyber"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
 
         <service
             android:name=".app.filebridge.FileBridgeForegroundService"

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/LauncherIconController.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/LauncherIconController.kt
@@ -1,0 +1,113 @@
+package one.zephyr.mobile.app
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import one.zephyr.mobile.ui.theme.ZephyrThemeId
+
+/**
+ * The launcher exposes one manifest alias per colour theme. Android cannot mutate an
+ * application's icon resource in place, so changing the desktop icon means enabling exactly one
+ * alias and disabling the other three.
+ *
+ * Component overrides survive process death and application updates. The selected theme is still
+ * the source of truth in SettingsRepository; MainActivity reapplies it after the active workspace
+ * emits its persisted preferences, so an install upgraded from the single-icon build migrates
+ * automatically.
+ */
+internal class LauncherIconController(context: Context) {
+    private val appContext = context.applicationContext
+    private val packageManager = appContext.packageManager
+
+    fun apply(themeId: ZephyrThemeId): Boolean = runCatching {
+        val changes = launcherIconPlan(themeId).filterNot(::alreadyApplied)
+        if (changes.isEmpty()) return true
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.setComponentEnabledSettings(
+                changes.map { state ->
+                    PackageManager.ComponentEnabledSetting(
+                        component(state.alias),
+                        state.packageManagerState,
+                        PackageManager.DONT_KILL_APP,
+                    )
+                },
+            )
+        } else {
+            // Before API 33 there is no atomic batch call. Enable the destination first so a
+            // launcher intent always has a live component, then remove stale aliases.
+            changes
+                .sortedByDescending { it.enabled }
+                .forEach { state ->
+                    packageManager.setComponentEnabledSetting(
+                        component(state.alias),
+                        state.packageManagerState,
+                        PackageManager.DONT_KILL_APP,
+                    )
+                }
+        }
+        true
+    }.getOrElse { error ->
+        Log.e(TAG, "Unable to switch launcher icon to ${themeId.wireName}", error)
+        false
+    }
+
+    private fun alreadyApplied(state: LauncherIconState): Boolean {
+        val configured = packageManager.getComponentEnabledSetting(component(state.alias))
+        val enabled = when (configured) {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED -> true
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED_UNTIL_USED,
+            -> false
+            PackageManager.COMPONENT_ENABLED_STATE_DEFAULT -> state.alias.enabledByDefault
+            else -> false
+        }
+        return enabled == state.enabled
+    }
+
+    private fun component(alias: LauncherIconAlias): ComponentName =
+        ComponentName(appContext.packageName, alias.componentClassName)
+
+    private val LauncherIconState.packageManagerState: Int
+        get() = if (enabled) {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        } else {
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        }
+
+    private companion object {
+        const val TAG = "ZephyrLauncherIcon"
+    }
+}
+
+internal enum class LauncherIconAlias(
+    val themeId: ZephyrThemeId,
+    val componentClassName: String,
+    val enabledByDefault: Boolean = false,
+) {
+    FROST(ZephyrThemeId.FROST, "one.zephyr.mobile.app.FrostLauncher", enabledByDefault = true),
+    LAVA(ZephyrThemeId.LAVA, "one.zephyr.mobile.app.LavaLauncher"),
+    ASAGI(ZephyrThemeId.ASAGI, "one.zephyr.mobile.app.AsagiLauncher"),
+    CYBER(ZephyrThemeId.CYBER, "one.zephyr.mobile.app.CyberLauncher"),
+    ;
+
+    companion object {
+        fun forTheme(themeId: ZephyrThemeId): LauncherIconAlias =
+            entries.single { it.themeId == themeId }
+    }
+}
+
+internal data class LauncherIconState(
+    val alias: LauncherIconAlias,
+    val enabled: Boolean,
+)
+
+internal fun launcherIconPlan(themeId: ZephyrThemeId): List<LauncherIconState> {
+    val selected = LauncherIconAlias.forTheme(themeId)
+    return LauncherIconAlias.entries.map { alias ->
+        LauncherIconState(alias = alias, enabled = alias == selected)
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/MainActivity.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/MainActivity.kt
@@ -66,10 +66,11 @@ class MainActivity : FragmentActivity() {
             val lockState by container.appLock.state.collectAsState()
             val account by container.accounts.collectAsState()
             val cachedAppearance = remember { appearanceFromLockCache() }
-            val themePrefs by remember(account) {
-                account?.settings?.observePreferences()?.map(::appearanceFromPrefs)
-                    ?: flowOf(cachedAppearance)
-            }.collectAsState(initial = cachedAppearance)
+            val loadedThemePrefs by remember(account) {
+                account?.settings?.observePreferences()?.map { appearanceFromPrefs(it) }
+                    ?: flowOf(null)
+            }.collectAsState(initial = null)
+            val themePrefs = loadedThemePrefs ?: cachedAppearance
             val languageCode by remember(account) {
                 account?.settings?.observePreferences()?.map { prefs ->
                     prefs[SettingsRepository.PREF_LANGUAGE]?.let { EntityCodec.string(it, "value") }
@@ -82,6 +83,13 @@ class MainActivity : FragmentActivity() {
                 AppearanceMode.AUTO -> systemDark
             }
 
+            LaunchedEffect(ready, account, loadedThemePrefs?.themeId) {
+                // Wait until Room has emitted the active workspace's real preference instead of
+                // briefly forcing Frost while startup is still loading Lava/Asagi/Cyber.
+                if (ready && account != null) {
+                    loadedThemePrefs?.let { container.launcherIcons.apply(it.themeId) }
+                }
+            }
             LaunchedEffect(languageCode) {
                 LocaleController.applyIfNeeded(this@MainActivity, languageCode)
             }

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import one.zephyr.mobile.BuildConfig
 import one.zephyr.mobile.app.AboutActionLauncher
+import one.zephyr.mobile.app.LauncherIconController
 import one.zephyr.mobile.contracts.BindingState
 import one.zephyr.mobile.model.AccountBinding
 import one.zephyr.mobile.model.NetworkPolicy
@@ -71,6 +72,9 @@ import one.zephyr.mobile.sync.SyncSettings
 class AppContainer(private val context: Context) {
 
     val aboutActions: AboutActionLauncher by lazy { AboutActionLauncher(context) }
+
+    /** Keeps the one enabled launcher alias aligned with the selected local colour theme. */
+    internal val launcherIcons: LauncherIconController by lazy { LauncherIconController(context) }
 
     /** Process-scoped protocol engines survive Activity recreation without orphaning sessions. */
     val vncEngine: VncEngine by lazy { SocketVncEngine() }

--- a/zephyr_one/mobile/android/app/src/main/res/drawable/ic_launcher_foreground_asagi.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/drawable/ic_launcher_foreground_asagi.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated from mobile/branding/production/zephyr-one-asagi.svg colours with fixed One paths. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+
+    <group
+        android:pivotX="100"
+        android:pivotY="100"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
+
+        <path
+            android:pathData="M 45 65 C 85 45, 135 55, 160 80 C 130 80, 95 95, 75 125"
+            android:strokeWidth="10"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round">
+            <aapt:attr name="android:strokeColor">
+                <gradient
+                    android:startX="30"
+                    android:startY="30"
+                    android:endX="170"
+                    android:endY="170"
+                    android:type="linear">
+                    <item android:offset="0" android:color="#FFEDF4F2" />
+                    <item android:offset="0.58" android:color="#FF9BBDB5" />
+                    <item android:offset="1" android:color="#FF5E8F83" />
+                </gradient>
+            </aapt:attr>
+        </path>
+
+        <group>
+            <clip-path
+                android:fillType="evenOdd"
+                android:pathData="M 0 0 H 200 V 200 H 0 Z M 140 115 A 5 4.8 0 1 0 150 115 A 5 4.8 0 1 0 140 115 Z" />
+            <path
+                android:pathData="M 50 75 C 90 75, 125 90, 145 115 C 115 135, 75 155, 40 135"
+                android:strokeWidth="6"
+                android:strokeAlpha="0.85"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round">
+                <aapt:attr name="android:strokeColor">
+                    <gradient
+                        android:startX="30"
+                        android:startY="30"
+                        android:endX="170"
+                        android:endY="170"
+                        android:type="linear">
+                        <item android:offset="0" android:color="#FFEDF4F2" />
+                        <item android:offset="0.58" android:color="#FF9BBDB5" />
+                        <item android:offset="1" android:color="#FF5E8F83" />
+                    </gradient>
+                </aapt:attr>
+            </path>
+        </group>
+
+        <path
+            android:pathData="M 78 88 C 108 106, 137 137, 170 128"
+            android:strokeWidth="3.5"
+            android:strokeAlpha="0.6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round">
+            <aapt:attr name="android:strokeColor">
+                <gradient
+                    android:startX="30"
+                    android:startY="30"
+                    android:endX="170"
+                    android:endY="170"
+                    android:type="linear">
+                    <item android:offset="0" android:color="#FFEDF4F2" />
+                    <item android:offset="0.58" android:color="#FF9BBDB5" />
+                    <item android:offset="1" android:color="#FF5E8F83" />
+                </gradient>
+            </aapt:attr>
+        </path>
+
+        <path
+            android:pathData="M144.95 120.88Q142.70 120.88 141.28 119.41Q139.85 117.95 139.85 115.59Q139.85 113.10 141.30 111.56Q142.74 110.02 145.12 110.02Q147.37 110.02 148.76 111.49Q150.15 112.97 150.15 115.38Q150.15 117.85 148.71 119.37Q147.27 120.88 144.95 120.88ZM145.05 112.06Q143.81 112.06 143.08 112.99Q142.34 113.93 142.34 115.46Q142.34 117.02 143.08 117.93Q143.81 118.84 145.00 118.84Q146.22 118.84 146.94 117.96Q147.66 117.07 147.66 115.51Q147.66 113.87 146.96 112.97Q146.26 112.06 145.05 112.06Z M160.62 120.70H158.31V116.53Q158.31 114.79 157.07 114.79Q156.46 114.79 156.08 115.25Q155.69 115.71 155.69 116.42V120.70H153.37V113.20H155.69V114.39H155.72Q156.55 113.02 158.13 113.02Q160.62 113.02 160.62 116.11Z M169.19 117.61H164.29Q164.41 119.24 166.35 119.24Q167.59 119.24 168.53 118.66V120.33Q167.49 120.88 165.83 120.88Q164.01 120.88 163.01 119.88Q162.00 118.87 162.00 117.07Q162.00 115.20 163.09 114.11Q164.17 113.02 165.75 113.02Q167.39 113.02 168.29 113.99Q169.19 114.97 169.19 116.64ZM167.04 116.19Q167.04 114.58 165.74 114.58Q165.18 114.58 164.77 115.04Q164.37 115.50 164.28 116.19Z"
+            android:fillColor="#FF4D9C8A"
+            android:fillAlpha="0.9" />
+
+        <path
+            android:pathData="M 75 122 A 3 3 0 1 1 75 128 A 3 3 0 1 1 75 122 Z"
+            android:fillColor="#829B96"
+            android:fillAlpha="0.8" />
+    </group>
+</vector>

--- a/zephyr_one/mobile/android/app/src/main/res/drawable/ic_launcher_foreground_cyber.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/drawable/ic_launcher_foreground_cyber.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated from mobile/branding/production/zephyr-one-cyber.svg colours with fixed One paths. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+
+    <group
+        android:pivotX="100"
+        android:pivotY="100"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
+
+        <path
+            android:pathData="M 45 65 C 85 45, 135 55, 160 80 C 130 80, 95 95, 75 125"
+            android:strokeWidth="10"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round">
+            <aapt:attr name="android:strokeColor">
+                <gradient
+                    android:startX="30"
+                    android:startY="30"
+                    android:endX="170"
+                    android:endY="170"
+                    android:type="linear">
+                    <item android:offset="0" android:color="#FFEEF3F5" />
+                    <item android:offset="0.58" android:color="#FF9EB7BD" />
+                    <item android:offset="1" android:color="#FF5D858D" />
+                </gradient>
+            </aapt:attr>
+        </path>
+
+        <group>
+            <clip-path
+                android:fillType="evenOdd"
+                android:pathData="M 0 0 H 200 V 200 H 0 Z M 140 115 A 5 4.8 0 1 0 150 115 A 5 4.8 0 1 0 140 115 Z" />
+            <path
+                android:pathData="M 50 75 C 90 75, 125 90, 145 115 C 115 135, 75 155, 40 135"
+                android:strokeWidth="6"
+                android:strokeAlpha="0.85"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round">
+                <aapt:attr name="android:strokeColor">
+                    <gradient
+                        android:startX="30"
+                        android:startY="30"
+                        android:endX="170"
+                        android:endY="170"
+                        android:type="linear">
+                        <item android:offset="0" android:color="#FFEEF3F5" />
+                        <item android:offset="0.58" android:color="#FF9EB7BD" />
+                        <item android:offset="1" android:color="#FF5D858D" />
+                    </gradient>
+                </aapt:attr>
+            </path>
+        </group>
+
+        <path
+            android:pathData="M 78 88 C 108 106, 137 137, 170 128"
+            android:strokeWidth="3.5"
+            android:strokeAlpha="0.6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round">
+            <aapt:attr name="android:strokeColor">
+                <gradient
+                    android:startX="30"
+                    android:startY="30"
+                    android:endX="170"
+                    android:endY="170"
+                    android:type="linear">
+                    <item android:offset="0" android:color="#FFEEF3F5" />
+                    <item android:offset="0.58" android:color="#FF9EB7BD" />
+                    <item android:offset="1" android:color="#FF5D858D" />
+                </gradient>
+            </aapt:attr>
+        </path>
+
+        <path
+            android:pathData="M144.95 120.88Q142.70 120.88 141.28 119.41Q139.85 117.95 139.85 115.59Q139.85 113.10 141.30 111.56Q142.74 110.02 145.12 110.02Q147.37 110.02 148.76 111.49Q150.15 112.97 150.15 115.38Q150.15 117.85 148.71 119.37Q147.27 120.88 144.95 120.88ZM145.05 112.06Q143.81 112.06 143.08 112.99Q142.34 113.93 142.34 115.46Q142.34 117.02 143.08 117.93Q143.81 118.84 145.00 118.84Q146.22 118.84 146.94 117.96Q147.66 117.07 147.66 115.51Q147.66 113.87 146.96 112.97Q146.26 112.06 145.05 112.06Z M160.62 120.70H158.31V116.53Q158.31 114.79 157.07 114.79Q156.46 114.79 156.08 115.25Q155.69 115.71 155.69 116.42V120.70H153.37V113.20H155.69V114.39H155.72Q156.55 113.02 158.13 113.02Q160.62 113.02 160.62 116.11Z M169.19 117.61H164.29Q164.41 119.24 166.35 119.24Q167.59 119.24 168.53 118.66V120.33Q167.49 120.88 165.83 120.88Q164.01 120.88 163.01 119.88Q162.00 118.87 162.00 117.07Q162.00 115.20 163.09 114.11Q164.17 113.02 165.75 113.02Q167.39 113.02 168.29 113.99Q169.19 114.97 169.19 116.64ZM167.04 116.19Q167.04 114.58 165.74 114.58Q165.18 114.58 164.77 115.04Q164.37 115.50 164.28 116.19Z"
+            android:fillColor="#FF4F9DA6"
+            android:fillAlpha="0.9" />
+
+        <path
+            android:pathData="M 75 122 A 3 3 0 1 1 75 128 A 3 3 0 1 1 75 122 Z"
+            android:fillColor="#7F9298"
+            android:fillAlpha="0.8" />
+    </group>
+</vector>

--- a/zephyr_one/mobile/android/app/src/main/res/drawable/ic_launcher_foreground_lava.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/drawable/ic_launcher_foreground_lava.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated from mobile/branding/production/zephyr-one-lava.svg colours with fixed One paths. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+
+    <group
+        android:pivotX="100"
+        android:pivotY="100"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
+
+        <path
+            android:pathData="M 45 65 C 85 45, 135 55, 160 80 C 130 80, 95 95, 75 125"
+            android:strokeWidth="10"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round">
+            <aapt:attr name="android:strokeColor">
+                <gradient
+                    android:startX="30"
+                    android:startY="30"
+                    android:endX="170"
+                    android:endY="170"
+                    android:type="linear">
+                    <item android:offset="0" android:color="#FFF1E8DF" />
+                    <item android:offset="0.58" android:color="#FFC79672" />
+                    <item android:offset="1" android:color="#FF8D5A3A" />
+                </gradient>
+            </aapt:attr>
+        </path>
+
+        <group>
+            <clip-path
+                android:fillType="evenOdd"
+                android:pathData="M 0 0 H 200 V 200 H 0 Z M 140 115 A 5 4.8 0 1 0 150 115 A 5 4.8 0 1 0 140 115 Z" />
+            <path
+                android:pathData="M 50 75 C 90 75, 125 90, 145 115 C 115 135, 75 155, 40 135"
+                android:strokeWidth="6"
+                android:strokeAlpha="0.85"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round">
+                <aapt:attr name="android:strokeColor">
+                    <gradient
+                        android:startX="30"
+                        android:startY="30"
+                        android:endX="170"
+                        android:endY="170"
+                        android:type="linear">
+                        <item android:offset="0" android:color="#FFF1E8DF" />
+                        <item android:offset="0.58" android:color="#FFC79672" />
+                        <item android:offset="1" android:color="#FF8D5A3A" />
+                    </gradient>
+                </aapt:attr>
+            </path>
+        </group>
+
+        <path
+            android:pathData="M 78 88 C 108 106, 137 137, 170 128"
+            android:strokeWidth="3.5"
+            android:strokeAlpha="0.6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round">
+            <aapt:attr name="android:strokeColor">
+                <gradient
+                    android:startX="30"
+                    android:startY="30"
+                    android:endX="170"
+                    android:endY="170"
+                    android:type="linear">
+                    <item android:offset="0" android:color="#FFF1E8DF" />
+                    <item android:offset="0.58" android:color="#FFC79672" />
+                    <item android:offset="1" android:color="#FF8D5A3A" />
+                </gradient>
+            </aapt:attr>
+        </path>
+
+        <path
+            android:pathData="M144.95 120.88Q142.70 120.88 141.28 119.41Q139.85 117.95 139.85 115.59Q139.85 113.10 141.30 111.56Q142.74 110.02 145.12 110.02Q147.37 110.02 148.76 111.49Q150.15 112.97 150.15 115.38Q150.15 117.85 148.71 119.37Q147.27 120.88 144.95 120.88ZM145.05 112.06Q143.81 112.06 143.08 112.99Q142.34 113.93 142.34 115.46Q142.34 117.02 143.08 117.93Q143.81 118.84 145.00 118.84Q146.22 118.84 146.94 117.96Q147.66 117.07 147.66 115.51Q147.66 113.87 146.96 112.97Q146.26 112.06 145.05 112.06Z M160.62 120.70H158.31V116.53Q158.31 114.79 157.07 114.79Q156.46 114.79 156.08 115.25Q155.69 115.71 155.69 116.42V120.70H153.37V113.20H155.69V114.39H155.72Q156.55 113.02 158.13 113.02Q160.62 113.02 160.62 116.11Z M169.19 117.61H164.29Q164.41 119.24 166.35 119.24Q167.59 119.24 168.53 118.66V120.33Q167.49 120.88 165.83 120.88Q164.01 120.88 163.01 119.88Q162.00 118.87 162.00 117.07Q162.00 115.20 163.09 114.11Q164.17 113.02 165.75 113.02Q167.39 113.02 168.29 113.99Q169.19 114.97 169.19 116.64ZM167.04 116.19Q167.04 114.58 165.74 114.58Q165.18 114.58 164.77 115.04Q164.37 115.50 164.28 116.19Z"
+            android:fillColor="#FFBF5A1F"
+            android:fillAlpha="0.9" />
+
+        <path
+            android:pathData="M 75 122 A 3 3 0 1 1 75 128 A 3 3 0 1 1 75 122 Z"
+            android:fillColor="#A58A78"
+            android:fillAlpha="0.8" />
+    </group>
+</vector>

--- a/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_asagi.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_asagi.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_asagi" />
+</adaptive-icon>

--- a/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_cyber.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_cyber.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_cyber" />
+</adaptive-icon>

--- a/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_lava.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_lava.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_lava" />
+</adaptive-icon>

--- a/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v33/ic_launcher_asagi.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v33/ic_launcher_asagi.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_asagi" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v33/ic_launcher_cyber.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v33/ic_launcher_cyber.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_cyber" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v33/ic_launcher_lava.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/mipmap-anydpi-v33/ic_launcher_lava.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_lava" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/LauncherIconControllerTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/LauncherIconControllerTest.kt
@@ -1,0 +1,46 @@
+package one.zephyr.mobile.app
+
+import one.zephyr.mobile.ui.theme.ZephyrThemeId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LauncherIconControllerTest {
+
+    @Test
+    fun `every colour theme owns one launcher alias`() {
+        assertEquals(ZephyrThemeId.entries.toSet(), LauncherIconAlias.entries.map { it.themeId }.toSet())
+        assertEquals(LauncherIconAlias.FROST, LauncherIconAlias.forTheme(ZephyrThemeId.FROST))
+        assertEquals(LauncherIconAlias.LAVA, LauncherIconAlias.forTheme(ZephyrThemeId.LAVA))
+        assertEquals(LauncherIconAlias.ASAGI, LauncherIconAlias.forTheme(ZephyrThemeId.ASAGI))
+        assertEquals(LauncherIconAlias.CYBER, LauncherIconAlias.forTheme(ZephyrThemeId.CYBER))
+    }
+
+    @Test
+    fun `each plan enables only the selected launcher`() {
+        ZephyrThemeId.entries.forEach { selectedTheme ->
+            val plan = launcherIconPlan(selectedTheme)
+            assertEquals(LauncherIconAlias.entries.size, plan.size)
+            assertEquals(1, plan.count { it.enabled })
+            assertEquals(selectedTheme, plan.single { it.enabled }.alias.themeId)
+            assertTrue(plan.filterNot { it.enabled }.all { it.alias.themeId != selectedTheme })
+        }
+    }
+
+    @Test
+    fun `only frost is enabled by manifest default`() {
+        assertTrue(LauncherIconAlias.FROST.enabledByDefault)
+        assertTrue(LauncherIconAlias.entries.filterNot { it == LauncherIconAlias.FROST }.none { it.enabledByDefault })
+    }
+
+    @Test
+    fun `aliases resolve to manifest component class names`() {
+        LauncherIconAlias.entries.forEach { alias ->
+            assertTrue(alias.componentClassName.startsWith("one.zephyr.mobile.app."))
+            assertTrue(alias.componentClassName.endsWith("Launcher"))
+            assertFalse(alias.componentClassName.contains(".debug."))
+        }
+        assertEquals(LauncherIconAlias.entries.size, LauncherIconAlias.entries.map { it.componentClassName }.toSet().size)
+    }
+}

--- a/zephyr_one/mobile/tests/android-launcher-icons.test.mjs
+++ b/zephyr_one/mobile/tests/android-launcher-icons.test.mjs
@@ -1,0 +1,78 @@
+/*
+ * The four source icons were committed before Android could select them. This contract pins the
+ * complete chain: source palette -> vector -> adaptive icon -> manifest alias -> runtime switch.
+ * It is intentionally independent of Gradle so a resource or alias can never disappear unnoticed.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MOBILE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const APP = path.join(MOBILE_ROOT, 'android/app/src/main');
+const RES = path.join(APP, 'res');
+const manifest = fs.readFileSync(path.join(APP, 'AndroidManifest.xml'), 'utf8');
+const controller = fs.readFileSync(
+  path.join(APP, 'kotlin/one/zephyr/mobile/app/LauncherIconController.kt'),
+  'utf8',
+);
+const activity = fs.readFileSync(
+  path.join(APP, 'kotlin/one/zephyr/mobile/app/MainActivity.kt'),
+  'utf8',
+);
+
+const themes = [
+  { wire: 'frost', enumName: 'FROST', alias: 'FrostLauncher', resource: 'ic_launcher', colors: ['EEF2F7', 'A8B5C3', '6E7B88', '0A84FF', '8E99A6'] },
+  { wire: 'lava', enumName: 'LAVA', alias: 'LavaLauncher', resource: 'ic_launcher_lava', colors: ['F1E8DF', 'C79672', '8D5A3A', 'BF5A1F', 'A58A78'] },
+  { wire: 'asagi', enumName: 'ASAGI', alias: 'AsagiLauncher', resource: 'ic_launcher_asagi', colors: ['EDF4F2', '9BBDB5', '5E8F83', '4D9C8A', '829B96'] },
+  { wire: 'cyber', enumName: 'CYBER', alias: 'CyberLauncher', resource: 'ic_launcher_cyber', colors: ['EEF3F5', '9EB7BD', '5D858D', '4F9DA6', '7F9298'] },
+];
+
+function blockForAlias(alias) {
+  const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return manifest.match(new RegExp(`<activity-alias[\\s\\S]*?android:name="\\.app\\.${escaped}"[\\s\\S]*?</activity-alias>`))?.[0];
+}
+
+test('manifest exposes exactly four launcher aliases and MainActivity is not a launcher', () => {
+  const aliases = [...manifest.matchAll(/<activity-alias\b/g)];
+  assert.equal(aliases.length, themes.length);
+  const activityBlock = manifest.match(/<activity\b[\s\S]*?android:name="\.app\.MainActivity"[\s\S]*?\/>/)?.[0];
+  assert.ok(activityBlock, 'MainActivity must be a non-launcher activity');
+  assert.doesNotMatch(activityBlock, /android\.intent\.category\.LAUNCHER/);
+
+  for (const theme of themes) {
+    const block = blockForAlias(theme.alias);
+    assert.ok(block, `${theme.alias} manifest alias is missing`);
+    assert.match(block, /android:targetActivity="\.app\.MainActivity"/);
+    assert.match(block, new RegExp(`android:icon="@mipmap/${theme.resource}"`));
+    assert.match(block, /android\.intent\.category\.LAUNCHER/);
+    assert.match(block, new RegExp(`android:enabled="${theme.wire === 'frost'}"`));
+  }
+});
+
+test('all adaptive icons carry the matching source palette and monochrome layer', () => {
+  for (const theme of themes) {
+    const foregroundName = theme.wire === 'frost' ? 'ic_launcher_foreground.xml' : `ic_launcher_foreground_${theme.wire}.xml`;
+    const foreground = fs.readFileSync(path.join(RES, 'drawable', foregroundName), 'utf8').toUpperCase();
+    for (const color of theme.colors) assert.match(foreground, new RegExp(color), `${theme.wire} is missing #${color}`);
+
+    for (const version of ['mipmap-anydpi-v26', 'mipmap-anydpi-v33']) {
+      const adaptive = fs.readFileSync(path.join(RES, version, `${theme.resource}.xml`), 'utf8');
+      const expectedForeground = theme.wire === 'frost' ? 'ic_launcher_foreground' : `ic_launcher_foreground_${theme.wire}`;
+      assert.match(adaptive, new RegExp(`@drawable/${expectedForeground}`));
+      if (version.endsWith('v33')) assert.match(adaptive, /<monochrome android:drawable="@drawable\/ic_launcher_monochrome"/);
+    }
+  }
+});
+
+test('runtime plan maps every theme to one manifest alias', () => {
+  for (const theme of themes) {
+    assert.match(controller, new RegExp(`${theme.enumName}\\(ZephyrThemeId\\.${theme.enumName}, "one\\.zephyr\\.mobile\\.app\\.${theme.alias}"`));
+  }
+  assert.match(controller, /setComponentEnabledSettings/);
+  assert.match(controller, /setComponentEnabledSetting/);
+  assert.match(controller, /launcherIconPlan\(themeId: ZephyrThemeId\)/);
+  assert.match(activity, /container\.launcherIcons\.apply\(it\.themeId\)/);
+  assert.match(activity, /loadedThemePrefs\?\.let/);
+});


### PR DESCRIPTION
## Summary
- package Frost, Lava, Asagi, and Cyber as Android adaptive launcher icons
- expose one launcher activity-alias per theme and keep exactly one enabled
- apply the persisted local theme after workspace preferences load, including upgrades from the single-icon build
- add JVM plan tests plus a static resource/manifest/runtime contract

## Verification
- `npm test`: 284 static + 10 API + 27 roundtrip + 15 secrets + 31 shared tests passed
- 23 launcher-related Android XML files parsed successfully before redundant round resources were removed; final icon contract passes
- mutation: mapping Cyber back to the default Frost resource is rejected by the new contract
- `git diff --check`

Android compilation and prerelease APK validation are handled by the existing Zephyr One Mobile CI because this sandbox intentionally has no Android SDK.