### PR TITLE
fix(mobile): paint the live SSH viewport instead of an empty Frost box

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -92,8 +92,8 @@ import one.zephyr.mobile.feature.sessions.TerminalCredentials
 import one.zephyr.mobile.feature.sessions.TerminalDockItem
 import one.zephyr.mobile.feature.sessions.TerminalRoute
 import one.zephyr.mobile.feature.sessions.TerminalViewModel
-import one.zephyr.mobile.feature.sessions.SimpleVtEmulator
 import one.zephyr.mobile.feature.sessions.SshTerminalHost
+import one.zephyr.mobile.feature.sessions.productionTerminalEmulator
 import one.zephyr.mobile.feature.sessions.TerminalWorkspaceState
 import one.zephyr.mobile.feature.tools.BatchExecutionScreen
 import one.zephyr.mobile.feature.tools.BatchExecutionViewModel
@@ -727,7 +727,7 @@ private fun BoundRoot(
                                 engine = sshEngine,
                                 findConnection = { id -> account.connections.find(id) },
                             ),
-                            emulator = SimpleVtEmulator(),
+                            emulator = productionTerminalEmulator(),
                             secretProvider = { connection -> account.terminalCredentials(connection) },
                         ),
                     ),

--- a/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/terminal/TerminalSession.java
@@ -175,7 +175,10 @@ public final class TerminalSession extends TerminalOutput {
     public void initializeEmulator(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
         mEmulator = new TerminalEmulator(this, columns, rows, cellWidthPixels, cellHeightPixels, mTranscriptRows, mClient);
 
-        if (mCustomInputStream != null || mCustomOutputStream != null) {
+        // Remote SSH/Telnet: no local PTY. The custom-stream constructor leaves mShellPath
+        // null; OutputListener is the byte sink. Going down the JNI path here would call
+        // createSubprocess(null, ...) the first time TerminalView laid out.
+        if (mShellPath == null || mCustomInputStream != null || mCustomOutputStream != null || mOutputListener != null) {
             if (mCustomInputStream != null) {
                 new Thread("TermSessionStreamReader[" + mHandle + "]") {
                     @Override
@@ -326,7 +329,9 @@ public final class TerminalSession extends TerminalOutput {
 
     /** Notify the {@link #mClient} that the screen has changed. */
     protected void notifyScreenUpdate() {
-        mClient.onTextChanged(this);
+        if (mClient != null) {
+            mClient.onTextChanged(this);
+        }
     }
 
     /** Reset state for terminal emulator state. */

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SimpleVtEmulator.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SimpleVtEmulator.kt
@@ -1,16 +1,21 @@
 package one.zephyr.mobile.feature.sessions
 
 /**
- * Terminal VT emulator powered by Termux engine.
+ * JVM-safe Termux parser wrapper.
  *
- * Full ANSI/VT100/VT220/xterm/truecolor/256-color support with scrollback reflow,
- * wide CJK glyphs, cursor tracking, and DEC private modes.
+ * Production attaches a [TermuxSessionBridge] so [TerminalView] can paint. This class stays a
+ * snapshot adapter for unit tests: constructing [TerminalSession] here would pull android.os.Handler
+ * into every emulator test.
  */
 class SimpleVtEmulator(
     maxScrollback: Int = 4_000,
+    outputSink: ((ByteArray) -> Unit)? = null,
 ) : TerminalEmulator {
 
-    private val delegate = TermuxTerminalEmulator(maxScrollback = maxScrollback)
+    private val delegate = TermuxTerminalEmulator(
+        maxScrollback = maxScrollback,
+        outputSink = outputSink,
+    )
 
     override val isAvailable: Boolean get() = delegate.isAvailable
 

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaint.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaint.kt
@@ -40,5 +40,9 @@ object TerminalCellPaint {
         return 0.2126f * r + 0.7152f * g + 0.0722f * b
     }
 
-    private const val MIN_CONTRAST = 2.2f
+    /**
+     * Only the near-invisible cases: white-on-Frost is ~1.09, ANSI green-on-Frost is ~1.97.
+     * A WCAG-sized floor would wash every bright SGR colour into chrome ink.
+     */
+    private const val MIN_CONTRAST = 1.5f
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaint.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaint.kt
@@ -1,0 +1,44 @@
+package one.zephyr.mobile.feature.sessions
+
+/**
+ * Picks a paint colour that stays readable on the chrome background.
+ *
+ * Termux's default scheme is white-on-black. Frost's terminal surface is a pale grey. A snapshot
+ * that still carries `0xFFFFFFFF` / `0` therefore paints invisible glyphs. The live [TerminalView]
+ * path applies [TermuxColorScheme] first; this helper is the Compose fallback and any host that
+ * draws [TerminalCell] without that scheme.
+ */
+object TerminalCellPaint {
+
+    fun foreground(cellArgb: Int, fallbackArgb: Int, backgroundArgb: Int): Int {
+        if (cellArgb == 0) return fallbackArgb
+        if (contrast(cellArgb, backgroundArgb) < MIN_CONTRAST) return fallbackArgb
+        return cellArgb
+    }
+
+    fun background(cellArgb: Int, fallbackArgb: Int): Int {
+        if (cellArgb == 0) return fallbackArgb
+        return cellArgb
+    }
+
+    fun contrast(fgArgb: Int, bgArgb: Int): Float {
+        val fg = luminance(fgArgb)
+        val bg = luminance(bgArgb)
+        val lighter = maxOf(fg, bg)
+        val darker = minOf(fg, bg)
+        return (lighter + 0.05f) / (darker + 0.05f)
+    }
+
+    private fun luminance(argb: Int): Float {
+        fun channel(value: Int): Float {
+            val c = value / 255f
+            return if (c <= 0.03928f) c / 12.92f else ((c + 0.055f) / 1.055f).let { it * it * it }
+        }
+        val r = channel((argb ushr 16) and 0xFF)
+        val g = channel((argb ushr 8) and 0xFF)
+        val b = channel(argb and 0xFF)
+        return 0.2126f * r + 0.7152f * g + 0.0722f * b
+    }
+
+    private const val MIN_CONTRAST = 2.2f
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -133,6 +133,13 @@ class TerminalViewModel(
         scope = viewModelScope,
     )
 
+    /**
+     * The live Termux session the view attaches to.
+     *
+     * Only a [TermuxSessionBridge] has a [com.termux.terminal.TerminalSession]. Wrapping the
+     * parser as [SimpleVtEmulator] and casting that wrapper left the pane on an empty box
+     * while SSH output kept arriving.
+     */
     val termux: TermuxSessionBridge? = emulator as? TermuxSessionBridge
 
     init {
@@ -161,6 +168,19 @@ class TerminalViewModel(
     private var outputJob: Job? = null
     private val emulatorLock = Any()
     private var connectRequested = false
+
+    init {
+        viewModelScope.launch {
+            var lastSize: TerminalSize? = null
+            controller.state.collect { surface ->
+                val size = surface.size
+                if (size != lastSize && size.columns > 0 && size.rows > 0) {
+                    lastSize = size
+                    synchronized(emulatorLock) { emulator.resize(size.columns, size.rows) }
+                }
+            }
+        }
+    }
     @Volatile private var opening = false
 
     private data class CachedTerminalFrame(
@@ -367,8 +387,17 @@ class TerminalViewModel(
         outputJob?.cancel()
         outputJob = viewModelScope.launch {
             host.output(sessionId).collect { bytes ->
-                val update = withContext(emulatorDispatcher) {
-                    synchronized(emulatorLock) { emulator.feed(bytes) }
+                // Termux's emulator and TerminalView share one buffer. Feeding it off the main
+                // thread races onDraw and paints a blank grid. Snapshot-only emulators stay on
+                // the background dispatcher so unit tests do not need a Looper.
+                val update = if (termux != null) {
+                    withContext(Dispatchers.Main.immediate) {
+                        synchronized(emulatorLock) { emulator.feed(bytes) }
+                    }
+                } else {
+                    withContext(emulatorDispatcher) {
+                        synchronized(emulatorLock) { emulator.feed(bytes) }
+                    }
                 }
                 controller.onModes(update.modes)
                 controller.onOutput(update.newRows, update.transcriptRows)

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt
@@ -12,8 +12,10 @@ import com.termux.terminal.TerminalSession
 import com.termux.terminal.TerminalSessionClient
 import com.termux.terminal.TextStyle
 import com.termux.terminal.WcWidth
+import android.os.Looper
 import com.termux.view.TerminalView
 import com.termux.view.TerminalViewClient
+import java.lang.ref.WeakReference
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -39,6 +41,12 @@ class TermuxSessionBridge(
 
     private val client = BridgeSessionClient()
 
+    @Volatile
+    private var lastColumns: Int = 80
+
+    @Volatile
+    private var lastRows: Int = 24
+
     val session: TerminalSession = TerminalSession(
         /* in = */ null,
         /* out = */ null,
@@ -53,15 +61,15 @@ class TermuxSessionBridge(
             lastColumns = emulator.mColumns
             lastRows = emulator.mRows
         }
+        // SSH banners arrive before the first layout. Without an emulator they are dropped and
+        // the first paint is an empty grid on Frost's term background.
+        created.updateSize(lastColumns, lastRows, 8, 16)
     }
 
     private val snapshotColors = TerminalColors()
 
     @Volatile
-    private var lastColumns: Int = 80
-
-    @Volatile
-    private var lastRows: Int = 24
+    private var attachedView: WeakReference<TerminalView>? = null
 
     val columns: Int get() = session.emulator?.mColumns ?: lastColumns
     val rows: Int get() = session.emulator?.mRows ?: lastRows
@@ -74,11 +82,14 @@ class TermuxSessionBridge(
         TerminalColors.COLOR_SCHEME.updateWith(props)
         session.emulator?.mColors?.reset()
         snapshotColors.reset()
+        attachedView?.get()?.onScreenUpdated()
         onScreenChanged()
     }
 
     fun attach(view: TerminalView) {
+        attachedView = WeakReference(view)
         view.attachSession(session)
+        view.onScreenUpdated()
     }
 
     fun feedRemote(bytes: ByteArray) {
@@ -229,7 +240,17 @@ class TermuxSessionBridge(
     }
 
     private inner class BridgeSessionClient : TerminalSessionClient {
-        override fun onTextChanged(changedSession: TerminalSession) = onScreenChanged()
+        override fun onTextChanged(changedSession: TerminalSession) {
+            val view = attachedView?.get()
+            if (view != null) {
+                if (Looper.myLooper() == Looper.getMainLooper()) {
+                    view.onScreenUpdated()
+                } else {
+                    view.post { view.onScreenUpdated() }
+                }
+            }
+            onScreenChanged()
+        }
         override fun onTitleChanged(changedSession: TerminalSession) = onTitle(changedSession.title)
         override fun onSessionFinished(finishedSession: TerminalSession) = onFinished()
         override fun onCopyTextToClipboard(session: TerminalSession, text: String) = onCopy(text)
@@ -329,3 +350,13 @@ internal object TermuxHandleSeq {
     private val next = AtomicInteger(1)
     fun next(): Int = next.getAndIncrement()
 }
+
+/**
+ * Production emulator: a live Termux session the view can attach to.
+ *
+ * [SimpleVtEmulator] is the JVM snapshot wrapper. The app used to construct that wrapper and then
+ * `as? TermuxSessionBridge`, which is always null, so the pane painted an empty Frost box over a
+ * live SSH stream.
+ */
+fun productionTerminalEmulator(maxScrollback: Int = 4_000): TerminalEmulator =
+    TermuxSessionBridge(maxScrollback = maxScrollback, writeBytes = {})

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxTerminalPane.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxTerminalPane.kt
@@ -1,18 +1,20 @@
 package one.zephyr.mobile.feature.sessions
 
+import android.graphics.Paint
 import android.graphics.Typeface
 import android.view.inputmethod.InputMethodManager
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.termux.view.TerminalView
@@ -24,6 +26,9 @@ import kotlin.math.roundToInt
  *
  * Keyboard is the system IME. Extra-key latches are read by [ZephyrTerminalViewClient] so the demo
  * Ctrl/Alt row actually modifies the next keystroke Termux sends.
+ *
+ * If the ViewModel was given a snapshot-only emulator (tests, or a host that still constructs
+ * [SimpleVtEmulator]), the pane draws the cell grid itself instead of an empty Frost box.
  */
 @Composable
 fun TermuxTerminalPane(
@@ -75,7 +80,15 @@ fun TermuxTerminalPane(
                     view.setTerminalViewClient(client)
                     view.isFocusable = true
                     view.isFocusableInTouchMode = true
+                    bridge.applyScheme(
+                        TermuxColorScheme(
+                            foregroundArgb = colors.text.toArgb(),
+                            backgroundArgb = colors.termBg.toArgb(),
+                            cursorArgb = colors.text.toArgb(),
+                        ),
+                    )
                     bridge.attach(view)
+                    view.post { view.onScreenUpdated() }
                 }
             },
             update = { view ->
@@ -94,26 +107,66 @@ fun TermuxTerminalPane(
             },
         )
     }
-
-    DisposableEffect(viewModel) {
-        onDispose { }
-    }
 }
 
 private fun spToPx(view: android.view.View, sp: Float): Int =
     (sp * view.resources.displayMetrics.scaledDensity).roundToInt().coerceAtLeast(8)
 
 @Composable
-private fun FallbackComposeViewport(viewModel: TerminalViewModel, colors: TerminalChromeColors) {
+internal fun FallbackComposeViewport(viewModel: TerminalViewModel, colors: TerminalChromeColors) {
     val revision by viewModel.surfaceRevision.collectAsStateWithLifecycle()
     val surface by viewModel.controller.state.collectAsStateWithLifecycle()
     val frame = remember(revision, surface.topRow, surface.size.rows) {
         viewModel.renderFrame(surface.topRow, surface.size.rows)
     }
-    Box(Modifier.fillMaxSize().background(colors.termBg))
-    /* Keep a live revision read so output still advances the fallback path. */
-    @Suppress("UNUSED_VARIABLE")
-    val unused = frame.lines.size
+    val density = LocalDensity.current
+    val textPaint = remember {
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            typeface = Typeface.MONOSPACE
+        }
+    }
+    val bgPaint = remember { Paint() }
+    val fallbackFg = colors.text.toArgb()
+    val fallbackBg = colors.termBg.toArgb()
+    val cellW = surface.fontSp * 0.6f * density.density
+    val lineH = surface.fontSp * 1.55f * density.density
+    textPaint.textSize = surface.fontSp * density.fontScale * density.density
+
+    Canvas(Modifier.fillMaxSize().background(colors.termBg)) {
+        val native = drawContext.canvas.nativeCanvas
+        val cursor = frame.cursor
+        frame.lines.forEachIndexed { row, line ->
+            var x = 0f
+            val top = row * lineH
+            val baseline = top + lineH - textPaint.fontMetrics.descent
+            for (cell in line.cells) {
+                if (cell.wideContinuation) {
+                    x += cellW
+                    continue
+                }
+                val bg = TerminalCellPaint.background(cell.background, fallbackBg)
+                if (bg != fallbackBg) {
+                    bgPaint.color = bg
+                    native.drawRect(x, top, x + cellW, top + lineH, bgPaint)
+                }
+                val glyph = cell.text
+                if (glyph.isNotEmpty() && glyph != " ") {
+                    textPaint.color = TerminalCellPaint.foreground(cell.foreground, fallbackFg, fallbackBg)
+                    textPaint.isFakeBoldText = cell.bold
+                    textPaint.textSkewX = if (cell.italic) -0.2f else 0f
+                    textPaint.isUnderlineText = cell.underline
+                    native.drawText(glyph, x, baseline, textPaint)
+                }
+                x += cellW
+            }
+        }
+        if (cursor != null && cursor.visible && cursor.row in frame.lines.indices) {
+            val cx = cursor.column * cellW
+            val cy = cursor.row * lineH
+            bgPaint.color = fallbackFg
+            native.drawRect(cx, cy, cx + 2f * density.density, cy + lineH, bgPaint)
+        }
+    }
 }
 
 internal fun termuxDefaultProperties(colors: TerminalChromeColors): Properties = Properties().apply {

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaintTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaintTest.kt
@@ -1,0 +1,33 @@
+package one.zephyr.mobile.feature.sessions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TerminalCellPaintTest {
+
+    @Test
+    fun transparentCellsFallBackToChromeInk() {
+        val frostBg = 0xFFF2F4F7.toInt()
+        val frostInk = 0xFF1C232B.toInt()
+        assertEquals(frostInk, TerminalCellPaint.foreground(0, frostInk, frostBg))
+        assertEquals(frostBg, TerminalCellPaint.background(0, frostBg))
+    }
+
+    @Test
+    fun whiteOnFrostIsReplacedBecauseItIsInvisible() {
+        val frostBg = 0xFFF2F4F7.toInt()
+        val frostInk = 0xFF1C232B.toInt()
+        val painted = TerminalCellPaint.foreground(0xFFFFFFFF.toInt(), frostInk, frostBg)
+        assertEquals(frostInk, painted)
+        assertTrue(TerminalCellPaint.contrast(0xFFFFFFFF.toInt(), frostBg) < 2.2f)
+    }
+
+    @Test
+    fun greenOnFrostStaysBecauseItIsReadable() {
+        val frostBg = 0xFFF2F4F7.toInt()
+        val frostInk = 0xFF1C232B.toInt()
+        val green = 0xFF00CD00.toInt()
+        assertEquals(green, TerminalCellPaint.foreground(green, frostInk, frostBg))
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaintTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalCellPaintTest.kt
@@ -20,7 +20,7 @@ class TerminalCellPaintTest {
         val frostInk = 0xFF1C232B.toInt()
         val painted = TerminalCellPaint.foreground(0xFFFFFFFF.toInt(), frostInk, frostBg)
         assertEquals(frostInk, painted)
-        assertTrue(TerminalCellPaint.contrast(0xFFFFFFFF.toInt(), frostBg) < 2.2f)
+        assertTrue(TerminalCellPaint.contrast(0xFFFFFFFF.toInt(), frostBg) < 1.5f)
     }
 
     @Test
@@ -28,6 +28,7 @@ class TerminalCellPaintTest {
         val frostBg = 0xFFF2F4F7.toInt()
         val frostInk = 0xFF1C232B.toInt()
         val green = 0xFF00CD00.toInt()
+        assertTrue(TerminalCellPaint.contrast(green, frostBg) >= 1.5f)
         assertEquals(green, TerminalCellPaint.foreground(green, frostInk, frostBg))
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt
@@ -74,16 +74,24 @@ class TerminalViewModelTest {
         private var update: EmulatorUpdate = EmulatorUpdate(),
     ) : TerminalEmulator {
         val fed = mutableListOf<ByteArray>()
+        val resizes = mutableListOf<Pair<Int, Int>>()
         var closed = false
             private set
         var snapshotTopRow = -1
             private set
+        var lastColumns = 80
+            private set
+        var lastRows = 24
+            private set
+        override fun resize(columns: Int, rows: Int) {
+            lastColumns = columns
+            lastRows = rows
+            resizes += columns to rows
+        }
 
         fun nextUpdate(next: EmulatorUpdate) {
             update = next
         }
-
-        override fun resize(columns: Int, rows: Int) = Unit
 
         override fun feed(bytes: ByteArray): EmulatorUpdate {
             fed += bytes
@@ -390,6 +398,32 @@ class TerminalViewModelTest {
         assertEquals(24, lines.size)
         assertEquals(0, emulator.snapshotTopRow)
         assertEquals(4, subject.cursor().row)
+    }
+
+    @Test
+    fun geometryChangesResizeTheEmulatorNotJustThePty() = runTest(mainDispatcher) {
+        val emulator = FakeEmulator()
+        val subject = subject(emulator = emulator)
+        subscribe(subject)
+        runCurrent()
+
+        assertEquals(listOf(80 to 24), emulator.resizes)
+
+        subject.controller.onGeometry(
+            totalWidthPx = 800f,
+            totalHeightPx = 1000f,
+            imeHeightPx = 0f,
+            shortcutMatrixHeightPx = 100f,
+            dockHeightPx = 80f,
+            cellWidthPx = 10f,
+            lineHeightPx = 20f,
+        )
+        runCurrent()
+
+        val last = emulator.resizes.last()
+        assertTrue("emulator must leave the default 80x24, was $last", last != 80 to 24)
+        assertEquals(last.first, subject.controller.state.value.size.columns)
+        assertEquals(last.second, subject.controller.state.value.size.rows)
     }
 
     @Test

--- a/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
@@ -30,7 +30,8 @@ test('new connections start with a visible password field', () => {
 test('app wires SSHJ instead of the unavailable stub', () => {
   const root = read(ROOT_KT);
   assert.match(root, /SshTerminalHost\(/);
-  assert.match(root, /SimpleVtEmulator\(/);
+  assert.match(root, /productionTerminalEmulator\(/);
+  assert.doesNotMatch(root, /emulator = SimpleVtEmulator\(/);
   assert.match(root, /autoConnect = true/);
   assert.doesNotMatch(root, /UnavailableTerminalHost\(TERMINAL_ENGINE_MISSING\)/);
   assert.match(read(CONTAINER), /SshjEngine\(/);

--- a/zephyr_one/mobile/tests/terminal-viewport-wiring.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-viewport-wiring.test.mjs
@@ -1,0 +1,85 @@
+/*
+ * After a successful SSH connect the terminal painted a blank Frost box.
+ *
+ * Two independent mistakes stacked:
+ *   1. ZephyrOneRoot constructed SimpleVtEmulator and TerminalViewModel.termux did
+ *      `emulator as? TermuxSessionBridge`, which is always null for that wrapper.
+ *      TermuxTerminalPane then took FallbackComposeViewport, which drew an empty Box.
+ *   2. TerminalSession.initializeEmulator treated a remote session as a local PTY
+ *      (mShellPath == null) and walked into JNI.createSubprocess. SSH banners that
+ *      arrived before layout were also dropped because mEmulator was still null.
+ *
+ * This suite is the cheap half. The JVM tests pin resize + contrast; CI compiles the
+ * AndroidView path.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ANDROID = path.join(ROOT, 'android');
+const read = (rel) => fs.readFileSync(path.join(ANDROID, rel), 'utf8');
+const codeOnly = (source) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
+const root = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const vm = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt');
+const pane = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxTerminalPane.kt');
+const session = read('feature-sessions/src/main/java/com/termux/terminal/TerminalSession.java');
+const bridge = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt');
+
+test('the live route constructs a Termux session, not the snapshot wrapper', () => {
+  const clean = codeOnly(root);
+  assert.match(clean, /productionTerminalEmulator\(/);
+  assert.doesNotMatch(clean, /emulator\s*=\s*SimpleVtEmulator\(/);
+});
+
+test('termux is only a TermuxSessionBridge, never a silent null from SimpleVtEmulator', () => {
+  const clean = codeOnly(vm);
+  assert.match(clean, /val termux: TermuxSessionBridge\? = emulator as\? TermuxSessionBridge/);
+  assert.doesNotMatch(clean, /is SimpleVtEmulator -> emulator\.bridge/);
+});
+
+test('the fallback viewport draws glyphs instead of an empty Box', () => {
+  const clean = codeOnly(pane);
+  assert.match(clean, /FallbackComposeViewport/);
+  assert.match(clean, /native\.drawText/);
+  assert.match(clean, /TerminalCellPaint\.foreground/);
+  assert.doesNotMatch(
+    clean,
+    /Box\(Modifier\.fillMaxSize\(\)\.background\(colors\.termBg\)\)\s*\/\*/,
+  );
+});
+
+test('a remote session never calls JNI.createSubprocess', () => {
+  const clean = codeOnly(session);
+  assert.match(
+    clean,
+    /if \(mShellPath == null \|\| mCustomInputStream != null \|\| mCustomOutputStream != null \|\| mOutputListener != null\)/,
+  );
+  const remote = clean.slice(
+    clean.indexOf('mShellPath == null'),
+    clean.indexOf('JNI.createSubprocess'),
+  );
+  assert.match(remote, /return;/);
+});
+
+test('the bridge creates an emulator before the first remote byte and invalidates the view', () => {
+  const clean = codeOnly(bridge);
+  assert.match(clean, /created\.updateSize\(lastColumns, lastRows, 8, 16\)/);
+  assert.match(clean, /fun productionTerminalEmulator/);
+  assert.match(clean, /view\.onScreenUpdated\(\)/);
+  assert.match(clean, /attachedView/);
+});
+
+test('the previous SimpleVtEmulator wiring fails this suite', () => {
+  const broken = 'emulator = SimpleVtEmulator()';
+  assert.match(broken, /SimpleVtEmulator\(/);
+  assert.throws(() => {
+    if (/emulator\s*=\s*SimpleVtEmulator\(/.test(broken)) {
+      throw new Error('snapshot wrapper has no TerminalSession');
+    }
+  }, /no TerminalSession/);
+});


### PR DESCRIPTION
## 现象

SSH 已连上（绿点、`48×39 (resized)`），中间画布是 Frost 浅底，一个字都没有。

## 原因

两件事叠在一起：

1. `ZephyrOneRoot` 构造 `SimpleVtEmulator()`，`TerminalViewModel.termux` 再 `as? TermuxSessionBridge`，永远是 null。`TermuxTerminalPane` 走 `FallbackComposeViewport`，而那个 fallback 是空 `Box`。
2. 远程 `TerminalSession` 的 `mShellPath == null`，`initializeEmulator` 仍会走进 `JNI.createSubprocess`。SSH banner 在第一次 layout 之前到达时 `mEmulator` 还是 null，被丢掉。

## 修复

- 生产路径改为 `productionTerminalEmulator()` → 真正的 `TermuxSessionBridge`。
- 远程 session 不再走本地 PTY；构造时先 `updateSize`，banner 能进 buffer。
- 几何变化同步 `emulator.resize`；Termux 喂字节改到主线程，避免和 `onDraw` 抢同一块 buffer。
- fallback 不再是空盒子：按单元格画字，白色字在 Frost 浅底上自动换成 chrome ink。

契约：`tests/terminal-viewport-wiring.test.mjs`。
JVM：`TerminalCellPaintTest`、`geometryChangesResizeTheEmulatorNotJustThePty`。