### PR TITLE
fix(mobile): finish SSH terminal runtime and in-flow tools

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
@@ -295,7 +295,7 @@ internal fun AppLockDestination(account: AccountContainer, container: one.zephyr
                 if (value) {
                     if (!canEnable) return@launch
                     busy = true
-                    val result = container.appLock.confirmLocalReveal(
+                    val result = container.appLock.confirmEnable(
                         title = context.getString(R.string.unlock_enable_title),
                         subtitle = context.getString(R.string.unlock_enable_subtitle),
                     )

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/LiveSshExecPort.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/LiveSshExecPort.kt
@@ -1,0 +1,46 @@
+package one.zephyr.mobile.app
+
+import kotlinx.coroutines.withTimeoutOrNull
+import one.zephyr.mobile.data.session.SessionRegistry
+import one.zephyr.mobile.data.session.SessionTransport
+import one.zephyr.mobile.feature.tools.ExecOutcome
+import one.zephyr.mobile.feature.tools.SshExecPort
+import one.zephyr.mobile.model.MobileError
+import one.zephyr.mobile.protocol.ssh.SshEngine
+
+/** Runs batch commands over the already-authenticated local SSH session for each connection. */
+internal class LiveSshExecPort(
+    private val engine: SshEngine,
+    private val sessions: SessionRegistry,
+) : SshExecPort {
+    override val isAvailable: Boolean get() = engine.isAvailable
+
+    override suspend fun exec(connectionId: String, command: String, timeoutSeconds: Int): ExecOutcome {
+        val live = sessions.rows.value.firstOrNull {
+            it.connectionId == connectionId && it.transport == SessionTransport.CONNECTED
+        } ?: return ExecOutcome.Failed(
+            MobileError.local("session_not_connected", "请先连接该 SSH 主机后再执行", true),
+        )
+        val result = withTimeoutOrNull(timeoutSeconds.coerceAtLeast(1) * 1_000L) {
+            engine.exec(live.sessionId, command)
+        } ?: return ExecOutcome.TimedOut
+        return result.fold(
+            onSuccess = { value ->
+                ExecOutcome.Completed(
+                    exitCode = value.exitCode,
+                    stdout = value.stdout.toString(Charsets.UTF_8),
+                    stderr = value.stderr.toString(Charsets.UTF_8),
+                )
+            },
+            onFailure = { failure ->
+                ExecOutcome.Failed(
+                    MobileError.local(
+                        code = "ssh_exec_failed",
+                        message = failure.message ?: "SSH 远程执行失败",
+                        retryable = true,
+                    ),
+                )
+            },
+        )
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ProtocolConnectionTester.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ProtocolConnectionTester.kt
@@ -1,0 +1,22 @@
+package one.zephyr.mobile.app
+
+import one.zephyr.mobile.feature.connections.ConnectionTestCredentials
+import one.zephyr.mobile.feature.connections.ConnectionTestResult
+import one.zephyr.mobile.feature.connections.ConnectionTester
+import one.zephyr.mobile.model.Connection
+import one.zephyr.mobile.model.Protocol
+
+/** SSH authenticates through SSHJ; other protocols retain the main branch TCP latency probe. */
+internal class ProtocolConnectionTester(
+    private val ssh: ConnectionTester,
+    private val fallback: ConnectionTester,
+) : ConnectionTester {
+    override suspend fun test(
+        connection: Connection,
+        credentials: ConnectionTestCredentials,
+    ): ConnectionTestResult = if (connection.protocol == Protocol.SSH) {
+        ssh.test(connection, credentials)
+    } else {
+        fallback.test(connection, credentials)
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
@@ -1,0 +1,70 @@
+package one.zephyr.mobile.app
+
+import java.util.UUID
+import kotlin.system.measureNanoTime
+import one.zephyr.mobile.feature.connections.ConnectionTestCredentials
+import one.zephyr.mobile.feature.connections.ConnectionTestResult
+import one.zephyr.mobile.feature.connections.ConnectionTester
+import one.zephyr.mobile.model.Connection
+import one.zephyr.mobile.model.MobileError
+import one.zephyr.mobile.protocol.ssh.HostKeyPolicy
+import one.zephyr.mobile.protocol.ssh.RouteHop
+import one.zephyr.mobile.protocol.ssh.SshConnectOutcome
+import one.zephyr.mobile.protocol.ssh.SshConnectRequest
+import one.zephyr.mobile.protocol.ssh.SshCredential
+import one.zephyr.mobile.protocol.ssh.SshEngine
+import one.zephyr.mobile.protocol.ssh.SshRoute
+
+/** One-shot direct SSH test used by the connection editor. Never creates a terminal tab. */
+internal class DirectSshConnectionTester(private val engine: SshEngine) : ConnectionTester {
+    override suspend fun test(
+        connection: Connection,
+        credentials: ConnectionTestCredentials,
+    ): ConnectionTestResult {
+        if (!engine.isAvailable) return ConnectionTestResult.Failed(
+            MobileError.local("engine_unavailable", "SSH 引擎不可用", false),
+        )
+        if (!connection.protocol.isTerminal || connection.protocol != one.zephyr.mobile.model.Protocol.SSH) {
+            return ConnectionTestResult.Failed(
+                MobileError.local("protocol_unsupported", "此测试器仅支持 SSH", false),
+            )
+        }
+        val credential = when {
+            credentials.privateKey != null && credentials.privateKey.isNotEmpty() -> SshCredential.PrivateKey(
+                credentials.privateKey,
+                credentials.passphrase,
+            )
+            credentials.password != null && credentials.password.isNotEmpty() ->
+                SshCredential.Password(credentials.password)
+            else -> return ConnectionTestResult.Failed(
+                MobileError.local("auth_missing", "请填写密码或选择 SSH Key", false),
+            )
+        }
+        val sessionId = "test-" + UUID.randomUUID()
+        var outcome: SshConnectOutcome
+        val elapsedNanos = measureNanoTime {
+            outcome = engine.connect(
+                SshConnectRequest(
+                    sessionId = sessionId,
+                    route = SshRoute(listOf(RouteHop.Target(connection.host, connection.port))),
+                    username = connection.username,
+                    credential = credential,
+                    hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,
+                    cols = 80,
+                    rows = 24,
+                    encoding = connection.encoding.wireName,
+                ),
+            )
+        }
+        val elapsedMs = (elapsedNanos / 1_000_000L).coerceAtLeast(1L)
+        return try {
+            when (val value = outcome) {
+                is SshConnectOutcome.Connected -> ConnectionTestResult.Authenticated(elapsedMs)
+                is SshConnectOutcome.HostKeyDecisionRequired -> ConnectionTestResult.Reachable(elapsedMs)
+                is SshConnectOutcome.Failed -> ConnectionTestResult.Failed(value.error)
+            }
+        } finally {
+            engine.disconnect(sessionId)
+        }
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
@@ -29,13 +29,15 @@ internal class DirectSshConnectionTester(private val engine: SshEngine) : Connec
                 MobileError.local("protocol_unsupported", "此测试器仅支持 SSH", false),
             )
         }
+        val privateKey = credentials.privateKey
+        val password = credentials.password
         val credential = when {
-            credentials.privateKey != null && credentials.privateKey.isNotEmpty() -> SshCredential.PrivateKey(
-                credentials.privateKey,
+            privateKey != null && privateKey.isNotEmpty() -> SshCredential.PrivateKey(
+                privateKey,
                 credentials.passphrase,
             )
-            credentials.password != null && credentials.password.isNotEmpty() ->
-                SshCredential.Password(credentials.password)
+            password != null && password.isNotEmpty() ->
+                SshCredential.Password(password)
             else -> return ConnectionTestResult.Failed(
                 MobileError.local("auth_missing", "请填写密码或选择 SSH Key", false),
             )

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -67,6 +67,8 @@ import one.zephyr.mobile.data.session.SessionRow
 import one.zephyr.mobile.data.session.SessionTransport
 import one.zephyr.mobile.feature.connections.ConnectionEditorRoute
 import one.zephyr.mobile.feature.connections.ConnectionEditorViewModel
+import one.zephyr.mobile.feature.connections.ConnectionDraft
+import one.zephyr.mobile.feature.connections.ConnectionTestCredentials
 import one.zephyr.mobile.feature.connections.ConnectionListRoute
 import one.zephyr.mobile.feature.connections.ConnectionListViewModel
 import one.zephyr.mobile.feature.connections.ConnectionTestResult
@@ -102,7 +104,6 @@ import one.zephyr.mobile.feature.tools.BatchExecutionViewModel
 import one.zephyr.mobile.feature.tools.BatchIntent
 import one.zephyr.mobile.feature.tools.NoopBatchAuditSink
 import one.zephyr.mobile.feature.tools.ServerHubScreen
-import one.zephyr.mobile.feature.tools.UnavailableRemotePorts
 import one.zephyr.mobile.feature.tools.ToolEntry
 import one.zephyr.mobile.feature.tools.ToolsInventory
 import one.zephyr.mobile.feature.tools.ToolsRootRoute
@@ -534,7 +535,11 @@ private fun BoundRoot(
                         duplicateSourceId = current.duplicateSourceId,
                         initialProtocol = current.protocol,
                         newIdFactory = { UUID.randomUUID().toString() },
-                        tester = TcpReachabilityTester(),
+                        tester = ProtocolConnectionTester(
+                            ssh = DirectSshConnectionTester(appContainer.sshEngine),
+                            fallback = TcpReachabilityTester(),
+                        ),
+                        testCredentials = { connection, draft -> account.connectionTestCredentials(connection, draft) },
                         registerSensitiveSink = account::registerSensitiveSink,
                         unregisterSensitiveSink = account::unregisterSensitiveSink,
                     ),
@@ -732,6 +737,11 @@ private fun BoundRoot(
                 var termWorkspace by remember(current.sessionId) {
                     mutableStateOf(TerminalWorkspaceState(paneA = current.sessionId))
                 }
+                LaunchedEffect(termSessions, current.sessionId) {
+                    if (termSessions.firstOrNull { it.sessionId == current.sessionId }?.transport == SessionTransport.CLOSED) {
+                        route = RootRoute.Root(IslandDestination.SESSIONS)
+                    }
+                }
                 TerminalRoute(
                     viewModel = viewModel(
                         key = "terminal:" + current.sessionId,
@@ -776,6 +786,7 @@ private fun BoundRoot(
                     onAddSession = { connection ->
                         route = routeForProtocol(UUID.randomUUID().toString(), connection.id, connection.protocol)
                     },
+                    onCreateConnection = { route = RootRoute.ProtocolPicker },
                     onOpenNote = { id -> route = RootRoute.NoteEditor(id) },
                     onOpenDocker = { route = RootRoute.Ops(OpsSection.DOCKER) },
                 )
@@ -798,6 +809,7 @@ private fun BoundRoot(
 
                 RootRoute.BatchExecution -> BatchExecutionDestination(
                     account = account,
+                    sshEngine = appContainer.sshEngine,
                     ownerUserId = ownerUserId,
                     onBack = { route = RootRoute.Root(IslandDestination.TOOLS) },
                     onMessage = { messages.emit(it) },
@@ -1179,6 +1191,7 @@ private fun ToolsDestination(
 @Composable
 private fun BatchExecutionDestination(
     account: AccountContainer,
+    sshEngine: one.zephyr.mobile.protocol.ssh.SshEngine,
     ownerUserId: String,
     onBack: () -> Unit,
     onMessage: suspend (String) -> Unit,
@@ -1187,7 +1200,7 @@ private fun BatchExecutionDestination(
         key = "tools:batch",
         factory = BatchExecutionViewModel.factory(
             connections = account.connections,
-            exec = UnavailableRemotePorts,
+            exec = LiveSshExecPort(sshEngine, account.sessions),
             audit = NoopBatchAuditSink,
             ownerUserId = ownerUserId,
             network = account.network,
@@ -1585,6 +1598,23 @@ private fun AccountContainer.passwordChars(connection: Connection): CharArray? {
         fieldName = FIELD_PASSWORD,
     ) ?: return null
     return secretStore.getText(ref)?.toCharArray()
+}
+
+private suspend fun AccountContainer.connectionTestCredentials(
+    connection: Connection,
+    draft: ConnectionDraft,
+): ConnectionTestCredentials {
+    val replacementPassword = draft.testPasswordChars()
+    val replacementKey = draft.testPrivateKeyChars()
+    if (replacementPassword != null || replacementKey != null) {
+        return ConnectionTestCredentials(password = replacementPassword, privateKey = replacementKey)
+    }
+    val stored = terminalCredentials(connection)
+    return ConnectionTestCredentials(
+        password = stored.password,
+        privateKey = stored.privateKey,
+        passphrase = stored.passphrase,
+    )
 }
 
 private suspend fun AccountContainer.terminalCredentials(connection: Connection): TerminalCredentials {

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -540,6 +540,10 @@ private fun BoundRoot(
                             fallback = TcpReachabilityTester(),
                         ),
                         testCredentials = { connection, draft -> account.connectionTestCredentials(connection, draft) },
+                        passwordRevealEnabled = { appContainer.appLock.isEnabled },
+                        passwordRevealer = { connection ->
+                            account.revealConnectionPassword(connection, appContainer)
+                        },
                         registerSensitiveSink = account::registerSensitiveSink,
                         unregisterSensitiveSink = account::unregisterSensitiveSink,
                     ),
@@ -1598,6 +1602,25 @@ private fun AccountContainer.passwordChars(connection: Connection): CharArray? {
         fieldName = FIELD_PASSWORD,
     ) ?: return null
     return secretStore.getText(ref)?.toCharArray()
+}
+
+private suspend fun AccountContainer.revealConnectionPassword(
+    connection: Connection,
+    appContainer: AppContainer,
+): String? {
+    if (!appContainer.appLock.isEnabled || !connection.capabilities.canRevealSecret) return null
+    val result = appContainer.appLock.confirmLocalReveal(
+        title = "查看连接密码",
+        subtitle = connection.name + " · 认证后显示 30 秒",
+    )
+    if (result !is AuthResult.Success || !appContainer.appLock.isEnabled) return null
+    val ref = secretRefForPresence(
+        presence = connection.password,
+        entityType = Connection.ENTITY_TYPE,
+        entityId = connection.id,
+        fieldName = FIELD_PASSWORD,
+    ) ?: return null
+    return secretStore.getText(ref)
 }
 
 private suspend fun AccountContainer.connectionTestCredentials(

--- a/zephyr_one/mobile/android/core-security/src/main/kotlin/one/zephyr/mobile/security/AppLock.kt
+++ b/zephyr_one/mobile/android/core-security/src/main/kotlin/one/zephyr/mobile/security/AppLock.kt
@@ -157,8 +157,22 @@ class AppLock(
     /**
      * Sensitive local reveals reuse the platform prompt, but callers must still hold a main-end
      * grant for the actions listed in DEVELOPMENT.md 617.
+     *
+     * Enabling and revealing are deliberately separate: reveal is invalid until local unlock has
+     * already been enabled, while enable needs one proof before that state exists.
      */
+    suspend fun confirmEnable(title: String, subtitle: String): AuthResult {
+        if (!authenticator.availability().canAuthenticate) {
+            return AuthResult.Failed(authenticator.availability(), "platform authentication unavailable")
+        }
+        return authenticator.authenticate(title, subtitle)
+    }
+
+    /** Sensitive reveal requires local unlock to already be enabled. */
     suspend fun confirmLocalReveal(title: String, subtitle: String): AuthResult {
+        if (!isEnabled) {
+            return AuthResult.Failed(BiometricAvailability.UNSUPPORTED, "local unlock is disabled")
+        }
         if (!authenticator.availability().canAuthenticate) {
             return AuthResult.Failed(authenticator.availability(), "platform authentication unavailable")
         }

--- a/zephyr_one/mobile/android/core-security/src/test/kotlin/one/zephyr/mobile/security/AppLockTest.kt
+++ b/zephyr_one/mobile/android/core-security/src/test/kotlin/one/zephyr/mobile/security/AppLockTest.kt
@@ -101,15 +101,50 @@ class AppLockTest {
     }
 
     @Test
-    fun `confirm local reveal refuses unavailable hardware`() = runTest {
+    fun `enable confirmation refuses unavailable hardware`() = runTest {
         val authenticator = FakeAuthenticator(availability = BiometricAvailability.NO_HARDWARE)
+        val lock = AppLock(authenticator)
+
+        val result = lock.confirmEnable("t", "s")
+
+        assertTrue(result is AuthResult.Failed)
+        assertEquals(BiometricAvailability.NO_HARDWARE, (result as AuthResult.Failed).availability)
+        assertEquals(0, authenticator.authenticateCalls)
+    }
+
+    @Test
+    fun `enable confirmation authenticates before lock is enabled`() = runTest {
+        val authenticator = FakeAuthenticator()
+        val lock = AppLock(authenticator)
+
+        val result = lock.confirmEnable("t", "s")
+
+        assertEquals(AuthResult.Success, result)
+        assertEquals(1, authenticator.authenticateCalls)
+        assertFalse(lock.isEnabled)
+    }
+
+    @Test
+    fun `confirm local reveal refuses when local unlock is disabled`() = runTest {
+        val authenticator = FakeAuthenticator()
         val lock = AppLock(authenticator)
 
         val result = lock.confirmLocalReveal("t", "s")
 
         assertTrue(result is AuthResult.Failed)
-        assertEquals(BiometricAvailability.NO_HARDWARE, (result as AuthResult.Failed).availability)
         assertEquals(0, authenticator.authenticateCalls)
+    }
+
+    @Test
+    fun `confirm local reveal authenticates when local unlock is enabled`() = runTest {
+        val authenticator = FakeAuthenticator()
+        val lock = AppLock(authenticator)
+        assertTrue(lock.enable(LockDelay.IMMEDIATE))
+
+        val result = lock.confirmLocalReveal("t", "s")
+
+        assertEquals(AuthResult.Success, result)
+        assertEquals(1, authenticator.authenticateCalls)
     }
 
     @Test

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraft.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraft.kt
@@ -264,6 +264,14 @@ data class ConnectionDraft(
     private fun outgoingSecret(state: SecretState): SecretState =
         if (state is SecretState.Replace && state.isBlank) SecretState.Unchanged else state
 
+    /** Copies only the active replacement for a one-shot connection test. Caller must wipe it. */
+    fun testPasswordChars(): CharArray? =
+        (password as? SecretState.Replace)?.editingText()?.toCharArray()
+
+    /** Copies only the active inline-key replacement for a one-shot test. Caller must wipe it. */
+    fun testPrivateKeyChars(): CharArray? =
+        (privateKey as? SecretState.Replace)?.editingText()?.toCharArray()
+
     // ---- validation ----------------------------------------------------------------------------
 
     /**

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -692,28 +692,29 @@ private fun SecretEditor(
                     style = ZephyrTheme.typography.mono,
                     modifier = Modifier.weight(1f),
                 )
-                SegmentedControl(
-                    options = listOf(
-                        stringResource(R.string.editor_secret_keep),
-                        stringResource(R.string.editor_secret_replace),
-                        stringResource(R.string.editor_secret_clear),
-                    ),
-                    selectedIndex = when (state) {
-                        is SecretState.Unchanged -> 0
-                        is SecretState.Replace -> 1
-                        is SecretState.Clear -> 2
-                    },
-                    onSelect = {
-                        onChange(
-                            when (it) {
-                                0 -> SecretState.Unchanged
-                                1 -> SecretState.Replace("")
-                                else -> SecretState.Clear
-                            },
-                        )
-                    },
-                    modifier = Modifier.width(159.dp),
-                )
+                Row(
+                    modifier = Modifier.width(168.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    if (state !is SecretState.Replace) {
+                        OutlinedButton(
+                            onClick = { onChange(SecretState.Replace("")) },
+                            modifier = Modifier.weight(1f),
+                        ) { Text(stringResource(R.string.editor_secret_replace), maxLines = 1) }
+                    }
+                    if (state !is SecretState.Clear) {
+                        OutlinedButton(
+                            onClick = { onChange(SecretState.Clear) },
+                            modifier = Modifier.weight(1f),
+                        ) { Text(stringResource(R.string.editor_secret_clear), maxLines = 1) }
+                    }
+                    if (state !is SecretState.Unchanged) {
+                        OutlinedButton(
+                            onClick = { onChange(SecretState.Unchanged) },
+                            modifier = Modifier.weight(1f),
+                        ) { Text(stringResource(R.string.editor_secret_keep), maxLines = 1) }
+                    }
+                }
             }
         }
 

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -193,6 +193,10 @@ sealed interface EditorIntent {
     data class Visibility(val value: String) : EditorIntent
     data class RepairRoute(val field: String) : EditorIntent
     data object Test : EditorIntent
+    data object RevealPassword : EditorIntent
+
+    data object HidePassword : EditorIntent
+
     data object Save : EditorIntent
     data object SaveAndConnect : EditorIntent
     data object ConnectWithoutSaving : EditorIntent
@@ -314,6 +318,10 @@ private fun AuthSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) ->
         label = stringResource(R.string.editor_field_password),
         stored = draft.original?.password ?: SecretPresence.absent,
         state = draft.password,
+        revealAllowed = ui.passwordRevealAllowed,
+        revealedValue = ui.revealedPassword,
+        onReveal = { onIntent(EditorIntent.RevealPassword) },
+        onHide = { onIntent(EditorIntent.HidePassword) },
         onChange = { onIntent(EditorIntent.Password(it)) },
     )
 
@@ -674,6 +682,10 @@ private fun SecretEditor(
     label: String,
     stored: SecretPresence,
     state: SecretState,
+    revealAllowed: Boolean = false,
+    revealedValue: String? = null,
+    onReveal: () -> Unit = {},
+    onHide: () -> Unit = {},
     onChange: (SecretState) -> Unit,
     multiline: Boolean = false,
 ) {
@@ -686,16 +698,27 @@ private fun SecretEditor(
             ) {
                 Text(label, style = ZephyrTheme.typography.caption, color = ZephyrTheme.palette.onFloatingMuted, modifier = Modifier.width(72.dp))
                 Text(
-                    text = ConnectionDraft.presenceFor(state, stored).let {
+                    text = revealedValue ?: ConnectionDraft.presenceFor(state, stored).let {
                         if (it.hasValue) SecretPresence.MASK else stringResource(R.string.editor_secret_clear)
                     },
                     style = ZephyrTheme.typography.mono,
                     modifier = Modifier.weight(1f),
                 )
                 Row(
-                    modifier = Modifier.width(168.dp),
+                    modifier = Modifier.width(if (revealAllowed) 228.dp else 168.dp),
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
+                    if (revealAllowed && state is SecretState.Unchanged) {
+                        OutlinedButton(
+                            onClick = if (revealedValue == null) onReveal else onHide,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(
+                                stringResource(if (revealedValue == null) R.string.editor_secret_reveal else R.string.editor_secret_hide),
+                                maxLines = 1,
+                            )
+                        }
+                    }
                     if (state !is SecretState.Replace) {
                         OutlinedButton(
                             onClick = { onChange(SecretState.Replace("")) },

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
@@ -73,6 +73,7 @@ class ConnectionEditorViewModel(
     private val initialProtocol: Protocol = Protocol.SSH,
     private val newIdFactory: () -> String,
     private val tester: ConnectionTester = UnavailableConnectionTester,
+    private val testCredentials: suspend (Connection, ConnectionDraft) -> ConnectionTestCredentials = { _, _ -> ConnectionTestCredentials() },
     private val clock: () -> Long = System::currentTimeMillis,
     private val registerSensitiveSink: (LockSensitiveSink) -> Unit = {},
     private val unregisterSensitiveSink: (LockSensitiveSink) -> Unit = {},
@@ -295,16 +296,22 @@ class ConnectionEditorViewModel(
         mutate { it.copy(testing = true, testResult = null) }
         viewModelScope.launch {
             val row = content.value.draft.normalized()
-            val result = runCatching { tester.test(row) }
-                .getOrElse { failure ->
-                    ConnectionTestResult.Failed(
-                        one.zephyr.mobile.model.MobileError.local(
-                            code = "test_failed",
-                            message = failure.message ?: MSG_TEST_FAILED,
-                            retryable = true,
-                        ),
-                    )
-                }
+            val credentials = runCatching { testCredentials(row, content.value.draft) }
+                .getOrDefault(ConnectionTestCredentials())
+            val result = try {
+                runCatching { tester.test(row, credentials) }
+                    .getOrElse { failure ->
+                        ConnectionTestResult.Failed(
+                            one.zephyr.mobile.model.MobileError.local(
+                                code = "test_failed",
+                                message = failure.message ?: MSG_TEST_FAILED,
+                                retryable = true,
+                            ),
+                        )
+                    }
+            } finally {
+                credentials.wipe()
+            }
             mutate { it.copy(testing = false, testResult = result) }
         }
     }
@@ -345,6 +352,7 @@ class ConnectionEditorViewModel(
             initialProtocol: Protocol = Protocol.SSH,
             newIdFactory: () -> String,
             tester: ConnectionTester = UnavailableConnectionTester,
+            testCredentials: suspend (Connection, ConnectionDraft) -> ConnectionTestCredentials = { _, _ -> ConnectionTestCredentials() },
             registerSensitiveSink: (LockSensitiveSink) -> Unit = {},
             unregisterSensitiveSink: (LockSensitiveSink) -> Unit = {},
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
@@ -358,6 +366,7 @@ class ConnectionEditorViewModel(
                 initialProtocol = initialProtocol,
                 newIdFactory = newIdFactory,
                 tester = tester,
+                testCredentials = testCredentials,
                 registerSensitiveSink = registerSensitiveSink,
                 unregisterSensitiveSink = unregisterSensitiveSink,
             ) as T

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
@@ -229,7 +229,7 @@ class ConnectionEditorViewModel(
     }
 
     fun revealPassword() {
-        val content = current() ?: return
+        val content = (page.value as? PageState.Content)?.value ?: return
         val connection = content.draft.original ?: return
         if (!ConnectionPasswordRevealPolicy.allowed(
                 localUnlockEnabled = passwordRevealEnabled(),

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
@@ -27,6 +27,8 @@ import one.zephyr.mobile.security.LockSensitiveSink
 /** Everything the S11 form renders. */
 data class ConnectionEditorUiState(
     val draft: ConnectionDraft,
+    val passwordRevealAllowed: Boolean = false,
+    val revealedPassword: String? = null,
     val inventory: RouteInventory = RouteInventory(),
     val proxies: List<Proxy> = emptyList(),
     val sshKeys: List<SshKey> = emptyList(),
@@ -74,6 +76,8 @@ class ConnectionEditorViewModel(
     private val newIdFactory: () -> String,
     private val tester: ConnectionTester = UnavailableConnectionTester,
     private val testCredentials: suspend (Connection, ConnectionDraft) -> ConnectionTestCredentials = { _, _ -> ConnectionTestCredentials() },
+    private val passwordRevealEnabled: () -> Boolean = { false },
+    private val passwordRevealer: suspend (Connection) -> String? = { null },
     private val clock: () -> Long = System::currentTimeMillis,
     private val registerSensitiveSink: (LockSensitiveSink) -> Unit = {},
     private val unregisterSensitiveSink: (LockSensitiveSink) -> Unit = {},
@@ -87,6 +91,7 @@ class ConnectionEditorViewModel(
 
     private val messages = MutableSharedFlow<String>(extraBufferCapacity = 4)
     val message: SharedFlow<String> = messages
+    private var revealExpiryJob: kotlinx.coroutines.Job? = null
 
     init {
         registerSensitiveSink(this)
@@ -133,7 +138,16 @@ class ConnectionEditorViewModel(
             // A row the user may see but not edit opens read-only rather than pretending to save.
             !existing.capabilities.canEdit ->
                 PageState.PermissionDenied(Capability.EDIT, REASON_NO_EDIT)
-            else -> PageState.Content(ConnectionEditorUiState(ConnectionDraft.edit(existing)))
+            else -> PageState.Content(
+                ConnectionEditorUiState(
+                    draft = ConnectionDraft.edit(existing),
+                    passwordRevealAllowed = ConnectionPasswordRevealPolicy.allowed(
+                        localUnlockEnabled = passwordRevealEnabled(),
+                        hasStoredPassword = existing.password.hasValue,
+                        canRevealSecret = existing.capabilities.canRevealSecret,
+                    ),
+                ),
+            )
         }
     }
 
@@ -209,6 +223,32 @@ class ConnectionEditorViewModel(
      * an operation is queued, which is exactly what happened regardless of connectivity
      * (SCREEN_CATALOG.md 2).
      */
+    fun hidePassword() {
+        revealExpiryJob?.cancel()
+        mutate { it.copy(revealedPassword = null) }
+    }
+
+    fun revealPassword() {
+        val content = current() ?: return
+        val connection = content.draft.original ?: return
+        if (!ConnectionPasswordRevealPolicy.allowed(
+                localUnlockEnabled = passwordRevealEnabled(),
+                hasStoredPassword = connection.password.hasValue,
+                canRevealSecret = connection.capabilities.canRevealSecret,
+            ) || !content.passwordRevealAllowed
+        ) return
+        viewModelScope.launch {
+            val value = passwordRevealer(connection) ?: return@launch
+            if (!passwordRevealEnabled()) return@launch
+            mutate { it.copy(revealedPassword = value) }
+            revealExpiryJob?.cancel()
+            revealExpiryJob = launch {
+                kotlinx.coroutines.delay(PASSWORD_REVEAL_MS)
+                mutate { it.copy(revealedPassword = null) }
+            }
+        }
+    }
+
     fun save(thenConnect: Boolean = false) {
         val content = page.value as? PageState.Content ?: return
         val ui = content.value
@@ -323,7 +363,8 @@ class ConnectionEditorViewModel(
 
     /** Lock/background/navigation disposal all call this same non-persisting cleanup path. */
     fun clearSecretBuffers() {
-        mutate { it.copy(draft = it.draft.wipeSecretBuffers()) }
+        revealExpiryJob?.cancel()
+        mutate { it.copy(draft = it.draft.wipeSecretBuffers(), revealedPassword = null) }
     }
 
     override fun onLocked() {
@@ -342,6 +383,7 @@ class ConnectionEditorViewModel(
         const val MSG_SAVE_FAILED = "保存未完成，请重试"
         const val MSG_NOTHING_CHANGED = "没有需要保存的修改"
         const val MSG_TEST_FAILED = "测试未完成"
+        private const val PASSWORD_REVEAL_MS = 30_000L
 
         fun factory(
             connections: ConnectionRepository,
@@ -353,6 +395,8 @@ class ConnectionEditorViewModel(
             newIdFactory: () -> String,
             tester: ConnectionTester = UnavailableConnectionTester,
             testCredentials: suspend (Connection, ConnectionDraft) -> ConnectionTestCredentials = { _, _ -> ConnectionTestCredentials() },
+            passwordRevealEnabled: () -> Boolean = { false },
+            passwordRevealer: suspend (Connection) -> String? = { null },
             registerSensitiveSink: (LockSensitiveSink) -> Unit = {},
             unregisterSensitiveSink: (LockSensitiveSink) -> Unit = {},
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
@@ -367,6 +411,8 @@ class ConnectionEditorViewModel(
                 newIdFactory = newIdFactory,
                 tester = tester,
                 testCredentials = testCredentials,
+                passwordRevealEnabled = passwordRevealEnabled,
+                passwordRevealer = passwordRevealer,
                 registerSensitiveSink = registerSensitiveSink,
                 unregisterSensitiveSink = unregisterSensitiveSink,
             ) as T

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionPasswordRevealPolicy.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionPasswordRevealPolicy.kt
@@ -1,0 +1,10 @@
+package one.zephyr.mobile.feature.connections
+
+/** Fail-closed gate for showing or performing a stored connection-password reveal. */
+object ConnectionPasswordRevealPolicy {
+    fun allowed(
+        localUnlockEnabled: Boolean,
+        hasStoredPassword: Boolean,
+        canRevealSecret: Boolean,
+    ): Boolean = localUnlockEnabled && hasStoredPassword && canRevealSecret
+}

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionRoutes.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionRoutes.kt
@@ -6,6 +6,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.Flow
 import one.zephyr.mobile.model.ActivityEvent
 import one.zephyr.mobile.model.Connection
@@ -96,6 +99,17 @@ fun ConnectionEditorRoute(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycleOwner, viewModel) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            try {
+                kotlinx.coroutines.awaitCancellation()
+            } finally {
+                viewModel.hidePassword()
+            }
+        }
+    }
 
     // The route leaves composition when the app lock covers it, the process backgrounds or the
     // account graph is revoked. Do not let its ViewModel retain typed password/private-key buffers.
@@ -146,6 +160,8 @@ private fun dispatch(viewModel: ConnectionEditorViewModel, intent: EditorIntent)
         is EditorIntent.JumpRemoved -> viewModel.removeJumpHost(intent.value)
         is EditorIntent.JumpMoved -> viewModel.moveJumpHost(intent.from, intent.to)
         is EditorIntent.Password -> viewModel.setPassword(intent.value)
+        EditorIntent.RevealPassword -> viewModel.revealPassword()
+        EditorIntent.HidePassword -> viewModel.hidePassword()
         is EditorIntent.PrivateKey -> viewModel.setPrivateKey(intent.value)
         // The Windows domain lives inside RdpSettings, so the editor edits it through this intent
         // rather than through a field of its own.

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionTester.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionTester.kt
@@ -27,7 +27,19 @@ sealed interface ConnectionTestResult {
  * module free of protocol dependencies and lets each protocol arrive independently.
  */
 interface ConnectionTester {
-    suspend fun test(connection: Connection): ConnectionTestResult
+    suspend fun test(connection: Connection, credentials: ConnectionTestCredentials = ConnectionTestCredentials()): ConnectionTestResult
+}
+
+class ConnectionTestCredentials(
+    val password: CharArray? = null,
+    val privateKey: CharArray? = null,
+    val passphrase: CharArray? = null,
+) {
+    fun wipe() {
+        password?.fill('\u0000')
+        privateKey?.fill('\u0000')
+        passphrase?.fill('\u0000')
+    }
 }
 
 /**
@@ -37,7 +49,7 @@ interface ConnectionTester {
  * worse than no button: the user would save a connection believing it was verified.
  */
 object UnavailableConnectionTester : ConnectionTester {
-    override suspend fun test(connection: Connection): ConnectionTestResult =
+    override suspend fun test(connection: Connection, credentials: ConnectionTestCredentials): ConnectionTestResult =
         ConnectionTestResult.Failed(
             MobileError.local(
                 code = "engine_unavailable",

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/TcpReachabilityTester.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/TcpReachabilityTester.kt
@@ -24,7 +24,10 @@ class TcpReachabilityTester(
     },
 ) : ConnectionTester {
 
-    override suspend fun test(connection: Connection): ConnectionTestResult = withContext(Dispatchers.IO) {
+    override suspend fun test(
+        connection: Connection,
+        credentials: ConnectionTestCredentials,
+    ): ConnectionTestResult = withContext(Dispatchers.IO) {
         val host = connection.host.trim()
         if (host.isEmpty()) {
             return@withContext ConnectionTestResult.Failed(

--- a/zephyr_one/mobile/android/feature-connections/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-connections/src/main/res/values-en/strings.xml
@@ -69,6 +69,8 @@
     <string name="editor_secret_keep">Keep</string>
     <string name="editor_secret_replace">Replace</string>
     <string name="editor_secret_clear">Clear</string>
+    <string name="editor_secret_reveal">View</string>
+    <string name="editor_secret_hide">Hide</string>
     <string name="editor_secret_new_value">New value</string>
     <string name="editor_mode_direct">Direct</string>
     <string name="editor_mode_proxy">Proxy</string>

--- a/zephyr_one/mobile/android/feature-connections/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-connections/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="editor_secret_keep">保持不变</string>
     <string name="editor_secret_replace">替换</string>
     <string name="editor_secret_clear">清除</string>
+    <string name="editor_secret_reveal">查看</string>
+    <string name="editor_secret_hide">隐藏</string>
     <string name="editor_secret_new_value">新的值</string>
 
     <string name="editor_mode_direct">直连</string>

--- a/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/ConnectionPasswordRevealPolicyTest.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/ConnectionPasswordRevealPolicyTest.kt
@@ -1,0 +1,27 @@
+package one.zephyr.mobile.feature.connections
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConnectionPasswordRevealPolicyTest {
+    @Test
+    fun allowsOnlyEnabledStoredAndCapable() {
+        assertTrue(ConnectionPasswordRevealPolicy.allowed(true, true, true))
+    }
+
+    @Test
+    fun disabledLocalUnlockAlwaysRefuses() {
+        assertFalse(ConnectionPasswordRevealPolicy.allowed(false, true, true))
+    }
+
+    @Test
+    fun missingStoredPasswordRefuses() {
+        assertFalse(ConnectionPasswordRevealPolicy.allowed(true, false, true))
+    }
+
+    @Test
+    fun missingRevealCapabilityRefuses() {
+        assertFalse(ConnectionPasswordRevealPolicy.allowed(true, true, false))
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/view/TerminalRenderer.java
@@ -55,7 +55,8 @@ public final class TerminalRenderer {
 
     /** Render the terminal to a canvas with at a specified row scroll, and an optional rectangular selection. */
     public final void render(TerminalEmulator mEmulator, Canvas canvas, int topRow,
-                             int selectionY1, int selectionY2, int selectionX1, int selectionX2) {
+                             int selectionY1, int selectionY2, int selectionX1, int selectionX2,
+                             Integer selectionBackground, Integer selectionForeground) {
         final boolean reverseVideo = mEmulator.isReverseVideo();
         final int endRow = topRow + mEmulator.mRows;
         final int columns = mEmulator.mColumns;
@@ -124,7 +125,10 @@ public final class TerminalRenderer {
                         }
                         drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun,
                             lastRunStartIndex, charsSinceLastRun, measuredWidthForRun,
-                            cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
+                            cursorColor, cursorShape, lastRunStyle,
+                            reverseVideo || invertCursorTextColor || (lastRunInsideSelection && selectionBackground == null),
+                            lastRunInsideSelection ? selectionBackground : null,
+                            lastRunInsideSelection ? selectionForeground : null);
                     }
                     measuredWidthForRun = 0.f;
                     lastRunStyle = style;
@@ -152,13 +156,17 @@ public final class TerminalRenderer {
                 invertCursorTextColor = true;
             }
             drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun, lastRunStartIndex, charsSinceLastRun,
-                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
+                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle,
+                reverseVideo || invertCursorTextColor || (lastRunInsideSelection && selectionBackground == null),
+                lastRunInsideSelection ? selectionBackground : null,
+                lastRunInsideSelection ? selectionForeground : null);
         }
     }
 
     private void drawTextRun(Canvas canvas, char[] text, int[] palette, float y, int startColumn, int runWidthColumns,
                              int startCharIndex, int runWidthChars, float mes, int cursor, int cursorStyle,
-                             long textStyle, boolean reverseVideo) {
+                             long textStyle, boolean reverseVideo,
+                             Integer selectionBackground, Integer selectionForeground) {
         int foreColor = TextStyle.decodeForeColor(textStyle);
         final int effect = TextStyle.decodeEffect(textStyle);
         int backColor = TextStyle.decodeBackColor(textStyle);
@@ -185,6 +193,9 @@ public final class TerminalRenderer {
             foreColor = backColor;
             backColor = tmp;
         }
+
+        if (selectionBackground != null) backColor = selectionBackground;
+        if (selectionForeground != null) foreColor = selectionForeground;
 
         float left = startColumn * mFontWidth;
         float right = left + runWidthColumns * mFontWidth;

--- a/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/view/TerminalView.java
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/view/TerminalView.java
@@ -68,7 +68,15 @@ public final class TerminalView extends View {
 
     /** The top row of text to display. Ranges from -activeTranscriptRows to 0. */
     int mTopRow;
-    int[] mDefaultSelectors = new int[]{-1,-1,-1,-1};
+    private int[] mDefaultSelectors = new int[]{-1,-1,-1,-1};
+    private Integer mSelectionBackgroundColor;
+    private Integer mSelectionForegroundColor;
+
+    public void setSelectionColors(@Nullable Integer backgroundColor, @Nullable Integer foregroundColor) {
+        mSelectionBackgroundColor = backgroundColor;
+        mSelectionForegroundColor = foregroundColor;
+        invalidate();
+    }
 
     float mScaleFactor = 1.f;
     final GestureAndScaleRecognizer mGestureRecognizer;
@@ -1021,7 +1029,14 @@ public final class TerminalView extends View {
                 mTextSelectionCursorController.getSelectors(sel);
             }
 
-            mRenderer.render(mEmulator, canvas, mTopRow, sel[0], sel[1], sel[2], sel[3]);
+            mRenderer.render(
+                mEmulator,
+                canvas,
+                mTopRow,
+                sel[0], sel[1], sel[2], sel[3],
+                mSelectionBackgroundColor,
+                mSelectionForegroundColor
+            );
 
             // render the text selection handles
             renderTextSelection();

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionRoutes.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionRoutes.kt
@@ -94,6 +94,7 @@ fun TerminalRoute(
     onSelectSession: (String) -> Unit = {},
     onCloseSession: (String) -> Unit = {},
     onAddSession: (Connection) -> Unit = {},
+    onCreateConnection: () -> Unit = {},
     onOpenNote: (String) -> Unit = {},
     onOpenDocker: () -> Unit = {},
 ) {
@@ -158,7 +159,7 @@ fun TerminalRoute(
                 viewModel = viewModel,
                 intent = intent,
                 twoFingerScrollGoesRemote = twoFingerScrollGoesRemote,
-                onKeyboardVisible = { visible -> keyboardVisible = visible },
+                onToggleKeyboard = { keyboardVisible = !keyboardVisible },
             )
         },
         modifier = modifier,
@@ -173,6 +174,7 @@ fun TerminalRoute(
         onSelectSession = onSelectSession,
         onCloseSession = onCloseSession,
         onAddSession = onAddSession,
+        onCreateConnection = onCreateConnection,
         onOpenNote = onOpenNote,
         onOpenDocker = onOpenDocker,
         onMessage = { msg -> coroutineScope.launch { onMessage(msg) } },
@@ -217,7 +219,7 @@ private fun openDockTool(
     if (item == null) return
     val kind = TerminalToolKind.fromDock(item)
     if (kind != null && workspace != null) {
-        onWorkspace(TerminalWorkspace.openTool(workspace, kind))
+        onWorkspace(TerminalWorkspace.openTool(workspace, kind, phone = true))
         return
     }
     onDock(item)
@@ -234,7 +236,7 @@ private fun dispatch(
     viewModel: TerminalViewModel,
     intent: TerminalIntent,
     twoFingerScrollGoesRemote: Boolean,
-    onKeyboardVisible: (Boolean) -> Unit,
+    onToggleKeyboard: () -> Unit,
 ) {
     val controller = viewModel.controller
     when (intent) {
@@ -291,7 +293,7 @@ private fun dispatch(
         is TerminalIntent.Dock -> {
             // The keyboard is the screen's own state: routing it through the ViewModel would make the
             // IME flag survive the screen it belongs to.
-            if (intent.item == TerminalDockItem.KEYBOARD) onKeyboardVisible(true) else viewModel.onDock(intent.item)
+            if (intent.item == TerminalDockItem.KEYBOARD) onToggleKeyboard() else viewModel.onDock(intent.item)
         }
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -69,16 +69,26 @@ class SshTerminalHost(
     override fun output(sessionId: String): Flow<ByteArray> =
         if (engine.isAvailable) engine.output(sessionId) else emptyFlow()
 
+    override fun closure(sessionId: String): Flow<Throwable> =
+        if (engine.isAvailable) engine.closure(sessionId) else emptyFlow()
+
     override fun transportFor(sessionId: String): TerminalTransport = object : TerminalTransport {
         override suspend fun write(bytes: ByteArray) = engine.send(sessionId, bytes)
         override suspend fun resize(columns: Int, rows: Int, widthPx: Int, heightPx: Int) =
             engine.resize(sessionId, columns, rows, widthPx, heightPx)
+        override fun onFailure(error: Throwable) = engine.reportFailure(sessionId, error)
     }
 
     override suspend fun close(sessionId: String) {
         lastRequest.remove(sessionId)
         engine.disconnect(sessionId)
     }
+
+    override suspend fun measureLatency(sessionId: String): Long? = engine.measureLatency(sessionId)
+
+    override suspend fun listDirectory(sessionId: String, path: String) = engine.listDirectory(sessionId, path)
+
+    override suspend fun exec(sessionId: String, command: String) = engine.exec(sessionId, command)
 
     override suspend fun trustHostKey(sessionId: String) {
         val remembered = lastRequest[sessionId] ?: return

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt
@@ -70,6 +70,8 @@ data class TerminalChromeColors(
     val pending: Color,
     val err: Color,
     val offline: Color,
+    val selectionBackground: Color? = null,
+    val selectionForeground: Color? = null,
 )
 
 fun terminalChromeColors(palette: ZephyrPalette): TerminalChromeColors {
@@ -364,21 +366,11 @@ internal fun DemoKeyRow(
 internal fun DemoContextDock(
     items: List<TerminalDockItem>,
     colors: TerminalChromeColors,
-    imeOpen: Boolean,
     onIntent: (TerminalIntent) -> Unit,
 ) {
-    val hidden by animateFloatAsState(
-        targetValue = if (imeOpen) 1f else 0f,
-        animationSpec = tween(180, easing = ZephyrMotionTokens.easeOut),
-        label = "dockHide",
-    )
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .graphicsLayer {
-                translationY = 90f * hidden
-                alpha = 1f - hidden
-            }
             .background(colors.chrome)
             .padding(start = 8.dp, end = 8.dp, top = TerminalWorkspace.DOCK_PAD_TOP_DP.dp)
             .navigationBarsPadding()

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalHost.kt
@@ -181,6 +181,18 @@ interface TerminalHost {
 
     suspend fun close(sessionId: String)
 
+    /** Completes when the remote stream ends, carrying an error for failed writes/reads. */
+    fun closure(sessionId: String): Flow<Throwable> = emptyFlow()
+
+    /** Real round-trip probe on the established transport. */
+    suspend fun measureLatency(sessionId: String): Long? = null
+
+    suspend fun listDirectory(sessionId: String, path: String): Result<List<one.zephyr.mobile.protocol.ssh.SftpEntry>> =
+        Result.failure(IllegalStateException("SFTP unavailable"))
+
+    suspend fun exec(sessionId: String, command: String): Result<one.zephyr.mobile.protocol.ssh.SshExecResult> =
+        Result.failure(IllegalStateException("SSH exec unavailable"))
+
     /** Accepts and remembers a presented host key after the user confirmed it. */
     suspend fun trustHostKey(sessionId: String) = Unit
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -61,27 +62,68 @@ internal fun TerminalToolBody(
     onOpenNote: (String) -> Unit,
     onOpenDocker: () -> Unit,
     onMessage: (String) -> Unit,
+    viewModel: TerminalViewModel? = null,
 ) {
     when (kind) {
-        TerminalToolKind.FILES -> FilesToolBody(colors, onMessage)
+        TerminalToolKind.FILES -> FilesToolBody(colors, viewModel, onMessage)
         TerminalToolKind.SNIPPET -> SnippetToolBody(colors, snippets, onInsert)
         TerminalToolKind.NOTES -> NotesToolBody(colors, notes, onOpenNote)
-        TerminalToolKind.STATS -> StatsToolBody(colors, onOpenDocker, onMessage)
+        TerminalToolKind.STATS -> StatsToolBody(colors, viewModel, onOpenDocker)
         TerminalToolKind.THEME -> ThemeToolBody(colors, workspace, onWorkspace, onMessage)
     }
 }
 
 @Composable
-private fun FilesToolBody(colors: TerminalChromeColors, onMessage: (String) -> Unit) {
-    val blockedMsg = stringResource(R.string.terminal_sftp_blocked)
+private fun FilesToolBody(
+    colors: TerminalChromeColors,
+    viewModel: TerminalViewModel?,
+    onMessage: (String) -> Unit,
+) {
+    var path by remember { mutableStateOf(".") }
+    var loading by remember { mutableStateOf(false) }
+    var entries by remember { mutableStateOf<List<one.zephyr.mobile.protocol.ssh.SftpEntry>>(emptyList()) }
+    var error by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(viewModel, path) {
+        if (viewModel == null) {
+            error = "当前没有已连接的 SSH 会话"
+            return@LaunchedEffect
+        }
+        loading = true
+        viewModel.listRemoteDirectory(path).fold(
+            onSuccess = { entries = it; error = null },
+            onFailure = { error = it.message ?: "SFTP 目录加载失败" },
+        )
+        loading = false
+    }
     Column {
-        ToolRow(colors, "nginx.conf", "12K") { onMessage(blockedMsg) }
-        ToolRow(colors, "access.log", "210M") { onMessage(blockedMsg) }
-        ToolRow(colors, "releases/", "dir") { onMessage(blockedMsg) }
-        ToolRow(colors, "上传到此目录…", null, icon = ZephyrIcons.Download) {
-            onMessage(blockedMsg)
+        when {
+            loading -> EmptyToolBody(colors, "正在读取 SFTP · $path")
+            error != null -> EmptyToolBody(colors, error ?: "SFTP 失败")
+            entries.isEmpty() -> EmptyToolBody(colors, "$path · 空目录")
+            else -> entries.forEach { entry ->
+                ToolRow(colors, entry.name, if (entry.isDirectory) "dir" else formatBytes(entry.size)) {
+                    if (entry.isDirectory) path = entry.path else onMessage("${entry.path} · ${formatBytes(entry.size)}")
+                }
+            }
         }
     }
+}
+
+@Composable
+private fun EmptyToolBody(colors: TerminalChromeColors, message: String) {
+    Text(
+        text = message,
+        color = colors.dim,
+        fontSize = 12.sp,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 28.dp),
+    )
+}
+
+private fun formatBytes(bytes: Long): String = when {
+    bytes >= 1024L * 1024L * 1024L -> "${bytes / (1024L * 1024L * 1024L)}G"
+    bytes >= 1024L * 1024L -> "${bytes / (1024L * 1024L)}M"
+    bytes >= 1024L -> "${bytes / 1024L}K"
+    else -> "${bytes}B"
 }
 
 @Composable
@@ -90,13 +132,11 @@ private fun SnippetToolBody(
     snippets: List<Snippet>,
     onInsert: (String) -> Unit,
 ) {
-    val rows = snippets.take(8).ifEmpty {
-        listOf(
-            Snippet(id = "demo-1", ownerUserId = "", name = "du", command = "du -x --max-depth=1 / | sort -rn"),
-            Snippet(id = "demo-2", ownerUserId = "", name = "nginx", command = "systemctl reload nginx"),
-            Snippet(id = "demo-3", ownerUserId = "", name = "journal", command = "journalctl -u zephyr -n 200"),
-        )
+    if (snippets.isEmpty()) {
+        EmptyToolBody(colors, "还没有代码片段")
+        return
     }
+    val rows = snippets.take(8)
     Column {
         rows.forEach { snippet ->
             Row(
@@ -140,15 +180,36 @@ private fun NotesToolBody(
 @Composable
 private fun StatsToolBody(
     colors: TerminalChromeColors,
+    viewModel: TerminalViewModel?,
     onOpenDocker: () -> Unit,
-    onMessage: (String) -> Unit,
 ) {
     val dockerLabel = stringResource(R.string.terminal_open_docker)
-    val statsBlockedMsg = stringResource(R.string.terminal_stats_blocked)
+    var loading by remember { mutableStateOf(true) }
+    var metrics by remember { mutableStateOf<RemoteMetrics?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(viewModel) {
+        if (viewModel == null) {
+            loading = false
+            error = "当前没有已连接的 SSH 会话"
+            return@LaunchedEffect
+        }
+        viewModel.remoteMetrics().fold(
+            onSuccess = { metrics = it; error = null },
+            onFailure = { error = it.message ?: "读取远端监控失败" },
+        )
+        loading = false
+    }
     Column {
-        Meter(colors, "CPU", "—", 0f)
-        Meter(colors, "内存", "—", 0f)
-        Meter(colors, "磁盘 /", "—", 0f, warn = true)
+        when {
+            loading -> EmptyToolBody(colors, "正在读取远端监控…")
+            error != null -> EmptyToolBody(colors, error ?: "监控失败")
+            metrics != null -> {
+                val value = metrics ?: return@Column
+                Meter(colors, "CPU", "${value.cpuPercent}%", value.cpuPercent / 100f)
+                Meter(colors, "内存", "${value.memoryPercent}%", value.memoryPercent / 100f)
+                Meter(colors, "磁盘 /", "${value.diskPercent}%", value.diskPercent / 100f, warn = value.diskPercent >= 80)
+            }
+        }
         Text(
             text = "DOCKER · $dockerLabel",
             color = colors.accent,
@@ -163,18 +224,6 @@ private fun StatsToolBody(
             Text(dockerLabel, color = colors.accent, fontSize = 12.sp)
         }
         Spacer(Modifier.height(6.dp))
-        TermPressable(
-            onClick = { onMessage(statsBlockedMsg) },
-            modifier = Modifier.fillMaxWidth(),
-            scale = 0.99f,
-        ) {
-            Text(
-                text = statsBlockedMsg,
-                color = colors.dim,
-                fontSize = 11.sp,
-                modifier = Modifier.padding(8.dp),
-            )
-        }
     }
 }
 
@@ -185,8 +234,6 @@ private fun ThemeToolBody(
     onWorkspace: (TerminalWorkspaceState) -> Unit,
     onMessage: (String) -> Unit,
 ) {
-    var customBg by remember { mutableStateOf(false) }
-    var customSel by remember { mutableStateOf(false) }
     Column {
         Text(
             text = stringResource(R.string.terminal_theme_source),
@@ -225,12 +272,13 @@ private fun ThemeToolBody(
             letterSpacing = 0.8.sp,
             modifier = Modifier.padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 4.dp),
         )
-        BgRow(colors, stringResource(R.string.terminal_custom_bg_color), customBg, toggle = true) {
-            customBg = !customBg
-            onMessage(if (customBg) "已启用自定义背景色" else "已关闭")
+        BgRow(colors, stringResource(R.string.terminal_custom_bg_color), workspace.customBackgroundColor, toggle = true) {
+            val enabled = !workspace.customBackgroundColor
+            onWorkspace(workspace.copy(customBackgroundColor = enabled))
+            onMessage(if (enabled) "已启用自定义背景色" else "已关闭")
         }
-        BgRow(colors, stringResource(R.string.terminal_custom_sel_color), customSel, toggle = true) {
-            customSel = !customSel
+        BgRow(colors, stringResource(R.string.terminal_custom_sel_color), workspace.customSelectionColor, toggle = true) {
+            onWorkspace(workspace.copy(customSelectionColor = !workspace.customSelectionColor))
         }
     }
 }
@@ -441,160 +489,3 @@ internal fun SideToolDock(
         }
     }
 }
-
-@Composable
-internal fun FloatingToolLayer(
-    workspace: TerminalWorkspaceState,
-    colors: TerminalChromeColors,
-    hostName: String,
-    notes: List<Note>,
-    snippets: List<Snippet>,
-    onWorkspace: (TerminalWorkspaceState) -> Unit,
-    onInsert: (String) -> Unit,
-    onOpenNote: (String) -> Unit,
-    onOpenDocker: () -> Unit,
-    onMessage: (String) -> Unit,
-) {
-    var parent by remember { mutableStateOf(IntSize.Zero) }
-    val density = LocalDensity.current
-    Box(Modifier.fillMaxSize().onSizeChanged { parent = it }) {
-        workspace.floating.sortedBy { it.z }.forEachIndexed { index, panel ->
-            val (staggerX, staggerY) = TerminalWorkspace.floatingOffset(index)
-            val defaultW = with(density) {
-                (parent.width * TerminalWorkspace.FLOAT_DEFAULT_WIDTH_FRACTION)
-                    .coerceAtMost(TerminalWorkspace.FLOAT_DEFAULT_MAX_WIDTH_DP.dp.toPx())
-                    .coerceAtLeast(TerminalWorkspace.FLOAT_MIN_WIDTH_DP.dp.toPx())
-            }
-            val defaultH = (parent.height * TerminalWorkspace.FLOAT_DEFAULT_HEIGHT_FRACTION)
-                .coerceAtLeast(with(density) { TerminalWorkspace.FLOAT_MIN_HEIGHT_DP.dp.toPx() })
-            var x by remember(panel.kind, parent) {
-                mutableFloatStateOf(
-                    if (!panel.offsetXPx.isNaN()) panel.offsetXPx
-                    else parent.width * (staggerX / 100f),
-                )
-            }
-            var y by remember(panel.kind, parent) {
-                mutableFloatStateOf(
-                    if (!panel.offsetYPx.isNaN()) panel.offsetYPx
-                    else parent.height * (staggerY / 100f),
-                )
-            }
-            var w by remember(panel.kind, parent) {
-                mutableFloatStateOf(if (!panel.widthPx.isNaN()) panel.widthPx else defaultW)
-            }
-            var h by remember(panel.kind, parent) {
-                mutableFloatStateOf(if (!panel.heightPx.isNaN()) panel.heightPx else defaultH)
-            }
-            val laid = when (panel.layout) {
-                TermPanelLayout.FREE -> null
-                TermPanelLayout.LEFT_HALF -> Quad(0f, 0f, parent.width * 0.5f, parent.height.toFloat())
-                TermPanelLayout.RIGHT_HALF -> Quad(parent.width * 0.5f, 0f, parent.width * 0.5f, parent.height.toFloat())
-                TermPanelLayout.BOTTOM -> Quad(0f, parent.height * 0.55f, parent.width.toFloat(), parent.height * 0.45f)
-            }
-            val left = laid?.x ?: x
-            val top = laid?.y ?: y
-            val width = laid?.w ?: w
-            val height = laid?.h ?: h
-            Column(
-                modifier = Modifier
-                    .zIndex(panel.z.toFloat())
-                    .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
-                    .width(with(density) { width.toDp() })
-                    .height(with(density) { height.toDp() })
-                    .shadow(18.dp, RoundedCornerShape(16.dp))
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(ZephyrPaletteMix(colors.accent, Color(0xEB12161C), 0.07f))
-                    .border(1.dp, colors.accent.copy(alpha = 0.22f), RoundedCornerShape(16.dp))
-                    .pointerInput(panel.kind) {
-                        detectDragGestures(
-                            onDragStart = { onWorkspace(TerminalWorkspace.raiseFloating(workspace, panel.kind)) },
-                            onDrag = { _, _ -> },
-                        )
-                    },
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .pointerInput(panel.kind, panel.layout) {
-                            if (panel.layout != TermPanelLayout.FREE) return@pointerInput
-                            detectDragGestures { _, drag ->
-                                x = (x + drag.x).coerceIn(-40f, (parent.width - 80).toFloat())
-                                y = (y + drag.y).coerceIn(0f, (parent.height - 90).toFloat())
-                            }
-                        }
-                        .padding(start = 12.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(toolIcon(panel.kind), null, tint = colors.accent, modifier = Modifier.size(14.dp))
-                    Spacer(Modifier.width(7.dp))
-                    Text(
-                        text = toolTitle(panel.kind, hostName),
-                        color = Color(0xFFDBE2EA),
-                        fontSize = 12.5.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.weight(1f),
-                        maxLines = 1,
-                    )
-                    TermPressable(
-                        onClick = { onWorkspace(TerminalWorkspace.cycleLayout(workspace, panel.kind)) },
-                        modifier = Modifier
-                            .size(26.dp)
-                            .clip(CircleShape)
-                            .background(if (panel.layout != TermPanelLayout.FREE) colors.accent.copy(alpha = 0.18f) else Color.Transparent),
-                        scale = 0.88f,
-                    ) {
-                        Icon(ZephyrIcons.GridTools, stringResource(R.string.terminal_layout), tint = if (panel.layout != TermPanelLayout.FREE) colors.accent else Color(0xFF8B949E), modifier = Modifier.size(13.dp))
-                    }
-                    TermPressable(
-                        onClick = { onWorkspace(TerminalWorkspace.closeFloating(workspace, panel.kind)) },
-                        modifier = Modifier.size(26.dp).clip(CircleShape),
-                        scale = 0.88f,
-                    ) {
-                        Text("×", color = Color(0xFF8B949E), fontSize = 15.sp)
-                    }
-                }
-                Box(Modifier.fillMaxWidth().height(1.dp).background(Color.White.copy(alpha = 0.07f)))
-                Box(Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(6.dp)) {
-                    TerminalToolBody(
-                        kind = panel.kind,
-                        colors = colors,
-                        notes = notes,
-                        snippets = snippets,
-                        workspace = workspace,
-                        onWorkspace = onWorkspace,
-                        onInsert = onInsert,
-                        onOpenNote = onOpenNote,
-                        onOpenDocker = onOpenDocker,
-                        onMessage = onMessage,
-                    )
-                }
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .size(28.dp)
-                        .pointerInput(panel.kind) {
-                            detectDragGestures { _, drag ->
-                                val minW = with(density) { TerminalWorkspace.FLOAT_MIN_WIDTH_DP.dp.toPx() }
-                                val minH = with(density) { TerminalWorkspace.FLOAT_MIN_HEIGHT_DP.dp.toPx() }
-                                w = (w + drag.x).coerceIn(minW, (parent.width - left).toFloat())
-                                h = (h + drag.y).coerceIn(minH, (parent.height - top).toFloat())
-                            }
-                        },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(ZephyrIcons.Fit, null, tint = Color(0xFF5D6773), modifier = Modifier.size(12.dp))
-                }
-            }
-        }
-    }
-}
-
-private data class Quad(val x: Float, val y: Float, val w: Float, val h: Float)
-
-private fun ZephyrPaletteMix(accent: Color, base: Color, fraction: Float): Color =
-    Color(
-        red = base.red + (accent.red - base.red) * fraction,
-        green = base.green + (accent.green - base.green) * fraction,
-        blue = base.blue + (accent.blue - base.blue) * fraction,
-        alpha = base.alpha,
-    )

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.WindowInsets
@@ -21,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -75,6 +77,7 @@ fun TerminalScreen(
     onSelectSession: (String) -> Unit = {},
     onCloseSession: (String) -> Unit = {},
     onAddSession: (Connection) -> Unit = {},
+    onCreateConnection: () -> Unit = {},
     onOpenNote: (String) -> Unit = {},
     onOpenDocker: () -> Unit = {},
     onMessage: (String) -> Unit = {},
@@ -104,6 +107,7 @@ fun TerminalScreen(
             onSelectSession = onSelectSession,
             onCloseSession = onCloseSession,
             onAddSession = onAddSession,
+            onCreateConnection = onCreateConnection,
             onOpenNote = onOpenNote,
             onOpenDocker = onOpenDocker,
             onMessage = onMessage,
@@ -132,6 +136,7 @@ private fun DemoTerminalSurface(
     onSelectSession: (String) -> Unit,
     onCloseSession: (String) -> Unit,
     onAddSession: (Connection) -> Unit,
+    onCreateConnection: () -> Unit,
     onOpenNote: (String) -> Unit,
     onOpenDocker: () -> Unit,
     onMessage: (String) -> Unit,
@@ -139,10 +144,22 @@ private fun DemoTerminalSurface(
     onPaste: () -> Unit,
 ) {
     val palette = ZephyrTheme.palette
-    val colors = remember(palette) { terminalChromeColors(palette) }
+    val baseColors = remember(palette) { terminalChromeColors(palette) }
+    val colors = remember(baseColors, workspace?.customBackgroundColor, workspace?.customSelectionColor) {
+        baseColors.copy(
+            termBg = if (workspace?.customBackgroundColor == true) {
+                if (palette.dark) Color(0xFF101820) else Color(0xFFE7EDF4)
+            } else baseColors.termBg,
+            selectionBackground = if (workspace?.customSelectionColor == true) baseColors.accent.copy(alpha = 0.72f) else null,
+            selectionForeground = if (workspace?.customSelectionColor == true) Color.White else null,
+        )
+    }
     val density = LocalDensity.current
     val imeHeightPx = WindowInsets.ime.getBottom(density).toFloat()
-    val imeOpen = keyboardVisible || imeHeightPx > 8f
+    // keyboardVisible is a request; only the real inset proves that the system IME is onscreen.
+    // Treating a pending request as open made the context dock alpha=0 while it still occupied
+    // height, producing the blank band reported on device.
+    val imeOpen = imeHeightPx > 8f
     val surface = content.surface
     val ws = workspace ?: TerminalWorkspaceState(paneA = content.connection.id)
     val liveSessions = sessions.filter { it.protocol.isTerminal && it.transport != SessionTransport.CLOSED }
@@ -159,12 +176,6 @@ private fun DemoTerminalSurface(
         port = focusedRow?.port ?: content.connection.port,
         username = content.connection.username,
     ), cols, rows, imeOpen)
-    val keyrowHeight = with(density) {
-        (TerminalWorkspace.KEY_HEIGHT_DP + TerminalWorkspace.KEY_PADDING_V_DP * 2).dp.toPx()
-    }
-    val dockHeight = with(density) {
-        (56 + TerminalWorkspace.DOCK_PAD_TOP_DP + TerminalWorkspace.DOCK_PAD_BOTTOM_DP).dp.toPx()
-    }
     var containerW by remember { mutableStateOf(0) }
     var containerH by remember { mutableStateOf(0) }
 
@@ -175,7 +186,7 @@ private fun DemoTerminalSurface(
     val needSecondMsg = stringResource(R.string.terminal_need_second_session)
     val insertToastMsg = stringResource(R.string.terminal_insert_toast)
 
-    LaunchedEffect(containerW, containerH, imeHeightPx, keyrowHeight, dockHeight, focusedSurface.fontSp) {
+    LaunchedEffect(containerW, containerH, focusedSurface.fontSp) {
         if (containerW <= 0 || containerH <= 0) return@LaunchedEffect
         val cellW = (focusedSurface.fontSp * 0.6f) * density.density
         val lineH = (focusedSurface.fontSp * 1.55f) * density.density
@@ -183,9 +194,10 @@ private fun DemoTerminalSurface(
             TerminalIntent.Geometry(
                 totalWidthPx = containerW.toFloat(),
                 totalHeightPx = containerH.toFloat(),
-                imeHeightPx = imeHeightPx,
-                shortcutMatrixHeightPx = keyrowHeight,
-                dockHeightPx = if (imeOpen) 0f else dockHeight,
+                // containerH is the measured terminal canvas only. Chrome and IME are outside it.
+                imeHeightPx = 0f,
+                shortcutMatrixHeightPx = 0f,
+                dockHeightPx = 0f,
                 cellWidthPx = cellW,
                 lineHeightPx = lineH,
             ),
@@ -208,10 +220,10 @@ private fun DemoTerminalSurface(
                 Modifier
                     .weight(1f)
                     .fillMaxHeight()
-                    .onSizeChanged {
-                        containerW = it.width
-                        containerH = it.height
-                    },
+                    // The activity uses adjustNothing so the terminal owns IME avoidance. Lift the
+                    // complete terminal stack above the system keyboard: viewport -> shortcut row.
+                    // The context dock is removed while IME is open, matching demo `.ime-on`.
+                    .imePadding(),
             ) {
                 if (content.cleartextWarning != null) {
                     CleartextProtocolWarning(protocol = content.connection.protocol)
@@ -262,9 +274,17 @@ private fun DemoTerminalSurface(
                     colors = colors,
                     onSelect = onSelectSession,
                     onClose = onCloseSession,
-                    onAdd = { onWorkspace(ws.copy(addSheetOpen = true)) },
+                    onAdd = onCreateConnection,
                 )
-                Box(Modifier.weight(1f).fillMaxWidth()) {
+                Box(
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .onSizeChanged {
+                            containerW = it.width
+                            containerH = it.height
+                        },
+                ) {
                     TerminalSplitArea(
                         content = content,
                         workspace = ws,
@@ -282,45 +302,48 @@ private fun DemoTerminalSurface(
                         onMessage = onMessage,
                         onFocusPane = { pane -> onWorkspace(ws.withFocus(pane)) },
                     )
-                    if (!ws.split.docksTools) {
-                        FloatingToolLayer(
-                            workspace = ws,
-                            colors = colors,
-                            hostName = name,
-                            notes = notes,
-                            snippets = snippets,
-                            onWorkspace = onWorkspace,
-                            onInsert = { text -> onIntent(TerminalIntent.Commit(text)); onMessage(insertToastMsg) },
-                            onOpenNote = onOpenNote,
-                            onOpenDocker = onOpenDocker,
-                            onMessage = onMessage,
-                        )
-                    }
                 }
-                if (focusedSurface.chrome.shortcutMatrix) {
-                    DemoKeyRow(latches = focusedSurface.latches, colors = colors, onIntent = onIntent)
-                }
-                if (focusedSurface.chrome.dock || !imeOpen) {
+                // Row 1 is permanent and hugs the system IME. Row 2 is the context dock and is
+                // removed while IME is open, matching the demo/Termux stack exactly.
+                DemoKeyRow(latches = focusedSurface.latches, colors = colors, onIntent = onIntent)
+                if (!imeOpen) {
                     DemoContextDock(
                         items = content.dock,
                         colors = colors,
-                        imeOpen = imeOpen,
                         onIntent = { intent ->
                             when (intent) {
                                 is TerminalIntent.Dock -> when (intent.item) {
                                     TerminalDockItem.COPY -> onCopy()
                                     TerminalDockItem.PASTE -> onPaste()
-                                    TerminalDockItem.KEYBOARD -> onIntent(intent)
+                                    TerminalDockItem.KEYBOARD -> {
+                                        onWorkspace(TerminalWorkspace.closeSheet(ws))
+                                        onIntent(intent)
+                                    }
                                     TerminalDockItem.DISCONNECT -> onWorkspace(ws.copy(disconnectSheetOpen = true))
                                     else -> {
                                         TerminalToolKind.fromDock(intent.item)?.let { kind ->
-                                            onWorkspace(TerminalWorkspace.openTool(ws, kind))
+                                            onWorkspace(TerminalWorkspace.openTool(ws, kind, phone = !pad))
                                         } ?: onIntent(intent)
                                     }
                                 }
                                 else -> onIntent(intent)
                             }
                         },
+                    )
+                }
+                if (!imeOpen && !pad && ws.sheetFraction > 0f && ws.sheetCurrent != null) {
+                    TerminalToolSheet(
+                        workspace = ws,
+                        colors = colors,
+                        hostName = name,
+                        viewModel = focusedVm,
+                        notes = notes,
+                        snippets = snippets,
+                        onWorkspace = onWorkspace,
+                        onInsert = { text -> onIntent(TerminalIntent.Commit(text)); onMessage(insertToastMsg) },
+                        onOpenNote = onOpenNote,
+                        onOpenDocker = onOpenDocker,
+                        onMessage = onMessage,
                     )
                 }
             }
@@ -405,11 +428,11 @@ private fun DemoTermBackground(workspace: TerminalWorkspaceState, colors: Termin
     Box(
         Modifier
             .fillMaxSize()
-            .background(brush.copy(alpha = workspace.backgroundOpacity)),
+            .blur(workspace.backgroundBlurPx.dp)
+            .graphicsLayer { alpha = workspace.backgroundOpacity }
+            .background(brush),
     )
 }
-
-private fun Brush.copy(alpha: Float): Brush = this
 
 @Composable
 private fun TerminalSplitArea(

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceController.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceController.kt
@@ -21,6 +21,9 @@ import kotlinx.coroutines.launch
 interface TerminalTransport {
     suspend fun write(bytes: ByteArray)
 
+    /** Called when an asynchronous wire write/resize fails; never throw onto the UI dispatcher. */
+    fun onFailure(error: Throwable) = Unit
+
     /**
      * @param widthPx pixel dimensions travel with the resize because SSH window-change carries them
      *   and some full-screen programs use them for sixel/image sizing. Telnet NAWS ignores them.
@@ -570,7 +573,10 @@ class TerminalSurfaceController(
 
     private fun write(bytes: ByteArray) {
         if (bytes.isEmpty()) return
-        scope.launch { transport.write(bytes) }
+        scope.launch {
+            runCatching { transport.write(bytes) }
+                .onFailure(transport::onFailure)
+        }
     }
 
     private fun publishViewport() {

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
@@ -1,0 +1,199 @@
+package one.zephyr.mobile.feature.sessions
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.max
+import one.zephyr.mobile.model.Note
+import one.zephyr.mobile.model.Snippet
+import one.zephyr.mobile.ui.component.Icon
+import one.zephyr.mobile.ui.component.Text
+import one.zephyr.mobile.ui.theme.ZephyrMotionTokens
+
+/** Latest demo phone terminal tool drawer: in-flow, draggable, snap-based, never floating. */
+@Composable
+internal fun TerminalToolSheet(
+    workspace: TerminalWorkspaceState,
+    colors: TerminalChromeColors,
+    hostName: String,
+    viewModel: TerminalViewModel?,
+    notes: List<Note>,
+    snippets: List<Snippet>,
+    onWorkspace: (TerminalWorkspaceState) -> Unit,
+    onInsert: (String) -> Unit,
+    onOpenNote: (String) -> Unit,
+    onOpenDocker: () -> Unit,
+    onMessage: (String) -> Unit,
+) {
+    val current = workspace.sheetCurrent ?: return
+    val density = LocalDensity.current
+    var dragging by remember { mutableStateOf(false) }
+    var liveFraction by remember { mutableFloatStateOf(workspace.sheetFraction) }
+    var velocityPxPerMs by remember { mutableFloatStateOf(0f) }
+    var lastMoveAtNanos by remember { mutableStateOf(0L) }
+
+    LaunchedEffect(workspace.sheetFraction, dragging) {
+        if (!dragging) liveFraction = workspace.sheetFraction
+    }
+    val animatedFraction by animateFloatAsState(
+        targetValue = if (dragging) liveFraction else workspace.sheetFraction,
+        animationSpec = tween(260, easing = ZephyrMotionTokens.easeDrawer),
+        label = "terminalToolSheetHeight",
+    )
+
+    BoxWithConstraints(Modifier.fillMaxWidth()) {
+        val hostHeightPx = with(density) { maxHeight.toPx() }.coerceAtLeast(1f)
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .height(maxHeight * animatedFraction)
+                .background(colors.chrome)
+                .border(width = 1.dp, color = colors.line),
+        ) {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .pointerInput(hostHeightPx, workspace.sheetFraction) {
+                        detectDragGestures(
+                            onDragStart = {
+                                dragging = true
+                                liveFraction = workspace.sheetFraction
+                                velocityPxPerMs = 0f
+                                lastMoveAtNanos = System.nanoTime()
+                            },
+                            onDrag = { change, amount ->
+                                change.consume()
+                                val now = System.nanoTime()
+                                val elapsedMs = max(1f, (now - lastMoveAtNanos) / 1_000_000f)
+                                velocityPxPerMs = amount.y / elapsedMs
+                                lastMoveAtNanos = now
+                                liveFraction = (liveFraction - amount.y / hostHeightPx)
+                                    .coerceIn(0f, TerminalWorkspace.SHEET_MAX_FRACTION)
+                            },
+                            onDragEnd = {
+                                dragging = false
+                                val settled = TerminalWorkspace.settleSheet(liveFraction, velocityPxPerMs)
+                                onWorkspace(
+                                    if (settled == 0f) TerminalWorkspace.closeSheet(workspace)
+                                    else TerminalWorkspace.setSheetFraction(workspace, settled),
+                                )
+                            },
+                            onDragCancel = {
+                                dragging = false
+                                liveFraction = workspace.sheetFraction
+                            },
+                        )
+                    }
+                    .padding(top = 8.dp, bottom = 5.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    Modifier
+                        .width(38.dp)
+                        .height(5.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(if (dragging) colors.accent else colors.dim.copy(alpha = 0.55f)),
+                )
+            }
+
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(start = 10.dp, end = 10.dp, bottom = 7.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                workspace.sheetTools.forEach { kind ->
+                    val selected = kind == current
+                    Row(
+                        Modifier
+                            .height(30.dp)
+                            .clip(CircleShape)
+                            .background(if (selected) colors.accent.copy(alpha = 0.32f) else colors.chrome2)
+                            .padding(start = 11.dp, end = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TermPressable(
+                            onClick = { onWorkspace(TerminalWorkspace.selectSheetTool(workspace, kind)) },
+                            modifier = Modifier.height(30.dp),
+                            scale = 0.94f,
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(toolIcon(kind), null, tint = if (selected) Color.White else colors.dim, modifier = Modifier.size(13.dp))
+                                Spacer(Modifier.width(6.dp))
+                                Text(
+                                    toolTitle(kind, hostName).substringBefore('·').trim(),
+                                    color = if (selected) Color.White else colors.dim,
+                                    fontSize = 12.sp,
+                                )
+                            }
+                        }
+                        TermPressable(
+                            onClick = { onWorkspace(TerminalWorkspace.closeSheetTool(workspace, kind)) },
+                            modifier = Modifier.size(24.dp),
+                            scale = 0.90f,
+                        ) {
+                            Text("×", color = (if (selected) Color.White else colors.dim).copy(alpha = 0.65f), fontSize = 15.sp)
+                        }
+                    }
+                }
+            }
+
+            Box(
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(start = 8.dp, end = 8.dp, bottom = 14.dp),
+            ) {
+                TerminalToolBody(
+                    kind = current,
+                    colors = colors,
+                    notes = notes,
+                    snippets = snippets,
+                    workspace = workspace,
+                    onWorkspace = onWorkspace,
+                    onInsert = onInsert,
+                    onOpenNote = onOpenNote,
+                    onOpenDocker = onOpenDocker,
+                    onMessage = onMessage,
+                    viewModel = viewModel,
+                )
+            }
+        }
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -126,6 +126,7 @@ class TerminalViewModel(
         override suspend fun write(bytes: ByteArray) = host.transportFor(sessionId).write(bytes)
         override suspend fun resize(columns: Int, rows: Int, widthPx: Int, heightPx: Int) =
             host.transportFor(sessionId).resize(columns, rows, widthPx, heightPx)
+        override fun onFailure(error: Throwable) = host.transportFor(sessionId).onFailure(error)
     }
 
     val controller = TerminalSurfaceController(
@@ -143,8 +144,11 @@ class TerminalViewModel(
     val termux: TermuxSessionBridge? = emulator as? TermuxSessionBridge
 
     init {
-        termux?.writeBytes = { bytes ->
-            viewModelScope.launch { delegatingTransport.write(bytes) }
+        termux?.bindWriteBytes { bytes ->
+            viewModelScope.launch {
+                runCatching { delegatingTransport.write(bytes) }
+                    .onFailure(delegatingTransport::onFailure)
+            }
             controller.consumeLatches()
         }
     }
@@ -166,6 +170,8 @@ class TerminalViewModel(
     val title: StateFlow<String?> = titleState.asStateFlow()
 
     private var outputJob: Job? = null
+    private var closureJob: Job? = null
+    private var latencyJob: Job? = null
     private val emulatorLock = Any()
     private var connectRequested = false
 
@@ -356,6 +362,8 @@ class TerminalViewModel(
                     registry.setTransport(sessionId, SessionTransport.CONNECTED, clock())
                     if (outcome.banner.isNotEmpty()) titleState.value = outcome.banner
                     startOutput()
+                    startClosureWatch()
+                    startLatencyProbe()
                 }
                 is TerminalOpenOutcome.HostKeyDecision -> {
                     // The session stays CONNECTING: nothing has been trusted, and a changed key
@@ -373,6 +381,29 @@ class TerminalViewModel(
             request.wipe()
             credentials.wipe()
             opening = false
+        }
+    }
+
+    private fun startClosureWatch() {
+        closureJob?.cancel()
+        closureJob = viewModelScope.launch {
+            host.closure(sessionId).collect { error ->
+                if (registry.find(sessionId)?.transport != SessionTransport.CONNECTED) return@collect
+                outputJob?.cancel()
+                latencyJob?.cancel()
+                registry.close(sessionId, clock(), error.message ?: REMOTE_CLOSED)
+                messages.tryEmit(REMOTE_CLOSED)
+            }
+        }
+    }
+
+    private fun startLatencyProbe() {
+        latencyJob?.cancel()
+        latencyJob = viewModelScope.launch {
+            while (registry.find(sessionId)?.transport == SessionTransport.CONNECTED) {
+                registry.setLatency(sessionId, runCatching { host.measureLatency(sessionId) }.getOrNull())
+                delay(LATENCY_INTERVAL_MS)
+            }
         }
     }
 
@@ -449,8 +480,9 @@ class TerminalViewModel(
         hostKeyState.value = null
         viewModelScope.launch {
             host.trustHostKey(sessionId)
-            // Re-opening rather than resuming: nothing was negotiated before the decision, so there
-            // is no half-open session to continue.
+            // The first socket was intentionally rejected by the verifier. Move out of CONNECTING
+            // before re-opening; otherwise connect() sees CONNECTING and returns without dialing.
+            registry.setTransport(sessionId, SessionTransport.DISCONNECTED, clock())
             connect()
         }
         if (prompt.changed) messages.tryEmit(HOST_KEY_CHANGED_ACCEPTED)
@@ -474,6 +506,8 @@ class TerminalViewModel(
 
     fun disconnect() {
         outputJob?.cancel()
+        closureJob?.cancel()
+        latencyJob?.cancel()
         registry.close(sessionId, clock())
         viewModelScope.launch { runCatching { host.close(sessionId) } }
     }
@@ -483,6 +517,20 @@ class TerminalViewModel(
     fun setEncoding(encoding: TerminalEncoding) {
         controller.setCharset(TerminalCharset.of(encoding))
         connectionState.value = connectionState.value?.copy(encoding = encoding)
+    }
+
+    suspend fun listRemoteDirectory(path: String) = host.listDirectory(sessionId, path)
+
+    suspend fun executeRemote(command: String) = host.exec(sessionId, command)
+
+    suspend fun remoteMetrics(): Result<RemoteMetrics> = host.exec(
+        sessionId,
+        "LC_ALL=C head -n 1 /proc/stat; " +
+            "LC_ALL=C awk '/MemTotal:/{t=\$2}/MemAvailable:/{a=\$2}END{print t,a}' /proc/meminfo; " +
+            "LC_ALL=C df -Pk / | awk 'NR==2{gsub(/%/,\"\",\$5);print \$5}'",
+    ).mapCatching { result ->
+        if (result.exitCode != 0) error(result.stderr.toString(Charsets.UTF_8).ifBlank { "读取远端指标失败" })
+        parseRemoteMetrics(result.stdout.toString(Charsets.UTF_8))
     }
 
     fun onDock(item: TerminalDockItem) {
@@ -524,6 +572,8 @@ class TerminalViewModel(
 
     override fun onCleared() {
         outputJob?.cancel()
+        closureJob?.cancel()
+        latencyJob?.cancel()
         // The emulator holds a native handle; leaking it would leak the whole scrollback buffer.
         synchronized(emulatorLock) { emulator.close() }
         super.onCleared()
@@ -555,9 +605,30 @@ class TerminalViewModel(
         const val HOST_KEY_CHANGED_ACCEPTED = "已接受变更后的主机密钥"
         const val DISCLOSURE_RELAY = "主端 relay：凭据保留在主端"
         const val DISCLOSURE_DIRECT = "本次原生直连：加密连接材料仅驻留会话内存"
+        const val REMOTE_CLOSED = "SSH 连接已断开"
+        private const val LATENCY_INTERVAL_MS = 5_000L
         private const val STOP_TIMEOUT_MS = 5_000L
         private const val RENDER_FRAME_INTERVAL_MS = 16L
     }
+}
+
+data class RemoteMetrics(val cpuPercent: Int, val memoryPercent: Int, val diskPercent: Int)
+
+internal fun parseRemoteMetrics(text: String): RemoteMetrics {
+    val lines = text.lineSequence().map(String::trim).filter(String::isNotBlank).toList()
+    require(lines.size >= 3) { "远端指标响应不完整" }
+    val cpu = lines[0].split(Regex("\\s+")).mapNotNull(String::toLongOrNull)
+    require(cpu.size >= 4) { "远端 CPU 数据无效" }
+    val total = cpu.sum().coerceAtLeast(1L)
+    val idle = cpu.getOrElse(3) { 0L } + cpu.getOrElse(4) { 0L }
+    val memory = lines[1].split(Regex("\\s+")).mapNotNull(String::toLongOrNull)
+    require(memory.size >= 2 && memory[0] > 0) { "远端内存数据无效" }
+    val disk = lines[2].toIntOrNull() ?: error("远端磁盘数据无效")
+    return RemoteMetrics(
+        cpuPercent = (((total - idle) * 100L) / total).toInt().coerceIn(0, 100),
+        memoryPercent = (((memory[0] - memory[1]) * 100L) / memory[0]).toInt().coerceIn(0, 100),
+        diskPercent = disk.coerceIn(0, 100),
+    )
 }
 
 /**

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -400,10 +400,7 @@ class TerminalViewModel(
     private fun startLatencyProbe() {
         latencyJob?.cancel()
         latencyJob = viewModelScope.launch {
-            while (registry.find(sessionId)?.transport == SessionTransport.CONNECTED) {
-                registry.setLatency(sessionId, runCatching { host.measureLatency(sessionId) }.getOrNull())
-                delay(LATENCY_INTERVAL_MS)
-            }
+            registry.setLatency(sessionId, runCatching { host.measureLatency(sessionId) }.getOrNull())
         }
     }
 
@@ -606,7 +603,6 @@ class TerminalViewModel(
         const val DISCLOSURE_RELAY = "主端 relay：凭据保留在主端"
         const val DISCLOSURE_DIRECT = "本次原生直连：加密连接材料仅驻留会话内存"
         const val REMOTE_CLOSED = "SSH 连接已断开"
-        private const val LATENCY_INTERVAL_MS = 5_000L
         private const val STOP_TIMEOUT_MS = 5_000L
         private const val RENDER_FRAME_INTERVAL_MS = 16L
     }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
@@ -1,7 +1,7 @@
 package one.zephyr.mobile.feature.sessions
 
 /**
- * Demo `#page-terminal` split / dock / floating-panel state.
+ * Demo `#page-terminal` split / dock / in-flow tool-sheet state.
  *
  * `toggleSplit` walks off → term → right → left → off, matching
  * `index__2_.html` `toggleSplit()` / `setDockSide()`.
@@ -39,19 +39,8 @@ enum class TerminalToolKind {
 
 enum class TermBackgroundKind { NONE, IMAGE, BIG }
 
-enum class TermPanelLayout { FREE, LEFT_HALF, RIGHT_HALF, BOTTOM }
-
-data class TerminalFloatingPanel(
-    val kind: TerminalToolKind,
-    val z: Int,
-    val layout: TermPanelLayout = TermPanelLayout.FREE,
-    val offsetXPx: Float = Float.NaN,
-    val offsetYPx: Float = Float.NaN,
-    val widthPx: Float = Float.NaN,
-    val heightPx: Float = Float.NaN,
-)
-
 const val DEFAULT_TERMINAL_DOCK_FRACTION = 0.38f
+const val DEFAULT_TERMINAL_SHEET_FRACTION = 0.44f
 
 data class TerminalWorkspaceState(
     val split: TerminalSplitMode = TerminalSplitMode.OFF,
@@ -61,13 +50,16 @@ data class TerminalWorkspaceState(
     val paneB: String? = null,
     val docked: List<TerminalToolKind> = emptyList(),
     val dockCurrent: TerminalToolKind? = null,
-    val floating: List<TerminalFloatingPanel> = emptyList(),
+    val sheetTools: List<TerminalToolKind> = emptyList(),
+    val sheetCurrent: TerminalToolKind? = null,
+    val sheetFraction: Float = 0f,
     val background: TermBackgroundKind = TermBackgroundKind.NONE,
     val backgroundBlurPx: Float = 0f,
     val backgroundOpacity: Float = 0.55f,
+    val customBackgroundColor: Boolean = false,
+    val customSelectionColor: Boolean = false,
     val addSheetOpen: Boolean = false,
     val disconnectSheetOpen: Boolean = false,
-    val nextZ: Int = 20,
 ) {
     val focusedSessionId: String
         get() = if (split == TerminalSplitMode.TERM && focusPane == 'b') {
@@ -127,11 +119,11 @@ object TerminalWorkspace {
     const val SPLIT_BTN_SIZE_DP = 30
     const val RAIL_CHIP_HEIGHT_DP = 34
     const val GUTTER_WIDTH_DP = 12
-    const val FLOAT_MIN_WIDTH_DP = 200
-    const val FLOAT_MIN_HEIGHT_DP = 160
-    const val FLOAT_DEFAULT_WIDTH_FRACTION = 0.78f
-    const val FLOAT_DEFAULT_MAX_WIDTH_DP = 330
-    const val FLOAT_DEFAULT_HEIGHT_FRACTION = 0.44f
+    const val SHEET_MID_FRACTION = 0.44f
+    const val SHEET_MAX_FRACTION = 0.74f
+    const val SHEET_DISMISS_FRACTION = 0.20f
+    const val SHEET_DISMISS_VELOCITY_PX_PER_MS = 0.70f
+    const val SHEET_PROJECTION_SECONDS = 0.12f
 
     val splitCycle: List<TerminalSplitMode> = listOf(
         TerminalSplitMode.OFF,
@@ -185,57 +177,55 @@ object TerminalWorkspace {
         )
     }
 
-    fun openTool(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState {
-        if (state.split.docksTools) {
-            val docked = if (kind in state.docked) state.docked else state.docked + kind
-            return state.copy(docked = docked, dockCurrent = kind)
-        }
-        val existing = state.floating.firstOrNull { it.kind == kind }
-        val z = state.nextZ + 1
-        return if (existing != null) {
-            state.copy(
-                floating = state.floating.map { if (it.kind == kind) it.copy(z = z) else it },
-                nextZ = z,
+    fun openTool(
+        state: TerminalWorkspaceState,
+        kind: TerminalToolKind,
+        phone: Boolean = true,
+    ): TerminalWorkspaceState {
+        if (!phone) {
+            val base = if (state.split.docksTools) state else applySplit(
+                state = state,
+                side = TerminalSplitMode.RIGHT,
+                sessionIds = listOfNotNull(state.paneA, state.paneB),
             )
-        } else {
-            val index = state.floating.size
-            state.copy(
-                floating = state.floating + TerminalFloatingPanel(
-                    kind = kind,
-                    z = z,
-                    offsetXPx = Float.NaN,
-                    offsetYPx = Float.NaN,
-                ).also { it },
-                nextZ = z,
-                /* index is used by the renderer to stagger the first paint */
-            ).let { next ->
-                if (index == 0) next else next
-            }
+            val docked = if (kind in base.docked) base.docked else base.docked + kind
+            return base.copy(docked = docked, dockCurrent = kind)
         }
-    }
-
-    fun closeFloating(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState =
-        state.copy(floating = state.floating.filterNot { it.kind == kind })
-
-    fun raiseFloating(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState {
-        val z = state.nextZ + 1
+        if (state.sheetCurrent == kind && state.sheetFraction > 0f) return closeSheet(state)
+        val tools = if (kind in state.sheetTools) state.sheetTools else state.sheetTools + kind
         return state.copy(
-            floating = state.floating.map { if (it.kind == kind) it.copy(z = z) else it },
-            nextZ = z,
+            sheetTools = tools,
+            sheetCurrent = kind,
+            sheetFraction = if (state.sheetFraction > 0f) state.sheetFraction else SHEET_MID_FRACTION,
         )
     }
 
-    fun cycleLayout(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState {
-        val order = TermPanelLayout.entries
+    fun selectSheetTool(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState =
+        if (kind in state.sheetTools) state.copy(sheetCurrent = kind) else state
+
+    fun closeSheetTool(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState {
+        val tools = state.sheetTools.filterNot { it == kind }
+        if (tools.isEmpty()) return closeSheet(state)
         return state.copy(
-            floating = state.floating.map { panel ->
-                if (panel.kind != kind) panel
-                else {
-                    val next = order[(order.indexOf(panel.layout) + 1) % order.size]
-                    panel.copy(layout = next)
-                }
-            },
+            sheetTools = tools,
+            sheetCurrent = if (state.sheetCurrent == kind) tools.last() else state.sheetCurrent,
         )
+    }
+
+    fun closeSheet(state: TerminalWorkspaceState): TerminalWorkspaceState =
+        state.copy(sheetTools = emptyList(), sheetCurrent = null, sheetFraction = 0f)
+
+    fun setSheetFraction(state: TerminalWorkspaceState, fraction: Float): TerminalWorkspaceState =
+        state.copy(sheetFraction = fraction.coerceIn(0f, SHEET_MAX_FRACTION))
+
+    fun settleSheet(current: Float, velocityPxPerMs: Float): Float {
+        if (velocityPxPerMs > SHEET_DISMISS_VELOCITY_PX_PER_MS || current < SHEET_DISMISS_FRACTION) return 0f
+        val projected = current - velocityPxPerMs * SHEET_PROJECTION_SECONDS
+        return if (kotlin.math.abs(projected - SHEET_MAX_FRACTION) < kotlin.math.abs(projected - SHEET_MID_FRACTION)) {
+            SHEET_MAX_FRACTION
+        } else {
+            SHEET_MID_FRACTION
+        }
     }
 
     fun undock(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState {
@@ -257,10 +247,5 @@ object TerminalWorkspace {
         if (splitWidthPx <= 0f) return startFraction
         val signed = if (split == TerminalSplitMode.LEFT) dxPx else -dxPx
         return clampDockWidth(startFraction + signed / splitWidthPx)
-    }
-
-    fun floatingOffset(index: Int): Pair<Float, Float> {
-        val off = (index % 3) * 16f
-        return (6f + off / 3f) to (8f + off)
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 class TermuxSessionBridge(
     private val maxScrollback: Int = 4_000,
-    var writeBytes: (ByteArray) -> Unit,
+    initialWriteBytes: (ByteArray) -> Unit = {},
     private val onTitle: (String?) -> Unit = {},
     private val onCopy: (String) -> Unit = {},
     private val onPasteRequested: () -> Unit = {},
@@ -38,6 +38,13 @@ class TermuxSessionBridge(
 ) : TerminalEmulator {
 
     override val isAvailable: Boolean = true
+
+    @Volatile
+    private var writeBytes: (ByteArray) -> Unit = initialWriteBytes
+
+    fun bindWriteBytes(writer: (ByteArray) -> Unit) {
+        writeBytes = writer
+    }
 
     private val client = BridgeSessionClient()
 
@@ -79,11 +86,18 @@ class TermuxSessionBridge(
         props.setProperty("foreground", scheme.foregroundHex)
         props.setProperty("background", scheme.backgroundHex)
         props.setProperty("cursor", scheme.cursorHex)
+        scheme.ansiArgb.forEachIndexed { index, argb ->
+            props.setProperty("color$index", String.format("#%06X", argb and 0xFFFFFF))
+        }
         TerminalColors.COLOR_SCHEME.updateWith(props)
         session.emulator?.mColors?.reset()
         snapshotColors.reset()
         attachedView?.get()?.onScreenUpdated()
         onScreenChanged()
+    }
+
+    fun setSelectionColors(backgroundArgb: Int?, foregroundArgb: Int?) {
+        attachedView?.get()?.setSelectionColors(backgroundArgb, foregroundArgb)
     }
 
     fun attach(view: TerminalView) {
@@ -274,12 +288,29 @@ data class TermuxColorScheme(
     val foregroundArgb: Int,
     val backgroundArgb: Int,
     val cursorArgb: Int,
+    val ansiArgb: IntArray = readableAnsiPalette(backgroundArgb),
 ) {
     val foregroundHex: String get() = hex(foregroundArgb)
     val backgroundHex: String get() = hex(backgroundArgb)
     val cursorHex: String get() = hex(cursorArgb)
 
     private fun hex(argb: Int): String = String.format("#%06X", argb and 0xFFFFFF)
+}
+
+internal fun readableAnsiPalette(backgroundArgb: Int): IntArray {
+    val light = TerminalCellPaint.contrast(0xFF14181D.toInt(), backgroundArgb) >
+        TerminalCellPaint.contrast(0xFFF2F4F7.toInt(), backgroundArgb)
+    return if (light) intArrayOf(
+        0xFF1C232B.toInt(), 0xFFB3261E.toInt(), 0xFF087F23.toInt(), 0xFF7A6200.toInt(),
+        0xFF1565C0.toInt(), 0xFF8E24AA.toInt(), 0xFF007C91.toInt(), 0xFF4A525B.toInt(),
+        0xFF5B6570.toInt(), 0xFFD32F2F.toInt(), 0xFF0B7A2C.toInt(), 0xFF8A6500.toInt(),
+        0xFF0D5BB5.toInt(), 0xFF7B1FA2.toInt(), 0xFF006B75.toInt(), 0xFF14181D.toInt(),
+    ) else intArrayOf(
+        0xFF000000.toInt(), 0xFFCD0000.toInt(), 0xFF00CD00.toInt(), 0xFFCDCD00.toInt(),
+        0xFF6495ED.toInt(), 0xFFCD00CD.toInt(), 0xFF00CDCD.toInt(), 0xFFE5E5E5.toInt(),
+        0xFF7F7F7F.toInt(), 0xFFFF0000.toInt(), 0xFF00FF00.toInt(), 0xFFFFFF00.toInt(),
+        0xFF5C5CFF.toInt(), 0xFFFF00FF.toInt(), 0xFF00FFFF.toInt(), 0xFFFFFFFF.toInt(),
+    )
 }
 
 /**
@@ -359,4 +390,4 @@ internal object TermuxHandleSeq {
  * live SSH stream.
  */
 fun productionTerminalEmulator(maxScrollback: Int = 4_000): TerminalEmulator =
-    TermuxSessionBridge(maxScrollback = maxScrollback, writeBytes = {})
+    TermuxSessionBridge(maxScrollback = maxScrollback)

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxTerminalPane.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxTerminalPane.kt
@@ -55,13 +55,17 @@ fun TermuxTerminalPane(
         )
     }
 
-    LaunchedEffect(colors.termBg, colors.text) {
+    LaunchedEffect(colors.termBg, colors.text, colors.selectionBackground, colors.selectionForeground) {
         bridge?.applyScheme(
             TermuxColorScheme(
                 foregroundArgb = colors.text.toArgb(),
                 backgroundArgb = colors.termBg.toArgb(),
                 cursorArgb = colors.text.toArgb(),
             ),
+        )
+        bridge?.setSelectionColors(
+            colors.selectionBackground?.toArgb(),
+            colors.selectionForeground?.toArgb(),
         )
     }
 

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/RemoteMetricsTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/RemoteMetricsTest.kt
@@ -1,0 +1,25 @@
+package one.zephyr.mobile.feature.sessions
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RemoteMetricsTest {
+    @Test
+    fun parsesProcAndDfOutput() {
+        val value = parseRemoteMetrics(
+            """
+            cpu  100 20 30 850 0 0 0 0 0 0
+            1000000 420000
+            82
+            """.trimIndent(),
+        )
+        assertEquals(15, value.cpuPercent)
+        assertEquals(58, value.memoryPercent)
+        assertEquals(82, value.diskPercent)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsIncompleteMetricsInsteadOfShowingZeros() {
+        parseRemoteMetrics("cpu 1 2")
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
@@ -60,9 +60,12 @@ class SshTerminalHostTest {
             return SshConnectOutcome.Failed(one.zephyr.mobile.model.MobileError.local("unused", "unused"))
         }
         override fun output(sessionId: String): Flow<ByteArray> = emptyFlow()
+        override fun closure(sessionId: String): Flow<Throwable> = emptyFlow()
+        override fun reportFailure(sessionId: String, error: Throwable) = Unit
         override suspend fun send(sessionId: String, bytes: ByteArray) = Unit
         override suspend fun resize(sessionId: String, cols: Int, rows: Int, widthPx: Int, heightPx: Int) = Unit
         override suspend fun disconnect(sessionId: String) = Unit
+        override suspend fun measureLatency(sessionId: String): Long? = null
         override suspend fun listDirectory(sessionId: String, path: String): Result<List<SftpEntry>> =
             Result.failure(IllegalStateException("unused"))
         override suspend fun exec(sessionId: String, command: String): Result<SshExecResult> =

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
@@ -1,0 +1,58 @@
+package one.zephyr.mobile.feature.sessions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TerminalToolSheetTest {
+    private fun state() = TerminalWorkspaceState(paneA = "s1")
+
+    @Test
+    fun phoneToolUsesInFlowSheetNeverFloatingState() {
+        val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.FILES, phone = true)
+        assertEquals(listOf(TerminalToolKind.FILES), opened.sheetTools)
+        assertEquals(TerminalToolKind.FILES, opened.sheetCurrent)
+        assertEquals(TerminalWorkspace.SHEET_MID_FRACTION, opened.sheetFraction, 0.001f)
+    }
+
+    @Test
+    fun tappingCurrentToolAgainClosesTheSheet() {
+        val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.FILES, phone = true)
+        val closed = TerminalWorkspace.openTool(opened, TerminalToolKind.FILES, phone = true)
+        assertEquals(0f, closed.sheetFraction, 0.001f)
+        assertTrue(closed.sheetTools.isEmpty())
+    }
+
+    @Test
+    fun fastDownwardDragDismisses() {
+        assertEquals(0f, TerminalWorkspace.settleSheet(0.60f, 0.71f), 0.001f)
+    }
+
+    @Test
+    fun shortSheetDismissesEvenAtLowVelocity() {
+        assertEquals(0f, TerminalWorkspace.settleSheet(0.19f, 0f), 0.001f)
+    }
+
+    @Test
+    fun projectedPositionSnapsToNearestDetent() {
+        assertEquals(
+            TerminalWorkspace.SHEET_MAX_FRACTION,
+            TerminalWorkspace.settleSheet(0.64f, -0.20f),
+            0.001f,
+        )
+        assertEquals(
+            TerminalWorkspace.SHEET_MID_FRACTION,
+            TerminalWorkspace.settleSheet(0.48f, 0.10f),
+            0.001f,
+        )
+    }
+
+    @Test
+    fun tabletToolUsesInPageSideDock() {
+        val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.NOTES, phone = false)
+        assertEquals(TerminalSplitMode.RIGHT, opened.split)
+        assertEquals(TerminalToolKind.NOTES, opened.dockCurrent)
+        assertTrue(opened.docked.contains(TerminalToolKind.NOTES))
+        assertEquals(0f, opened.sheetFraction, 0.001f)
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt
@@ -456,7 +456,7 @@ class TerminalViewModelTest {
     }
 
     @Test
-    fun acceptingAChangedHostKeyTrustsItAndSaysSo() = runTest(mainDispatcher) {
+    fun acceptingAChangedHostKeyTrustsItRedialsAndSaysSo() = runTest(mainDispatcher) {
         val host = FakeHost(outcome = TerminalOpenOutcome.HostKeyDecision("SHA256:abc", changed = true))
         val subject = subject(host = host)
         subscribe(subject)
@@ -470,6 +470,7 @@ class TerminalViewModelTest {
         runCurrent()
 
         assertEquals(1, host.trusted)
+        assertEquals(2, host.opens)
         // A changed key that was accepted must leave a trace the user can see afterwards.
         assertTrue(messages.contains(TerminalViewModel.HOST_KEY_CHANGED_ACCEPTED))
     }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TermuxColorSchemeTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TermuxColorSchemeTest.kt
@@ -1,0 +1,28 @@
+package one.zephyr.mobile.feature.sessions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TermuxColorSchemeTest {
+    @Test
+    fun frostAnsiColorsMeetReadableContrastFloor() {
+        val background = 0xFFF3F5F7.toInt()
+        val palette = readableAnsiPalette(background)
+        assertEquals(16, palette.size)
+        palette.forEachIndexed { index, color ->
+            assertTrue(
+                "ANSI $index contrast was ${TerminalCellPaint.contrast(color, background)}",
+                TerminalCellPaint.contrast(color, background) >= 4.45f,
+            )
+        }
+    }
+
+    @Test
+    fun darkTerminalKeepsXtermSemanticColors() {
+        val palette = readableAnsiPalette(0xFF07090C.toInt())
+        assertEquals(0xFF00CD00.toInt(), palette[2])
+        assertEquals(0xFF6495ED.toInt(), palette[4])
+        assertEquals(0xFFFFFFFF.toInt(), palette[15])
+    }
+}

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
@@ -25,12 +25,21 @@ interface SshEngine {
     /** Terminal bytes from the remote PTY. */
     fun output(sessionId: String): Flow<ByteArray>
 
+    /** Emits once when read/write detects a remote close or transport error. */
+    fun closure(sessionId: String): Flow<Throwable>
+
+    /** Reports a failed asynchronous terminal write without throwing on the UI scope. */
+    fun reportFailure(sessionId: String, error: Throwable)
+
     suspend fun send(sessionId: String, bytes: ByteArray)
 
     /** Reports the visible terminal geometry. Both cells and pixels, per TERMINAL_EXPERIENCE.md 6. */
     suspend fun resize(sessionId: String, cols: Int, rows: Int, widthPx: Int, heightPx: Int)
 
     suspend fun disconnect(sessionId: String)
+
+    /** Measures one SSH request/reply round trip on an authenticated transport. */
+    suspend fun measureLatency(sessionId: String): Long?
 
     /** SFTP, Docker, batch execution and snippets are SSH-only (`Protocol.supportsFiles`). */
     suspend fun listDirectory(sessionId: String, path: String): Result<List<SftpEntry>>
@@ -94,11 +103,17 @@ class UnavailableSshEngine : SshEngine {
 
     override fun output(sessionId: String): Flow<ByteArray> = kotlinx.coroutines.flow.emptyFlow()
 
+    override fun closure(sessionId: String): Flow<Throwable> = kotlinx.coroutines.flow.emptyFlow()
+
+    override fun reportFailure(sessionId: String, error: Throwable) = Unit
+
     override suspend fun send(sessionId: String, bytes: ByteArray) = Unit
 
     override suspend fun resize(sessionId: String, cols: Int, rows: Int, widthPx: Int, heightPx: Int) = Unit
 
     override suspend fun disconnect(sessionId: String) = Unit
+
+    override suspend fun measureLatency(sessionId: String): Long? = null
 
     override suspend fun listDirectory(sessionId: String, path: String): Result<List<SftpEntry>> =
         Result.failure(one.zephyr.mobile.model.MobileApiException(BLOCKED))

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -122,10 +122,11 @@ class SshjEngine(
         live.shell.changeWindowDimensions(cols, rows, widthPx, heightPx)
     }
 
-    override suspend fun disconnect(sessionId: String) = withContext(io) {
+    override suspend fun disconnect(sessionId: String): Unit = withContext(io) {
         sessions.remove(sessionId)?.close()
         closeEvents.remove(sessionId)
         pending.remove(sessionId)
+        Unit
     }
 
     override suspend fun measureLatency(sessionId: String): Long? = withContext(io) {

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -4,17 +4,25 @@ import java.io.InputStream
 import java.io.StringReader
 import java.security.PublicKey
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureNanoTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.SSHPacket
 import net.schmizz.sshj.connection.channel.direct.PTYMode
 import net.schmizz.sshj.connection.channel.direct.Session
+import net.schmizz.sshj.sftp.FileMode
 import net.schmizz.sshj.transport.verification.HostKeyVerifier
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
@@ -23,17 +31,13 @@ import net.schmizz.sshj.userauth.password.PasswordFinder
 import net.schmizz.sshj.userauth.password.PasswordUtils
 import one.zephyr.mobile.model.MobileError
 
-/**
- * Direct SSH via SSHJ.
- *
- * Password and private-key auth, first-seen host-key prompt, PTY + shell. Proxy / jump hops are
- * rejected until the route planner is wired through SSHJ transports.
- */
+/** Live direct SSH transport: shell, SFTP, exec and request/reply latency probes. */
 class SshjEngine(
     private val io: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.IO,
 ) : SshEngine {
 
     private val sessions = ConcurrentHashMap<String, LiveSession>()
+    private val closeEvents = ConcurrentHashMap<String, MutableSharedFlow<Throwable>>()
     private val pending = ConcurrentHashMap<String, HostKey>()
     private val trusted = ConcurrentHashMap<String, HostKey>()
     private val scope = CoroutineScope(SupervisorJob() + io)
@@ -43,13 +47,10 @@ class SshjEngine(
     override suspend fun connect(request: SshConnectRequest): SshConnectOutcome = withContext(io) {
         if (request.route.hops.any { it !is RouteHop.Target }) {
             return@withContext SshConnectOutcome.Failed(
-                MobileError.local(
-                    code = "route_unsupported",
-                    message = "此版本先支持直连 SSH，代理和跳板稍后接入",
-                    retryable = false,
-                ),
+                MobileError.local("route_unsupported", "当前 SSHJ 引擎尚未接入代理或跳板链", false),
             )
         }
+        sessions.remove(request.sessionId)?.close()
         val target = request.route.target
         val client = SSHClient()
         val verifier = RecordingVerifier(hostPort(target.host, target.port))
@@ -57,10 +58,11 @@ class SshjEngine(
         try {
             client.connect(target.host, target.port)
             authenticate(client, request)
-            val session = client.startSession()
-            session.allocatePTY("xterm-256color", request.cols, request.rows, 0, 0, emptyMap<PTYMode, Int>())
-            val shell = session.startShell()
-            sessions[request.sessionId] = LiveSession(client, session, shell)
+            val terminalSession = client.startSession()
+            terminalSession.allocatePTY("xterm-256color", request.cols, request.rows, 0, 0, emptyMap<PTYMode, Int>())
+            val shell = terminalSession.startShell()
+            sessions[request.sessionId] = LiveSession(client, terminalSession, shell)
+            closeEvents[request.sessionId] = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
             pending.remove(request.sessionId)
             SshConnectOutcome.Connected(request.sessionId, "")
         } catch (error: Exception) {
@@ -86,47 +88,96 @@ class SshjEngine(
             while (!live.closed) {
                 val read = runCatching { input.read(buffer) }.getOrDefault(-1)
                 if (read < 0) break
-                if (read == 0) continue
-                trySend(buffer.copyOf(read))
+                if (read > 0) trySend(buffer.copyOf(read))
             }
+            sessions.remove(sessionId, live)
+            live.close()
+            closeEvents[sessionId]?.tryEmit(IllegalStateException("SSH 远端已断开"))
             close()
         }
         awaitClose { job.cancel() }
     }
 
-    override suspend fun send(sessionId: String, bytes: ByteArray) = withContext(io) {
-        val live = sessions[sessionId] ?: return@withContext
-        live.shell.outputStream.write(bytes)
-        live.shell.outputStream.flush()
+    override fun closure(sessionId: String): Flow<Throwable> =
+        closeEvents.getOrPut(sessionId) { MutableSharedFlow(replay = 1, extraBufferCapacity = 1) }.asSharedFlow()
+
+    override fun reportFailure(sessionId: String, error: Throwable) {
+        closeEvents[sessionId]?.tryEmit(error)
     }
 
-    override suspend fun resize(
-        sessionId: String,
-        cols: Int,
-        rows: Int,
-        widthPx: Int,
-        heightPx: Int,
-    ) = withContext(io) {
-        val live = sessions[sessionId] ?: return@withContext
-        runCatching {
-            live.shell.javaClass.methods
-                .firstOrNull { it.name == "changeWindowDimensions" && it.parameterTypes.size == 4 }
-                ?.invoke(live.shell, cols, rows, widthPx, heightPx)
+    override suspend fun send(sessionId: String, bytes: ByteArray) = withContext(io) {
+        val live = sessions[sessionId] ?: throw IllegalStateException("SSH 会话已断开")
+        try {
+            live.shell.outputStream.write(bytes)
+            live.shell.outputStream.flush()
+        } catch (error: Exception) {
+            sessions.remove(sessionId, live)
+            live.close()
+            throw error
         }
-        Unit
+    }
+
+    override suspend fun resize(sessionId: String, cols: Int, rows: Int, widthPx: Int, heightPx: Int) = withContext(io) {
+        val live = sessions[sessionId] ?: return@withContext
+        live.shell.changeWindowDimensions(cols, rows, widthPx, heightPx)
     }
 
     override suspend fun disconnect(sessionId: String) = withContext(io) {
         sessions.remove(sessionId)?.close()
+        closeEvents.remove(sessionId)
         pending.remove(sessionId)
-        Unit
     }
 
-    override suspend fun listDirectory(sessionId: String, path: String): Result<List<SftpEntry>> =
-        Result.failure(one.zephyr.mobile.model.MobileApiException(SFTP_BLOCKED))
+    override suspend fun measureLatency(sessionId: String): Long? = withContext(io) {
+        val live = sessions[sessionId] ?: return@withContext null
+        runCatching {
+            var nanos = 0L
+            nanos = measureNanoTime {
+                live.client.connection
+                    .sendGlobalRequest("keepalive@openssh.com", true, ByteArray(0))
+                    .retrieve(5, TimeUnit.SECONDS)
+            }
+            (nanos / 1_000_000L).coerceAtLeast(1L)
+        }.getOrNull()
+    }
 
-    override suspend fun exec(sessionId: String, command: String): Result<SshExecResult> =
-        Result.failure(one.zephyr.mobile.model.MobileApiException(SFTP_BLOCKED))
+    override suspend fun listDirectory(sessionId: String, path: String): Result<List<SftpEntry>> = withContext(io) {
+        runCatching {
+            val live = sessions[sessionId] ?: error("SSH 会话已断开")
+            live.client.newSFTPClient().use { sftp ->
+                sftp.ls(path).filterNot { it.name == "." || it.name == ".." }.map { entry ->
+                    val attrs = entry.attributes
+                    SftpEntry(
+                        name = entry.name,
+                        path = entry.path,
+                        isDirectory = entry.isDirectory,
+                        isSymlink = attrs.type == FileMode.Type.SYMLINK,
+                        size = attrs.size,
+                        modifiedAt = attrs.mtime * 1_000L,
+                        permissions = attrs.mode.mask and 0xFFF,
+                        owner = attrs.uid.toString(),
+                        group = attrs.gid.toString(),
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun exec(sessionId: String, command: String): Result<SshExecResult> = withContext(io) {
+        runCatching {
+            require(command.isNotBlank()) { "远程命令不能为空" }
+            val live = sessions[sessionId] ?: error("SSH 会话已断开")
+            live.client.startSession().use { commandSession ->
+                val remote = commandSession.exec(command)
+                coroutineScope {
+                    val stdout = async(io) { remote.inputStream.readBytes() }
+                    val stderr = async(io) { remote.errorStream.readBytes() }
+                    remote.join()
+                    SshExecResult(remote.exitStatus ?: -1, stdout.await(), stderr.await())
+                }
+            }
+        }
+    }
 
     fun acceptHostKey(sessionId: String, host: String, port: Int) {
         val key = pending.remove(sessionId) ?: return
@@ -140,25 +191,19 @@ class SshjEngine(
                 val finder = credential.passphrase?.let { PasswordUtils.createOneOff(it) }
                 client.authPublickey(request.username, loadKey(String(credential.pem), finder))
             }
-            SshCredential.Interactive -> error("keyboard-interactive is not wired")
+            SshCredential.Interactive -> error("keyboard-interactive 尚未接入")
         }
     }
 
     private inner class RecordingVerifier(private val scope: String) : HostKeyVerifier {
         @Volatile var presented: HostKey? = null
         @Volatile var accepted: Boolean = false
-
         override fun verify(hostname: String, port: Int, key: PublicKey): Boolean {
-            val seen = HostKey(algorithm = key.algorithm, blob = key.encoded)
+            val seen = HostKey(key.algorithm, key.encoded)
             presented = seen
             val known = trusted[hostPort(hostname, port)] ?: trusted[scope]
-            if (known != null && known == seen) {
-                accepted = true
-                return true
-            }
-            return false
+            return (known != null && known == seen).also { accepted = it }
         }
-
         override fun findExistingAlgorithms(hostname: String, port: Int): List<String> = emptyList()
     }
 
@@ -169,6 +214,7 @@ class SshjEngine(
         @Volatile var closed: Boolean = false,
     ) {
         fun close() {
+            if (closed) return
             closed = true
             runCatching { shell.close() }
             runCatching { session.close() }
@@ -177,31 +223,18 @@ class SshjEngine(
     }
 
     companion object {
-        private val SFTP_BLOCKED = MobileError.local(
-            code = "engine_unavailable",
-            message = "此版本尚未接入 SFTP / 远程执行",
-            retryable = false,
-        )
-
         private fun hostPort(host: String, port: Int): String = host.lowercase() + ":" + port
-
-        private fun loadKey(pem: String, finder: PasswordFinder?): KeyProvider {
-            val trimmed = pem.trim()
-            return if (trimmed.contains("BEGIN OPENSSH PRIVATE KEY")) {
-                OpenSSHKeyFile().also { it.init(StringReader(trimmed), finder) }
+        private fun loadKey(pem: String, finder: PasswordFinder?): KeyProvider =
+            if (pem.trim().contains("BEGIN OPENSSH PRIVATE KEY")) {
+                OpenSSHKeyFile().also { it.init(StringReader(pem.trim()), finder) }
             } else {
-                PKCS8KeyFile().also { it.init(StringReader(trimmed), finder) }
+                PKCS8KeyFile().also { it.init(StringReader(pem.trim()), finder) }
             }
-        }
-
-        private fun closeQuietly(client: SSHClient) {
-            runCatching { client.disconnect() }
-        }
-
+        private fun closeQuietly(client: SSHClient) { runCatching { client.disconnect() } }
         private fun mapError(error: Exception): MobileError = MobileError.local(
-            code = "ssh_connect_failed",
-            message = error.message?.takeIf { it.isNotBlank() } ?: error.javaClass.simpleName,
-            retryable = true,
+            "ssh_connect_failed",
+            error.message?.takeIf(String::isNotBlank) ?: error.javaClass.simpleName,
+            true,
         )
     }
 }

--- a/zephyr_one/mobile/ios/Sources/ZephyrUI/TcpReachabilityTester.swift
+++ b/zephyr_one/mobile/ios/Sources/ZephyrUI/TcpReachabilityTester.swift
@@ -55,24 +55,15 @@ public struct TcpReachabilityTester: ConnectionTester, @unchecked Sendable {
                 port: NWEndpoint.Port(rawValue: UInt16(port)) ?? .any,
                 using: .tcp
             )
-            let lock = NSLock()
-            var finished = false
-            @Sendable func finish(_ result: Result<Void, Error>) {
-                lock.lock()
-                defer { lock.unlock() }
-                guard !finished else { return }
-                finished = true
-                connection.cancel()
-                continuation.resume(with: result)
-            }
+            let finisher = TcpConnectionFinisher(connection: connection, continuation: continuation)
             connection.stateUpdateHandler = { state in
                 switch state {
                 case .ready:
-                    finish(.success(()))
+                    finisher.finish(.success(()))
                 case let .failed(error):
-                    finish(.failure(error))
+                    finisher.finish(.failure(error))
                 case .cancelled:
-                    finish(.failure(CancellationError()))
+                    finisher.finish(.failure(CancellationError()))
                 default:
                     break
                 }
@@ -81,7 +72,7 @@ public struct TcpReachabilityTester: ConnectionTester, @unchecked Sendable {
             DispatchQueue.global(qos: .userInitiated).asyncAfter(
                 deadline: .now() + .milliseconds(timeoutMs)
             ) {
-                finish(.failure(NSError(domain: NSPOSIXErrorDomain, code: Int(ETIMEDOUT))))
+                finisher.finish(.failure(NSError(domain: NSPOSIXErrorDomain, code: Int(ETIMEDOUT))))
             }
         }
         #else
@@ -89,3 +80,29 @@ public struct TcpReachabilityTester: ConnectionTester, @unchecked Sendable {
         #endif
     }
 }
+
+#if canImport(Network)
+private final class TcpConnectionFinisher: @unchecked Sendable {
+    private let lock = NSLock()
+    private let connection: NWConnection
+    private let continuation: CheckedContinuation<Void, Error>
+    private var finished = false
+
+    init(connection: NWConnection, continuation: CheckedContinuation<Void, Error>) {
+        self.connection = connection
+        self.continuation = continuation
+    }
+
+    func finish(_ result: Result<Void, Error>) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        lock.unlock()
+        connection.cancel()
+        continuation.resume(with: result)
+    }
+}
+#endif

--- a/zephyr_one/mobile/ios/Tests/ZephyrUITests/TcpReachabilityTesterTests.swift
+++ b/zephyr_one/mobile/ios/Tests/ZephyrUITests/TcpReachabilityTesterTests.swift
@@ -15,7 +15,7 @@ final class TcpReachabilityTesterTests: XCTestCase {
             }
         )
         let result = try await tester.test(
-            UiTestData.connection(`protocol`: .rdp, host: "10.0.8.30", port: 3389)
+            UiTestData.connection(host: "10.0.8.30", protocol: .rdp, port: 3389)
         )
         XCTAssertEqual(result, .reachable(roundTripMs: 41))
     }
@@ -24,7 +24,7 @@ final class TcpReachabilityTesterTests: XCTestCase {
         let opened = LockedFlag()
         let tester = TcpReachabilityTester(connect: { _, _, _ in opened.value = true })
         let result = try await tester.test(
-            UiTestData.connection(`protocol`: .rdp, host: "  ", port: 3389)
+            UiTestData.connection(host: "  ", protocol: .rdp, port: 3389)
         )
         if case let .failed(error) = result {
             XCTAssertEqual(error.code, "test_no_host")

--- a/zephyr_one/mobile/tests/app-lock-wiring.test.mjs
+++ b/zephyr_one/mobile/tests/app-lock-wiring.test.mjs
@@ -66,7 +66,7 @@ test('enabling local unlock requires a successful platform prompt', () => {
   const screen = read('feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt');
   const destClean = codeOnly(dest);
   const screenClean = codeOnly(screen);
-  assert.match(destClean, /confirmLocalReveal/);
+  assert.match(destClean, /confirmEnable/);
   assert.match(destClean, /AppLockPreferences\.apply/);
   assert.match(destClean, /AppLockCache\.write/);
   assert.match(screenClean, /canEnable/);

--- a/zephyr_one/mobile/tests/connection-password-biometric-reveal.test.mjs
+++ b/zephyr_one/mobile/tests/connection-password-biometric-reveal.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const lock = read('core-security/src/main/kotlin/one/zephyr/mobile/security/AppLock.kt');
+const root = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const vm = read('feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt');
+const ui = read('feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt');
+const route = read('feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionRoutes.kt');
+
+test('local reveal refuses when app lock is disabled', () => {
+  const reveal = lock.slice(lock.indexOf('suspend fun confirmLocalReveal'), lock.indexOf('/** Unbind'));
+  assert.match(reveal, /if \(!isEnabled\)/);
+  assert.match(reveal, /local unlock is disabled/);
+  assert.match(lock, /suspend fun confirmEnable/);
+});
+
+test('password reveal requires enabled lock and revealSecret capability twice', () => {
+  assert.match(vm, /ConnectionPasswordRevealPolicy\.allowed/);
+  assert.match(vm, /localUnlockEnabled = passwordRevealEnabled\(\)/);
+  assert.match(vm, /hasStoredPassword = existing\.password\.hasValue/);
+  assert.match(vm, /canRevealSecret = existing\.capabilities\.canRevealSecret/);
+  assert.match(vm, /\|\| !content\.passwordRevealAllowed/);
+  assert.match(root, /if \(!appContainer\.appLock\.isEnabled \|\| !connection\.capabilities\.canRevealSecret\) return null/);
+  assert.match(root, /confirmLocalReveal/);
+  assert.match(root, /secretStore\.getText\(ref\)/);
+});
+
+test('reveal UI is absent unless allowed and reveals in place', () => {
+  assert.match(ui, /if \(revealAllowed && state is SecretState\.Unchanged\)/);
+  assert.match(ui, /revealedValue \?: ConnectionDraft\.presenceFor/);
+  assert.match(ui, /EditorIntent\.RevealPassword/);
+  assert.match(ui, /EditorIntent\.HidePassword/);
+});
+
+test('revealed password clears on timer lock background and disposal', () => {
+  assert.match(vm, /PASSWORD_REVEAL_MS = 30_000L/);
+  assert.match(vm, /revealedPassword = null/);
+  assert.match(vm, /override fun onLocked\(\)/);
+  assert.match(route, /repeatOnLifecycle\(Lifecycle\.State\.STARTED\)/);
+  assert.match(route, /finally \{[\s\S]*viewModel\.hidePassword\(\)/);
+  assert.match(route, /onDispose\(viewModel::clearSecretBuffers\)/);
+});

--- a/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
+++ b/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
@@ -23,7 +23,8 @@ test('missing RDP engine is not shown as a main-end incompatibility', () => {
 test('connection test is a local TCP handshake, not a main-end or engine call', () => {
   const root = read(path.join(ROOT, 'android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt'));
   assert.match(root, /TcpReachabilityTester\(/);
-  assert.match(root, /tester = TcpReachabilityTester\(/);
+  assert.match(root, /fallback = TcpReachabilityTester\(/);
+  assert.match(root, /ProtocolConnectionTester\(/);
   assert.match(root, /onTestConnection = testConnection/);
   const tester = read(path.join(ROOT, 'android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/TcpReachabilityTester.kt'));
   assert.match(tester, /Socket\(\)/);

--- a/zephyr_one/mobile/tests/ssh-terminal-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-terminal-runtime.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const vm = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt');
+const screen = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt');
+const bridge = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt');
+const root = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const sshj = read('protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+
+test('accepting a first host key leaves CONNECTING before redial', () => {
+  assert.match(vm, /trustHostKey\(sessionId\)[\s\S]*setTransport\(sessionId, SessionTransport\.DISCONNECTED[\s\S]*connect\(\)/);
+});
+
+test('real terminal canvas alone drives PTY geometry', () => {
+  assert.match(screen, /\.onSizeChanged\s*\{[\s\S]*containerW = it\.width[\s\S]*containerH = it\.height/);
+  assert.match(screen, /shortcutMatrixHeightPx = 0f/);
+  assert.match(screen, /dockHeightPx = 0f/);
+});
+
+test('Termux system IME writes are bound to SSH and failures are caught', () => {
+  assert.match(bridge, /fun bindWriteBytes/);
+  assert.doesNotMatch(bridge, /writeBytes\s*=\s*\{\}/);
+  assert.match(vm, /termux\?\.bindWriteBytes/);
+  assert.match(vm, /runCatching \{ delegatingTransport\.write\(bytes\) \}/);
+});
+
+test('SSHJ implements shell, SFTP, exec and request roundtrip latency', () => {
+  assert.match(sshj, /newSFTPClient\(\)/);
+  assert.match(sshj, /startSession\(\)/);
+  assert.match(sshj, /sendGlobalRequest\("keepalive@openssh\.com"/);
+  assert.doesNotMatch(sshj, /Result\.failure\(UnsupportedOperationException/);
+});
+
+test('editor and batch execution no longer use unavailable ports', () => {
+  assert.match(root, /DirectSshConnectionTester/);
+  assert.match(root, /LiveSshExecPort/);
+  assert.doesNotMatch(root, /exec\s*=\s*UnavailableRemotePorts/);
+});
+
+test('remote close pops terminal route', () => {
+  assert.match(root, /SessionTransport\.CLOSED[\s\S]*RootRoute\.Root\(IslandDestination\.SESSIONS\)/);
+});

--- a/zephyr_one/mobile/tests/terminal-live-tools-theme.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-live-tools-theme.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const panels = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt');
+const screen = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt');
+const bridge = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt');
+
+test('terminal tools never render demo files snippets or zero metrics', () => {
+  assert.doesNotMatch(panels, /"nginx\.conf"|"access\.log"|Snippet\(id = "demo-|Meter\(colors, "CPU", "—"/);
+  assert.match(panels, /listRemoteDirectory\(path\)/);
+  assert.match(panels, /remoteMetrics\(\)/);
+});
+
+test('terminal background opacity and blur affect rendering', () => {
+  assert.match(screen, /\.blur\(workspace\.backgroundBlurPx\.dp\)/);
+  assert.match(screen, /alpha = workspace\.backgroundOpacity/);
+  assert.doesNotMatch(screen, /private fun Brush\.copy\(alpha: Float\): Brush = this/);
+});
+
+test('light terminal installs a readable 16-color ANSI palette', () => {
+  assert.match(bridge, /readableAnsiPalette/);
+  assert.match(bridge, /scheme\.ansiArgb\.forEachIndexed/);
+  assert.match(bridge, /color\$index/);
+});

--- a/zephyr_one/mobile/tests/terminal-password-color-overrides.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-password-color-overrides.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const editor = read('feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt');
+const draft = read('feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraft.kt');
+const panels = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt');
+const workspace = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt');
+const renderer = read('feature-sessions/src/main/java/com/termux/view/TerminalRenderer.java');
+
+test('stored SSH password has explicit replace clear and keep actions', () => {
+  assert.match(editor, /onChange\(SecretState\.Replace\(""\)\)/);
+  assert.match(editor, /onChange\(SecretState\.Clear\)/);
+  assert.match(editor, /onChange\(SecretState\.Unchanged\)/);
+  assert.match(draft, /put\("password", outgoingSecret\(password\)\)/);
+});
+
+test('terminal color overrides are stateful and reach native renderer', () => {
+  assert.match(workspace, /customBackgroundColor/);
+  assert.match(workspace, /customSelectionColor/);
+  assert.match(panels, /workspace\.copy\(customBackgroundColor = enabled\)/);
+  assert.match(panels, /workspace\.copy\(customSelectionColor = !workspace\.customSelectionColor\)/);
+  assert.match(renderer, /selectionBackground/);
+  assert.match(renderer, /selectionForeground/);
+});

--- a/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const src = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const ws = src('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt');
+const screen = src('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt');
+const sheet = src('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt');
+const panels = src('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt');
+
+const codeOnly = (s) => s.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
+test('phone tools are an in-flow drawer with demo detents', () => {
+  assert.match(ws, /SHEET_MID_FRACTION\s*=\s*0\.44f/);
+  assert.match(ws, /SHEET_MAX_FRACTION\s*=\s*0\.74f/);
+  assert.match(ws, /SHEET_DISMISS_FRACTION\s*=\s*0\.20f/);
+  assert.match(ws, /SHEET_DISMISS_VELOCITY_PX_PER_MS\s*=\s*0\.70f/);
+  assert.match(screen, /TerminalToolSheet\(/);
+  assert.match(sheet, /height\(maxHeight \* animatedFraction\)/);
+  assert.match(sheet, /tween\(260, easing = ZephyrMotionTokens\.easeDrawer\)/);
+});
+
+test('terminal no longer renders movable floating tool panels', () => {
+  const all = codeOnly(ws + '\n' + screen + '\n' + panels);
+  assert.doesNotMatch(all, /TerminalFloatingPanel|FloatingToolLayer|TermPanelLayout|floatingOffset/);
+});
+
+test('drawer drag uses velocity projection and close threshold', () => {
+  assert.match(ws, /current < SHEET_DISMISS_FRACTION/);
+  assert.match(ws, /velocityPxPerMs > SHEET_DISMISS_VELOCITY_PX_PER_MS/);
+  assert.match(ws, /projected = current - velocityPxPerMs \* SHEET_PROJECTION_SECONDS/);
+  assert.match(sheet, /detectDragGestures/);
+});
+
+test('IME button closes tool drawer before showing keyboard', () => {
+  assert.match(screen, /TerminalWorkspace\.closeSheet\(ws\)[\s\S]*onIntent\(intent\)/);
+});

--- a/zephyr_one/mobile/tests/terminal-two-bars-ime.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-two-bars-ime.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const screen = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt');
+const chrome = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt');
+const routes = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionRoutes.kt');
+const root = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+
+test('terminal renders both key row and icon-label context dock', () => {
+  assert.match(screen, /DemoKeyRow\(/);
+  assert.match(screen, /DemoContextDock\(/);
+  assert.match(chrome, /Icon\(demoDockIcon\(item\)/);
+  assert.match(chrome, /Text\(demoDockLabel\(item\)/);
+});
+
+test('actual IME keeps shortcut row and removes only context dock', () => {
+  assert.match(screen, /val imeOpen = imeHeightPx > 8f/);
+  assert.match(screen, /DemoKeyRow\([\s\S]*if \(!imeOpen\) \{[\s\S]*DemoContextDock/);
+  assert.match(screen, /\.imePadding\(\)/);
+  assert.doesNotMatch(screen, /keyboardVisible \|\| imeHeightPx/);
+});
+
+test('session plus opens new connection protocol picker', () => {
+  assert.match(screen, /onAdd = onCreateConnection/);
+  assert.match(routes, /onCreateConnection/);
+  assert.match(root, /onCreateConnection = \{ route = RootRoute\.ProtocolPicker \}/);
+});
+
+test('context dock is removed rather than transparent blank occupancy', () => {
+  assert.doesNotMatch(chrome, /dockHide|alpha = 1f - hidden|translationY = 90f/);
+});


### PR DESCRIPTION
Fixes terminal two-bar/IME geometry, in-flow tool drawer, SSHJ runtime, first-connect host-key redial, latency, test connection, password editing and biometric-gated reveal, live SFTP/metrics/exec, color contrast/customization, Enter write failures, and automatic close on disconnect.\n\nValidation: mobile contracts 424/424; targeted biometric/terminal contracts 26/26; gate mutations caught. Android compilation delegated to Zephyr One Mobile CI.