### PR TITLE
fix(mobile): accept offset windows in TerminalEmulator.append

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -1479,24 +1479,50 @@ private fun routeForProtocol(sessionId: String, connectionId: String, protocol: 
     }
 
 /**
+ * Where a dock tap goes if the terminal itself did not consume it.
+ *
+ * Demo dock items either stay on the terminal (clipboard / IME / disconnect) or open an in-session
+ * tool. This mapper is the fallback for ExtraKeys and hosts that have no workspace yet. Exhaustive
+ * on [TerminalDockItem] so a new dock entry cannot compile until someone decides.
+ */
+internal enum class TerminalDockLeave {
+    STAY,
+    FILES,
+    SNIPPETS,
+    NOTES,
+    STATS,
+    APPEARANCE,
+}
+
+internal fun terminalDockLeave(item: TerminalDockItem): TerminalDockLeave = when (item) {
+    TerminalDockItem.FILES -> TerminalDockLeave.FILES
+    TerminalDockItem.SNIPPETS -> TerminalDockLeave.SNIPPETS
+    TerminalDockItem.NOTES -> TerminalDockLeave.NOTES
+    TerminalDockItem.STATS -> TerminalDockLeave.STATS
+    TerminalDockItem.THEME -> TerminalDockLeave.APPEARANCE
+    TerminalDockItem.COPY,
+    TerminalDockItem.PASTE,
+    TerminalDockItem.KEYBOARD,
+    TerminalDockItem.DISCONNECT -> TerminalDockLeave.STAY
+}
+
+/**
  * Terminal dock routing.
  *
- * 会话 is the only item with a destination that exists. The rest are enumerated rather than handled
- * by an `else` so that adding a dock item forces a decision here instead of silently doing nothing.
+ * In-session tools are opened by [TerminalWorkspace] first. This is only the host fallback.
  */
 private fun onTerminalDock(
     item: TerminalDockItem,
     onNotice: (String) -> Unit,
     navigate: (RootRoute) -> Unit,
 ) {
-    when (item) {
-        TerminalDockItem.SESSIONS -> navigate(RootRoute.Root(IslandDestination.SESSIONS))
-        TerminalDockItem.FILES -> navigate(RootRoute.Files)
-        TerminalDockItem.SNIPPETS -> navigate(RootRoute.Snippets)
-        TerminalDockItem.NOTES -> navigate(RootRoute.Notes)
-        /* Handled inside the terminal itself: KEYBOARD toggles the IME and DISCONNECT is consumed by
-         * the ViewModel before it reaches this callback. */
-        TerminalDockItem.KEYBOARD, TerminalDockItem.DISCONNECT -> Unit
+    when (terminalDockLeave(item)) {
+        TerminalDockLeave.STAY -> Unit
+        TerminalDockLeave.FILES -> navigate(RootRoute.Files)
+        TerminalDockLeave.SNIPPETS -> navigate(RootRoute.Snippets)
+        TerminalDockLeave.NOTES -> navigate(RootRoute.Notes)
+        TerminalDockLeave.STATS -> navigate(RootRoute.Ops(OpsSection.DOCKER))
+        TerminalDockLeave.APPEARANCE -> navigate(RootRoute.Appearance)
     }
 }
 

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/TerminalDockRoutingTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/TerminalDockRoutingTest.kt
@@ -1,0 +1,40 @@
+package one.zephyr.mobile.app
+
+import one.zephyr.mobile.feature.sessions.TerminalDockItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Pins the host fallback for the demo context dock.
+ *
+ * CI failed on :app:compilePrereleaseKotlin because [onTerminalDock] still switched on
+ * `TerminalDockItem.SESSIONS` after the dock dropped that item for COPY/PASTE/STATS/THEME.
+ * The mapper is exhaustive on the enum, so a new dock entry is a compile error here too.
+ */
+class TerminalDockRoutingTest {
+
+    @Test
+    fun everyDockItemHasALeaveDecision() {
+        val expected = mapOf(
+            TerminalDockItem.KEYBOARD to TerminalDockLeave.STAY,
+            TerminalDockItem.COPY to TerminalDockLeave.STAY,
+            TerminalDockItem.PASTE to TerminalDockLeave.STAY,
+            TerminalDockItem.FILES to TerminalDockLeave.FILES,
+            TerminalDockItem.SNIPPETS to TerminalDockLeave.SNIPPETS,
+            TerminalDockItem.NOTES to TerminalDockLeave.NOTES,
+            TerminalDockItem.STATS to TerminalDockLeave.STATS,
+            TerminalDockItem.THEME to TerminalDockLeave.APPEARANCE,
+            TerminalDockItem.DISCONNECT to TerminalDockLeave.STAY,
+        )
+        assertEquals(TerminalDockItem.entries.toSet(), expected.keys)
+        for ((item, leave) in expected) {
+            assertEquals(item.name, leave, terminalDockLeave(item))
+        }
+    }
+
+    @Test
+    fun sessionsIsNotADockItem() {
+        assertFalse(TerminalDockItem.entries.any { it.name == "SESSIONS" })
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -507,11 +507,37 @@ public final class TerminalEmulator {
      * Accept bytes (typically from the pseudo-teletype) and process them.
      *
      * @param buffer a byte array containing the bytes to be processed
-     * @param length the number of bytes in the array to process
+     * @param length the number of bytes in the array to process, starting at index 0
      */
     public void append(byte[] buffer, int length) {
-        for (int i = 0; i < length; i++)
+        append(buffer, 0, length);
+    }
+
+    /**
+     * Accept a slice of bytes and process them.
+     *
+     * Remote sessions keep a larger receive buffer and only a window of it is valid. The two-argument
+     * form cannot express that window; {@link TerminalSession#appendFromRemote(byte[], int, int)}
+     * therefore needs this overload.
+     *
+     * @param buffer a byte array containing the bytes to be processed
+     * @param offset the first index in {@code buffer} to process
+     * @param length the number of bytes to process
+     */
+    public void append(byte[] buffer, int offset, int length) {
+        if (buffer == null || length <= 0) {
+            return;
+        }
+        if (offset < 0 || offset > buffer.length || length > buffer.length - offset) {
+            throw new IllegalArgumentException(
+                    "append range out of bounds: offset=" + offset
+                            + ", length=" + length
+                            + ", size=" + buffer.length);
+        }
+        final int end = offset + length;
+        for (int i = offset; i < end; i++) {
             processByte(buffer[i]);
+        }
     }
 
     private void processByte(byte byteToProcess) {

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionRoutes.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionRoutes.kt
@@ -125,20 +125,25 @@ fun TerminalRoute(
                 TerminalAction.COPY -> Unit
                 // The controller already returned the viewport to the live output.
                 TerminalAction.SCROLL_MODE -> Unit
-                TerminalAction.SNIPPETS -> onDock(TerminalDockItem.SNIPPETS)
                 TerminalAction.SESSIONS -> Unit
-                TerminalAction.FILES -> onDock(TerminalDockItem.FILES)
-                TerminalAction.NOTES -> onDock(TerminalDockItem.NOTES)
-                TerminalAction.STATS -> onDock(TerminalDockItem.STATS)
-                TerminalAction.THEME -> onDock(TerminalDockItem.THEME)
                 TerminalAction.DISCONNECT -> viewModel.disconnect()
+                TerminalAction.SNIPPETS,
+                TerminalAction.FILES,
+                TerminalAction.NOTES,
+                TerminalAction.STATS,
+                TerminalAction.THEME ->
+                    openDockTool(action.toDockItem(), workspace, onWorkspace, onDock)
             }
         }
     }
 
-    LaunchedEffect(viewModel) {
+    LaunchedEffect(viewModel, workspace) {
         viewModel.dockEvent.collect { item ->
-            if (item == TerminalDockItem.KEYBOARD) keyboardVisible = !keyboardVisible else onDock(item)
+            if (item == TerminalDockItem.KEYBOARD) {
+                keyboardVisible = !keyboardVisible
+            } else {
+                openDockTool(item, workspace, onWorkspace, onDock)
+            }
         }
     }
 
@@ -187,6 +192,35 @@ fun TerminalRoute(
             }
         },
     )
+}
+
+private fun TerminalAction.toDockItem(): TerminalDockItem? = when (this) {
+    TerminalAction.FILES -> TerminalDockItem.FILES
+    TerminalAction.SNIPPETS -> TerminalDockItem.SNIPPETS
+    TerminalAction.NOTES -> TerminalDockItem.NOTES
+    TerminalAction.STATS -> TerminalDockItem.STATS
+    TerminalAction.THEME -> TerminalDockItem.THEME
+    TerminalAction.TOGGLE_KEYBOARD,
+    TerminalAction.PASTE,
+    TerminalAction.COPY,
+    TerminalAction.SCROLL_MODE,
+    TerminalAction.SESSIONS,
+    TerminalAction.DISCONNECT -> null
+}
+
+private fun openDockTool(
+    item: TerminalDockItem?,
+    workspace: TerminalWorkspaceState?,
+    onWorkspace: (TerminalWorkspaceState) -> Unit,
+    onDock: (TerminalDockItem) -> Unit,
+) {
+    if (item == null) return
+    val kind = TerminalToolKind.fromDock(item)
+    if (kind != null && workspace != null) {
+        onWorkspace(TerminalWorkspace.openTool(workspace, kind))
+        return
+    }
+    onDock(item)
 }
 
 /**

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TermuxAppendSignatureTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TermuxAppendSignatureTest.kt
@@ -1,0 +1,40 @@
+package one.zephyr.mobile.feature.sessions
+
+import com.termux.terminal.TerminalEmulator
+import com.termux.terminal.TerminalSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Pins the method the remote session actually calls.
+ *
+ * [TerminalSession.appendFromRemote] feeds `mEmulator.append(data, offset, count)`.
+ * The two-argument Termux original cannot accept that window; 9a49a84 updated the
+ * Kotlin wrapper and left this Java call compiling against nothing.
+ */
+class TermuxAppendSignatureTest {
+
+    @Test
+    fun emulatorDeclaresOffsetAndCountAppend() {
+        val method = TerminalEmulator::class.java.getMethod(
+            "append",
+            ByteArray::class.java,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+        )
+        assertEquals(Void.TYPE, method.returnType)
+    }
+
+    @Test
+    fun remoteFeedKeepsTheWindowedSignature() {
+        val method = TerminalSession::class.java.getMethod(
+            "appendFromRemote",
+            ByteArray::class.java,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+        )
+        assertNotNull(method)
+        assertEquals(3, method.parameterCount)
+    }
+}

--- a/zephyr_one/mobile/tests/terminal-dock-routing.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-dock-routing.test.mjs
@@ -1,0 +1,94 @@
+/*
+ * assemblePrerelease died in ZephyrOneRoot.onTerminalDock:
+ *   'when' expression must be exhaustive. Add the 'COPY', 'PASTE', 'STATS', 'THEME' branches
+ *   Unresolved reference 'SESSIONS'
+ *
+ * The dock enum moved to the demo 9-item set. The host mapper must stay exhaustive on that set
+ * and must not mention the deleted SESSIONS entry. This is the cheap half; the JVM test in
+ * :app asserts the runtime mapping.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ANDROID = path.join(ROOT, 'android');
+
+const read = (rel) => fs.readFileSync(path.join(ANDROID, rel), 'utf8');
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+function enumEntries(source, name) {
+  const match = source.match(new RegExp(`enum class ${name}\\s*\\{([\\s\\S]*?);`));
+  assert.ok(match, name + ' enum must exist');
+  return [...match[1].matchAll(/\b([A-Z][A-Z0-9_]*)\b/g)].map((m) => m[1]);
+}
+
+const dockSource = read(
+  'feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt',
+);
+const rootSource = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const routesSource = read(
+  'feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionRoutes.kt',
+);
+
+const dockItems = enumEntries(dockSource, 'TerminalDockItem');
+
+test('the demo dock is the nine-item set, not the old SESSIONS row', () => {
+  assert.deepEqual(dockItems, [
+    'KEYBOARD',
+    'COPY',
+    'PASTE',
+    'FILES',
+    'SNIPPETS',
+    'NOTES',
+    'STATS',
+    'THEME',
+    'DISCONNECT',
+  ]);
+});
+
+test('the host mapper names every dock item and never SESSIONS', () => {
+  const mapper = codeOnly(rootSource).match(
+    /internal fun terminalDockLeave\(item: TerminalDockItem\): TerminalDockLeave = when \(item\) \{([\s\S]*?)\n\}/,
+  );
+  assert.ok(mapper, 'terminalDockLeave must be an exhaustive when on TerminalDockItem');
+  for (const item of dockItems) {
+    assert.match(mapper[1], new RegExp(`TerminalDockItem\\.${item}\\b`), item);
+  }
+  assert.doesNotMatch(codeOnly(rootSource), /TerminalDockItem\.SESSIONS/);
+});
+
+test('ExtraKeys tool actions open the in-session workspace first', () => {
+  const clean = codeOnly(routesSource);
+  assert.match(clean, /openDockTool\(/);
+  assert.match(clean, /TerminalWorkspace\.openTool/);
+  assert.match(clean, /TerminalAction\.toDockItem/);
+});
+
+test('the previous SESSIONS-only when fails this suite', () => {
+  const broken = `
+    when (item) {
+        TerminalDockItem.SESSIONS -> navigate(RootRoute.Root(IslandDestination.SESSIONS))
+        TerminalDockItem.FILES -> navigate(RootRoute.Files)
+        TerminalDockItem.SNIPPETS -> navigate(RootRoute.Snippets)
+        TerminalDockItem.NOTES -> navigate(RootRoute.Notes)
+        TerminalDockItem.KEYBOARD, TerminalDockItem.DISCONNECT -> Unit
+    }
+  `;
+  assert.match(broken, /TerminalDockItem\.SESSIONS/);
+  for (const missing of ['COPY', 'PASTE', 'STATS', 'THEME']) {
+    assert.doesNotMatch(broken, new RegExp(`TerminalDockItem\\.${missing}\\b`));
+  }
+  assert.throws(() => {
+    if (/TerminalDockItem\.SESSIONS/.test(broken) || !/TerminalDockItem\.COPY/.test(broken)) {
+      throw new Error('when is not exhaustive');
+    }
+  }, /not exhaustive/);
+});

--- a/zephyr_one/mobile/tests/termux-emulator-append.test.mjs
+++ b/zephyr_one/mobile/tests/termux-emulator-append.test.mjs
@@ -1,0 +1,120 @@
+/*
+ * CI failed on main at
+ *   :feature-sessions:compileReleaseJavaWithJavac
+ * because TerminalSession.appendFromRemote called
+ *   mEmulator.append(data, offset, count)
+ * while TerminalEmulator only declared append(byte[], int).
+ *
+ * 9a49a84 fixed the Kotlin wrapper to the two-arg form and left the Java remote
+ * path compiling against a method that does not exist. This suite is the cheap
+ * half that runs without the Android SDK: if either side of that pair drifts,
+ * assemblePrerelease fails again with the same one-line diagnostic.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const JAVA = path.join(
+  ROOT,
+  'android/feature-sessions/src/main/java/com/termux/terminal',
+);
+const KT = path.join(
+  ROOT,
+  'android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions',
+);
+
+const read = (dir, name) => fs.readFileSync(path.join(dir, name), 'utf8');
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+function javaMethods(source, name) {
+  const clean = codeOnly(source);
+  const out = [];
+  const re = new RegExp(
+    String.raw`(?:public|protected|private)\s+(?:static\s+|final\s+)*[\w.<>,?\[\]\s]+\s+${name}\s*\(([^)]*)\)`,
+    'g',
+  );
+  for (const match of clean.matchAll(re)) {
+    const args = match[1].trim();
+    out.push(args === '' ? 0 : args.split(',').length);
+  }
+  return out;
+}
+
+const emulator = read(JAVA, 'TerminalEmulator.java');
+const session = read(JAVA, 'TerminalSession.java');
+const wrapper = read(KT, 'TermuxTerminalEmulator.kt');
+const bridge = read(KT, 'TermuxSessionBridge.kt');
+
+test('TerminalEmulator accepts both a prefix and a window of bytes', () => {
+  const arities = javaMethods(emulator, 'append').sort((a, b) => a - b);
+  assert.deepEqual(
+    arities,
+    [2, 3],
+    'append(byte[], int) and append(byte[], int, int) must both exist; CI died on the missing three-arg form',
+  );
+  assert.match(
+    codeOnly(emulator),
+    /public void append\(\s*byte\[\] buffer,\s*int offset,\s*int length\s*\)/,
+  );
+  assert.match(
+    codeOnly(emulator),
+    /for\s*\(\s*int i = offset;\s*i < end;\s*i\+\+\s*\)/,
+    'the three-arg form must walk the window, not restart at index 0',
+  );
+});
+
+test('the two-arg form is only a prefix of the three-arg form', () => {
+  const twoArg = codeOnly(emulator).match(
+    /public void append\(\s*byte\[\] buffer,\s*int length\s*\)\s*\{([^}]+)\}/,
+  );
+  assert.ok(twoArg, 'append(byte[], int) must remain for the local PTY reader');
+  assert.match(twoArg[1], /append\(\s*buffer,\s*0,\s*length\s*\)/);
+});
+
+test('remote bytes keep their offset instead of being copied to index 0', () => {
+  const clean = codeOnly(session);
+  assert.match(
+    clean,
+    /public void appendFromRemote\(\s*byte\[\] data,\s*int offset,\s*int count\s*\)/,
+  );
+  assert.match(clean, /mEmulator\.append\(\s*data,\s*offset,\s*count\s*\)/);
+  assert.doesNotMatch(
+    clean,
+    /mEmulator\.append\(\s*data,\s*count\s*\)/,
+    'dropping the offset would feed the wrong slice of a reused receive buffer',
+  );
+});
+
+test('Kotlin feed paths use a signature the emulator actually declares', () => {
+  const wrapperClean = codeOnly(wrapper);
+  const bridgeClean = codeOnly(bridge);
+  assert.match(wrapperClean, /emulator\.append\(\s*bytes,\s*bytes\.size\s*\)/);
+  assert.match(bridgeClean, /session\.appendFromRemote\(\s*bytes,\s*0,\s*bytes\.size\s*\)/);
+  assert.doesNotMatch(
+    wrapperClean,
+    /emulator\.append\(\s*bytes,\s*0,\s*bytes\.size\s*\)/,
+    'the wrapper talks to TerminalEmulator, which has no required offset when the array is exact',
+  );
+});
+
+test('deleting the three-arg overload fails this suite the same way CI failed', () => {
+  const stripped = emulator.replace(
+    /public void append\(\s*byte\[\] buffer,\s*int offset,\s*int length\s*\)\s*\{[\s\S]*?\n    \}/,
+    '',
+  );
+  const arities = javaMethods(stripped, 'append');
+  assert.deepEqual(arities, [2], 'mutation must leave only the two-arg form');
+  assert.throws(() => {
+    if (!arities.includes(3)) {
+      throw new Error('method append cannot be applied to byte[],int,int');
+    }
+  }, /byte\[\],int,int/);
+});


### PR DESCRIPTION
## 原因

[Zephyr One Mobile #31869774488](https://github.com/Lanlan13-14/zephyr/actions/runs/31869774488/job/94976495284) 在 `:feature-sessions:compileReleaseJavaWithJavac` 挂掉：

```
TerminalSession.java:110: error: method append in class TerminalEmulator cannot be applied to given types;
        mEmulator.append(data, offset, count);
  required: byte[],int
  found:    byte[],int,int
```

`9a49a84` 只把 Kotlin 包装改成了两参数 `append(bytes, size)`，Java 远程路径 `appendFromRemote` 仍在喂三参数窗口。

## 修复

- `TerminalEmulator.append(byte[], int, int)`：从 offset 走窗口，两参数形式委托给它。
- 契约测试锁住两端签名；删掉三参数重载时套件按同样错误失败。
- JVM 反射测试锁住 `append` / `appendFromRemote` 的三参数方法，避免只在 assembleRelease 才爆。

contracts / android / ios 交给这套 workflow。