### PR TITLE
fix(mobile): Android RDP rdp_session_create_failed

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import one.zephyr.mobile.app.di.AppContainer
+import one.zephyr.mobile.protocol.rdp.RdpAndroidRuntime
 
 /**
  * Process entry point.
@@ -41,6 +42,7 @@ class ZephyrOneApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        RdpAndroidRuntime.installHome(filesDir)
         container = AppContainer(this)
         container.clearPendingBindingAuthentication()
         WorkManager.initialize(this, workManagerConfiguration)

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
@@ -79,8 +79,11 @@ class AppContainer(private val context: Context) {
     /** Process-scoped protocol engines survive Activity recreation without orphaning sessions. */
     val vncEngine: VncEngine by lazy { SocketVncEngine() }
 
-    /** Reports unavailable until the packaged FreeRDP JNI library can be loaded. */
-    val rdpEngine: RdpEngine by lazy { AndroidRdpEngine() }
+    /**
+     * Packaged FreeRDP. The filesDir is the process HOME FreeRDP 3.30 requires
+     * before `freerdp_settings_new`; without it JNI create() returns 0.
+     */
+    val rdpEngine: RdpEngine by lazy { AndroidRdpEngine(context.filesDir) }
 
     /** Process-scoped SSH client. Direct password / key auth only. */
     val sshEngine: one.zephyr.mobile.protocol.ssh.SshEngine by lazy {

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/StartupThemeTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/StartupThemeTest.kt
@@ -36,6 +36,7 @@ class StartupThemeTest {
         assertFalse(source.contains("runBlocking"))
         assert(source.contains("readyState"))
         assert(source.contains("applicationScope.launch"))
+        assert(source.contains("RdpAndroidRuntime.installHome"))
     }
 
     @Test

--- a/zephyr_one/mobile/android/feature-remote/src/test/kotlin/one/zephyr/mobile/feature/remote/RdpViewModelOperationTest.kt
+++ b/zephyr_one/mobile/android/feature-remote/src/test/kotlin/one/zephyr/mobile/feature/remote/RdpViewModelOperationTest.kt
@@ -112,6 +112,29 @@ class RdpViewModelOperationTest {
     }
 
     @Test
+    fun unknownCertificateHoldsOnTheSessionPageUntilAccepted() = runTest(mainDispatcher) {
+        val engine = RecordingEngine(review = true)
+        val vm = viewModel(engine = engine)
+        backgroundScope.launch { vm.state.collect { } }
+        runCurrent()
+        vm.connect()
+        runCurrent()
+
+        val prompt = requireNotNull(content(vm).certificatePrompt)
+        assertEquals("AA:BB:CC:DD", prompt.review.sha256Fingerprint)
+        assertEquals(false, prompt.changed)
+        assertEquals(1, engine.connects)
+
+        vm.acceptCertificate()
+        runCurrent()
+        assertEquals(1, engine.trusts)
+        assertEquals(2, engine.connects)
+        assertNull(content(vm).certificatePrompt)
+        vm.disconnect()
+        runCurrent()
+    }
+
+    @Test
     fun disconnectClosesTheRegistryRowSoTheHostCanPopTheWindow() = runTest(mainDispatcher) {
         val registry = SessionRegistry()
         val engine = RecordingEngine()
@@ -171,27 +194,47 @@ class RdpViewModelOperationTest {
         return (state as PageState.Content<RemoteContent>).value
     }
 
-    private class RecordingEngine(private val available: Boolean = true) : RdpEngine {
+    private class RecordingEngine(
+        private val available: Boolean = true,
+        private val review: Boolean = false,
+    ) : RdpEngine {
         override val isAvailable: Boolean get() = available
         var lastRequest: RdpConnectRequest? = null
         var lastOutcome: RdpConnectOutcome? = null
         var disconnects = 0
+        var connects = 0
+        var trusts = 0
         val sent = mutableListOf<RdpInputEvent>()
 
         override suspend fun connect(request: RdpConnectRequest): RdpConnectOutcome {
             lastRequest = request
-            val outcome = if (!available) {
-                RdpConnectOutcome.Failed(
+            connects += 1
+            val outcome = when {
+                !available -> RdpConnectOutcome.Failed(
                     one.zephyr.mobile.model.MobileError.local(
                         AndroidRdpEngine.ENGINE_UNAVAILABLE,
                         "not packaged",
                     ),
                 )
-            } else {
-                RdpConnectOutcome.Connected(800, 600, request.channels)
+                review && trusts == 0 -> RdpConnectOutcome.CertificateReview(
+                    request = one.zephyr.mobile.protocol.rdp.RdpCertificateReview(
+                        host = request.host,
+                        port = request.port,
+                        subject = request.host,
+                        issuer = "",
+                        notBefore = 0L,
+                        notAfter = 0L,
+                        sha256Fingerprint = "AA:BB:CC:DD",
+                    ),
+                )
+                else -> RdpConnectOutcome.Connected(800, 600, request.channels)
             }
             lastOutcome = outcome
             return outcome
+        }
+
+        override suspend fun trustCertificate(sessionId: String, replaceExisting: Boolean) {
+            trusts += 1
         }
 
         override fun frames(sessionId: String): Flow<RdpFrame> = emptyFlow()

--- a/zephyr_one/mobile/android/protocol-rdp/NATIVE_BUILD.md
+++ b/zephyr_one/mobile/android/protocol-rdp/NATIVE_BUILD.md
@@ -35,12 +35,20 @@ clipboard reassembly patch used by `zephyr_one/native/freerdp-core`. Desktop
 `.lib` or host `.a` files are not compatible and CMake deliberately rejects a
 missing Android archive. Android zlib is linked from the NDK.
 
+Android never exports `HOME`. FreeRDP 3.30 `freerdp_settings_new` fails
+closed when `GetKnownPath(KNOWN_PATH_HOME)` is NULL, so the engine must
+`setenv("HOME", filesDir)` before the first `create()`. Official aFreeRDP
+does the same in `LibFreeRDP.freerdp_new`.
+
 The current C shim cannot yet implement two mobile contracts:
 
 - Certificate review: it exposes only a fingerprint log event, not certificate
-  DER, subject, issuer, validity, or a paused trust decision.
+  DER, subject, issuer, validity, or a paused trust decision. The Kotlin
+  engine therefore connects with verification on, captures the fingerprint,
+  prompts, and retries with `ignore_certificate` only after the user accepts
+  or a stored fingerprint matches.
 - SAF drive redirection: FreeRDP expects a POSIX directory path. A persisted
   Android document-tree URI needs a filesystem provider, not a fake path.
 
-Until those C ABI extensions exist, JNI keeps certificate verification enabled
-and rejects drive-enabled connect requests.
+Until a filesystem provider exists, JNI rejects drive-enabled connect
+requests.

--- a/zephyr_one/mobile/android/protocol-rdp/src/main/cpp/zephyr_rdp_jni.c
+++ b/zephyr_one/mobile/android/protocol-rdp/src/main/cpp/zephyr_rdp_jni.c
@@ -67,6 +67,13 @@ static void event_callback(void* user, int32_t code, int32_t a, int32_t b, const
         jstring message = text ? (*env)->NewStringUTF(env, text) : NULL;
         if (method) (*env)->CallVoidMethod(env, session->sink, method, a, message);
         if (message) (*env)->DeleteLocalRef(env, message);
+    } else if (code == ZEPHYR_RDP_EV_LOG && text && text[0]) {
+        jmethodID method = sink_method(env, session->sink, "onCertificateFingerprint",
+                                       "(Ljava/lang/String;)V");
+        jstring fingerprint = (*env)->NewStringUTF(env, text);
+        if (method && fingerprint)
+            (*env)->CallVoidMethod(env, session->sink, method, fingerprint);
+        if (fingerprint) (*env)->DeleteLocalRef(env, fingerprint);
     } else if (code == ZEPHYR_RDP_EV_CLIPBOARD && text && a >= 2 && (a % 2) == 0) {
         jmethodID method = sink_method(env, session->sink, "onClipboard", "(Ljava/lang/String;)V");
         const uint8_t* bytes = (const uint8_t*)text;
@@ -156,7 +163,9 @@ static char* copy_password(JNIEnv* env, jcharArray value) {
         }
     }
     memset(chars, 0, (size_t)units * sizeof(jchar));
-    (*env)->ReleaseCharArrayElements(env, value, chars, 0);
+    /* JNI_ABORT: do not write the zeros back. Kotlin may retry create()
+     * with the same CharArray after a certificate-fingerprint review. */
+    (*env)->ReleaseCharArrayElements(env, value, chars, JNI_ABORT);
     return result;
 }
 
@@ -172,32 +181,60 @@ Java_one_zephyr_mobile_protocol_rdp_JniRdpNativeBridge_create(
     jclass cls = (*env)->GetObjectClass(env, config);
     if (!cls) return 0;
 
-    char* host = copy_utf8(env, (jstring)(*env)->GetObjectField(env, config, field(env, cls, "host", "Ljava/lang/String;")));
-    char* username = copy_utf8(env, (jstring)(*env)->GetObjectField(env, config, field(env, cls, "username", "Ljava/lang/String;")));
-    char* domain = copy_utf8(env, (jstring)(*env)->GetObjectField(env, config, field(env, cls, "domain", "Ljava/lang/String;")));
-    char* password = copy_password(env, (jcharArray)(*env)->GetObjectField(env, config, field(env, cls, "password", "[C")));
+    jfieldID host_id = field(env, cls, "host", "Ljava/lang/String;");
+    jfieldID username_id = field(env, cls, "username", "Ljava/lang/String;");
+    jfieldID domain_id = field(env, cls, "domain", "Ljava/lang/String;");
+    jfieldID password_id = field(env, cls, "password", "[C");
+    jfieldID port_id = field(env, cls, "port", "I");
+    jfieldID width_id = field(env, cls, "widthPx", "I");
+    jfieldID height_id = field(env, cls, "heightPx", "I");
+    jfieldID audio_id = field(env, cls, "audio", "Z");
+    jfieldID microphone_id = field(env, cls, "microphone", "Z");
+    jfieldID clipboard_id = field(env, cls, "clipboard", "Z");
+    jfieldID gfx_id = field(env, cls, "gfx", "Z");
+    jfieldID wallpaper_id = field(env, cls, "disableWallpaper", "Z");
+    jfieldID themes_id = field(env, cls, "disableThemes", "Z");
+    jfieldID menu_id = field(env, cls, "disableMenuAnims", "Z");
+    jfieldID drag_id = field(env, cls, "disableFullWindowDrag", "Z");
+    jfieldID font_id = field(env, cls, "allowFontSmoothing", "Z");
+    jfieldID ignore_id = field(env, cls, "ignoreCertificate", "Z");
+    if (!host_id || !username_id || !domain_id || !password_id || !port_id || !width_id ||
+        !height_id || !audio_id || !microphone_id || !clipboard_id || !gfx_id || !wallpaper_id ||
+        !themes_id || !menu_id || !drag_id || !font_id || !ignore_id ||
+        (*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        (*env)->DeleteLocalRef(env, cls);
+        return 0;
+    }
+
+    char* host = copy_utf8(env, (jstring)(*env)->GetObjectField(env, config, host_id));
+    char* username = copy_utf8(env, (jstring)(*env)->GetObjectField(env, config, username_id));
+    char* domain = copy_utf8(env, (jstring)(*env)->GetObjectField(env, config, domain_id));
+    char* password = copy_password(env, (jcharArray)(*env)->GetObjectField(env, config, password_id));
 
     zephyr_rdp_config native_config = {0};
     native_config.host = host;
-    native_config.port = (uint32_t)(*env)->GetIntField(env, config, field(env, cls, "port", "I"));
+    native_config.port = (uint32_t)(*env)->GetIntField(env, config, port_id);
     native_config.username = username;
     native_config.password = password;
     native_config.domain = domain;
-    native_config.width = (uint32_t)(*env)->GetIntField(env, config, field(env, cls, "widthPx", "I"));
-    native_config.height = (uint32_t)(*env)->GetIntField(env, config, field(env, cls, "heightPx", "I"));
+    native_config.width = (uint32_t)(*env)->GetIntField(env, config, width_id);
+    native_config.height = (uint32_t)(*env)->GetIntField(env, config, height_id);
     native_config.color_depth = 32;
     native_config.security = ZEPHYR_RDP_SEC_NLA;
-    native_config.ignore_certificate = 0;
-    native_config.audio_mode = (*env)->GetBooleanField(env, config, field(env, cls, "audio", "Z")) ? ZEPHYR_RDP_AUDIO_LOCAL : ZEPHYR_RDP_AUDIO_OFF;
-    native_config.microphone = (*env)->GetBooleanField(env, config, field(env, cls, "microphone", "Z"));
-    native_config.clipboard = (*env)->GetBooleanField(env, config, field(env, cls, "clipboard", "Z"));
+    native_config.ignore_certificate = (*env)->GetBooleanField(env, config, ignore_id) ? 1 : 0;
+    native_config.audio_mode = (*env)->GetBooleanField(env, config, audio_id)
+        ? ZEPHYR_RDP_AUDIO_LOCAL
+        : ZEPHYR_RDP_AUDIO_OFF;
+    native_config.microphone = (*env)->GetBooleanField(env, config, microphone_id);
+    native_config.clipboard = (*env)->GetBooleanField(env, config, clipboard_id);
     native_config.dynamic_resolution = 1;
-    native_config.gfx = (*env)->GetBooleanField(env, config, field(env, cls, "gfx", "Z")) ? 1 : 0;
-    native_config.disable_wallpaper = (*env)->GetBooleanField(env, config, field(env, cls, "disableWallpaper", "Z")) ? 1 : 0;
-    native_config.disable_themes = (*env)->GetBooleanField(env, config, field(env, cls, "disableThemes", "Z")) ? 1 : 0;
-    native_config.disable_menu_anims = (*env)->GetBooleanField(env, config, field(env, cls, "disableMenuAnims", "Z")) ? 1 : 0;
-    native_config.disable_full_window_drag = (*env)->GetBooleanField(env, config, field(env, cls, "disableFullWindowDrag", "Z")) ? 1 : 0;
-    native_config.allow_font_smoothing = (*env)->GetBooleanField(env, config, field(env, cls, "allowFontSmoothing", "Z")) ? 1 : 0;
+    native_config.gfx = (*env)->GetBooleanField(env, config, gfx_id) ? 1 : 0;
+    native_config.disable_wallpaper = (*env)->GetBooleanField(env, config, wallpaper_id) ? 1 : 0;
+    native_config.disable_themes = (*env)->GetBooleanField(env, config, themes_id) ? 1 : 0;
+    native_config.disable_menu_anims = (*env)->GetBooleanField(env, config, menu_id) ? 1 : 0;
+    native_config.disable_full_window_drag = (*env)->GetBooleanField(env, config, drag_id) ? 1 : 0;
+    native_config.allow_font_smoothing = (*env)->GetBooleanField(env, config, font_id) ? 1 : 0;
 
     android_rdp_session* session = (android_rdp_session*)calloc(1, sizeof(*session));
     if (session) {

--- a/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngine.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngine.kt
@@ -1,5 +1,6 @@
 package one.zephyr.mobile.protocol.rdp
 
+import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -17,11 +18,25 @@ import one.zephyr.mobile.model.RdpChannel
 class AndroidRdpEngine internal constructor(
     private val native: RdpNativeBridge,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val fingerprints: RdpFingerprintBook = MemoryRdpFingerprintBook(),
+    homeDir: File? = null,
+    installHome: (File) -> Unit = { RdpAndroidRuntime.installHome(it) },
 ) : RdpEngine {
 
     constructor() : this(JniRdpNativeBridge)
 
+    constructor(filesDir: File) : this(
+        native = JniRdpNativeBridge,
+        fingerprints = FileRdpFingerprintBook(File(filesDir, TRUST_FILE_NAME)),
+        homeDir = filesDir,
+    )
+
     private val sessions = ConcurrentHashMap<String, Session>()
+    private val pendingReviews = ConcurrentHashMap<String, PendingReview>()
+
+    init {
+        if (homeDir != null) installHome(homeDir)
+    }
 
     override val isAvailable: Boolean
         get() = native.isAvailable
@@ -47,74 +62,40 @@ class AndroidRdpEngine internal constructor(
             return failure(SESSION_EXISTS, "An RDP session with this id already exists", retryable = false)
         }
 
-        val (width, height) = RdpGeometry.normalize(request.widthPx, request.heightPx)
-        val session = Session()
-        if (sessions.putIfAbsent(request.sessionId, session) != null) {
-            return failure(SESSION_EXISTS, "An RDP session with this id already exists", retryable = false)
-        }
-
-        val display = RdpDisplayPolicy.nativeFlags(request.quality)
-        val config = NativeRdpConfig(
-            host = request.host,
-            port = request.port,
-            username = request.username,
-            domain = request.domain,
-            password = request.password,
-            widthPx = width,
-            heightPx = height,
-            audio = RdpChannel.AUDIO in request.channels,
-            microphone = RdpChannel.MICROPHONE in request.channels,
-            clipboard = RdpChannel.CLIPBOARD in request.channels,
-            gfx = display.gfx,
-            disableWallpaper = display.disableWallpaper,
-            disableThemes = display.disableThemes,
-            disableMenuAnims = display.disableMenuAnims,
-            disableFullWindowDrag = display.disableFullWindowDrag,
-            allowFontSmoothing = display.allowFontSmoothing,
-            requestedFps = request.fps.value,
-        )
-
         return try {
-            val handle = native.create(config, session.sink)
-            if (handle == 0L) {
-                sessions.remove(request.sessionId, session)
-                return failure(SESSION_CREATE_FAILED, "FreeRDP rejected the session settings")
-            }
-            session.handle = handle
-            val thread = Thread({
-                try {
-                    val result = native.run(handle)
-                    session.connectEvents.trySend(
-                        ConnectEvent.Error(result, "FreeRDP exited before reporting a connection"),
-                    )
-                } catch (error: Throwable) {
-                    session.connectEvents.trySend(ConnectEvent.Error(-1, error.message))
-                } finally {
-                    sessions.remove(request.sessionId, session)
-                    session.free(native)
-                    session.runThread = null
+            val stored = fingerprints.find(request.host, request.port)
+            val first = openNative(request, ignoreCertificate = false)
+            val presented = first.fingerprint?.let(RdpFingerprintBook::normalize)?.takeIf { it.isNotEmpty() }
+            if (first.outcome is RdpConnectOutcome.Connected) return first.outcome
+            if (presented != null) {
+                if (stored != null && stored == presented) {
+                    return openNative(request, ignoreCertificate = true).outcome
                 }
-            }, "zephyr-rdp-${request.sessionId}").apply { isDaemon = true }
-            session.runThread = thread
-            thread.start()
-            session.runStarted = true
-
-            when (val event = session.connectEvents.receive()) {
-                is ConnectEvent.Connected -> RdpConnectOutcome.Connected(event.width, event.height, request.channels)
-                is ConnectEvent.Error -> {
-                    stopAndJoin(request.sessionId, session)
-                    failure(NATIVE_CONNECT_FAILED, event.message ?: "FreeRDP connect failed", true)
-                }
+                pendingReviews[request.sessionId] = PendingReview(request.host, request.port, presented)
+                return RdpConnectOutcome.CertificateReview(
+                    request = RdpCertificateReview(
+                        host = request.host,
+                        port = request.port,
+                        subject = request.host,
+                        issuer = "",
+                        notBefore = 0L,
+                        notAfter = 0L,
+                        sha256Fingerprint = presented,
+                    ),
+                    changed = stored != null,
+                    previousFingerprint = stored,
+                )
             }
-        } catch (error: CancellationException) {
-            withContext(NonCancellable) { stopAndJoin(request.sessionId, session) }
-            throw error
-        } catch (error: Throwable) {
-            stopAndJoin(request.sessionId, session)
-            failure(NATIVE_CONNECT_FAILED, error.message ?: "FreeRDP connect failed", true)
+            first.outcome
         } finally {
             request.password?.fill('\u0000')
         }
+    }
+
+    override suspend fun trustCertificate(sessionId: String, replaceExisting: Boolean) {
+        val pending = pendingReviews.remove(sessionId) ?: return
+        if (replaceExisting) fingerprints.remove(pending.host, pending.port)
+        fingerprints.put(pending.host, pending.port, pending.fingerprint)
     }
 
     override fun frames(sessionId: String): Flow<RdpFrame> =
@@ -142,11 +123,107 @@ class AndroidRdpEngine internal constructor(
         sessions[sessionId]?.clipboard ?: kotlinx.coroutines.flow.emptyFlow()
 
     override suspend fun disconnect(sessionId: String) {
+        pendingReviews.remove(sessionId)
         val session = sessions.remove(sessionId) ?: return
         session.stop(native)
         withContext(ioDispatcher) {
             val thread = session.runThread
             if (thread != null && thread !== Thread.currentThread()) thread.join()
+        }
+    }
+
+    private suspend fun openNative(
+        request: RdpConnectRequest,
+        ignoreCertificate: Boolean,
+    ): NativeAttempt {
+        if (sessions.containsKey(request.sessionId)) {
+            return NativeAttempt(failure(SESSION_EXISTS, "An RDP session with this id already exists", false))
+        }
+
+        val (width, height) = RdpGeometry.normalize(request.widthPx, request.heightPx)
+        val session = Session()
+        if (sessions.putIfAbsent(request.sessionId, session) != null) {
+            return NativeAttempt(failure(SESSION_EXISTS, "An RDP session with this id already exists", false))
+        }
+
+        val display = RdpDisplayPolicy.nativeFlags(request.quality)
+        // JNI copy_password historically wrote zeros back into the Java array.
+        // The stored-fingerprint retry is a second create() in this same connect(),
+        // so each attempt must own a fresh copy.
+        val attemptPassword = request.password?.copyOf()
+        val config = NativeRdpConfig(
+            host = request.host,
+            port = request.port,
+            username = request.username,
+            domain = request.domain,
+            password = attemptPassword,
+            widthPx = width,
+            heightPx = height,
+            audio = RdpChannel.AUDIO in request.channels,
+            microphone = RdpChannel.MICROPHONE in request.channels,
+            clipboard = RdpChannel.CLIPBOARD in request.channels,
+            gfx = display.gfx,
+            disableWallpaper = display.disableWallpaper,
+            disableThemes = display.disableThemes,
+            disableMenuAnims = display.disableMenuAnims,
+            disableFullWindowDrag = display.disableFullWindowDrag,
+            allowFontSmoothing = display.allowFontSmoothing,
+            requestedFps = request.fps.value,
+            ignoreCertificate = ignoreCertificate,
+        )
+
+        return try {
+            val handle = native.create(config, session.sink)
+            if (handle == 0L) {
+                sessions.remove(request.sessionId, session)
+                return NativeAttempt(
+                    failure(SESSION_CREATE_FAILED, "FreeRDP rejected the session settings"),
+                    session.fingerprint,
+                )
+            }
+            session.handle = handle
+            val thread = Thread({
+                try {
+                    val result = native.run(handle)
+                    session.connectEvents.trySend(
+                        ConnectEvent.Error(result, "FreeRDP exited before reporting a connection"),
+                    )
+                } catch (error: Throwable) {
+                    session.connectEvents.trySend(ConnectEvent.Error(-1, error.message))
+                } finally {
+                    sessions.remove(request.sessionId, session)
+                    session.free(native)
+                    session.runThread = null
+                }
+            }, "zephyr-rdp-${request.sessionId}").apply { isDaemon = true }
+            session.runThread = thread
+            thread.start()
+            session.runStarted = true
+
+            when (val event = session.connectEvents.receive()) {
+                is ConnectEvent.Connected -> NativeAttempt(
+                    RdpConnectOutcome.Connected(event.width, event.height, request.channels),
+                    session.fingerprint,
+                )
+                is ConnectEvent.Error -> {
+                    stopAndJoin(request.sessionId, session)
+                    NativeAttempt(
+                        failure(NATIVE_CONNECT_FAILED, event.message ?: "FreeRDP connect failed", true),
+                        session.fingerprint,
+                    )
+                }
+            }
+        } catch (error: CancellationException) {
+            withContext(NonCancellable) { stopAndJoin(request.sessionId, session) }
+            throw error
+        } catch (error: Throwable) {
+            stopAndJoin(request.sessionId, session)
+            NativeAttempt(
+                failure(NATIVE_CONNECT_FAILED, error.message ?: "FreeRDP connect failed", true),
+                session.fingerprint,
+            )
+        } finally {
+            attemptPassword?.fill('\u0000')
         }
     }
 
@@ -167,6 +244,7 @@ class AndroidRdpEngine internal constructor(
         @Volatile var handle: Long = 0L
         @Volatile var runStarted: Boolean = false
         @Volatile var runThread: Thread? = null
+        @Volatile var fingerprint: String? = null
         private var pointerButtons: Int = 0
 
         val connectEvents = Channel<ConnectEvent>(capacity = 1)
@@ -193,6 +271,10 @@ class AndroidRdpEngine internal constructor(
 
             override fun onClipboard(text: String) {
                 clipboard.tryEmit(text)
+            }
+
+            override fun onCertificateFingerprint(value: String) {
+                fingerprint = value
             }
         }
 
@@ -260,6 +342,17 @@ class AndroidRdpEngine internal constructor(
         data class Error(val code: Int, val message: String?) : ConnectEvent
     }
 
+    private data class NativeAttempt(
+        val outcome: RdpConnectOutcome,
+        val fingerprint: String? = null,
+    )
+
+    private data class PendingReview(
+        val host: String,
+        val port: Int,
+        val fingerprint: String,
+    )
+
     companion object {
         const val ENGINE_UNAVAILABLE = "rdp_engine_unavailable"
         const val DRIVE_UNSUPPORTED = "rdp_drive_provider_unavailable"
@@ -267,6 +360,7 @@ class AndroidRdpEngine internal constructor(
         const val SESSION_EXISTS = "rdp_session_exists"
         const val SESSION_CREATE_FAILED = "rdp_session_create_failed"
         const val NATIVE_CONNECT_FAILED = "rdp_connect_failed"
+        const val TRUST_FILE_NAME = "rdp-trust.properties"
         private const val FRAME_BUFFER_CAPACITY = 32
         private const val CLIPBOARD_BUFFER_CAPACITY = 4
         private const val MAX_WHEEL_STEP = 255
@@ -295,6 +389,7 @@ internal data class NativeRdpConfig(
     val disableFullWindowDrag: Boolean = true,
     val allowFontSmoothing: Boolean = true,
     val requestedFps: Int = 30,
+    val ignoreCertificate: Boolean = false,
 )
 
 internal interface NativeRdpSink {
@@ -302,6 +397,7 @@ internal interface NativeRdpSink {
     fun onError(code: Int, message: String?)
     fun onFrame(x: Int, y: Int, width: Int, height: Int, rgba: ByteArray)
     fun onClipboard(text: String)
+    fun onCertificateFingerprint(fingerprint: String)
 }
 
 internal interface RdpNativeBridge {

--- a/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpAndroidRuntime.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpAndroidRuntime.kt
@@ -1,0 +1,32 @@
+package one.zephyr.mobile.protocol.rdp
+
+import java.io.File
+
+/**
+ * Process environment FreeRDP 3.30 requires before `freerdp_settings_new`.
+ *
+ * Android never exports `HOME`. WinPR then returns NULL from `GetKnownPath(KNOWN_PATH_HOME)`,
+ * `freerdp_settings_new` fails, `zephyr_rdp_new` returns NULL, and JNI `create()` reports
+ * `rdp_session_create_failed` before any TCP packet is sent. Official aFreeRDP does the same
+ * `setenv("HOME", filesDir)` in `freerdp_new`.
+ */
+object RdpAndroidRuntime {
+
+    const val HOME_ENV = "HOME"
+
+    fun installHome(
+        filesDir: File,
+        setEnv: (name: String, value: String) -> Unit = { name, value -> setProcessEnv(name, value) },
+    ): String {
+        val path = filesDir.absoluteFile.apply { mkdirs() }.absolutePath
+        require(path.isNotBlank()) { "RDP HOME directory is blank" }
+        setEnv(HOME_ENV, path)
+        return path
+    }
+
+    internal fun setProcessEnv(name: String, value: String) {
+        val os = Class.forName("android.system.Os")
+        val method = os.getMethod("setenv", String::class.java, String::class.java, Boolean::class.javaPrimitiveType)
+        method.invoke(null, name, value, true)
+    }
+}

--- a/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBook.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBook.kt
@@ -29,10 +29,14 @@ interface RdpFingerprintBook {
             }
             val hex = buildString(value.length) {
                 for (ch in value) {
-                    if (ch in '0'..'9' || ch in 'a'..'f' || ch in 'A'..'F') append(ch.uppercaseChar())
+                    when (ch) {
+                        ' ', '\t', ':', '-' -> Unit
+                        in '0'..'9', in 'a'..'f', in 'A'..'F' -> append(ch.uppercaseChar())
+                        else -> return ""
+                    }
                 }
             }
-            if (hex.isEmpty()) return ""
+            if (hex.isEmpty() || hex.length % 2 != 0) return ""
             return hex.chunked(2).joinToString(":")
         }
     }

--- a/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBook.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBook.kt
@@ -1,0 +1,108 @@
+package one.zephyr.mobile.protocol.rdp
+
+import java.io.File
+import java.util.Locale
+import java.util.Properties
+
+/**
+ * Host:port → SHA-256 fingerprint allowlist for the Android FreeRDP shim.
+ *
+ * The C ABI only exposes the fingerprint on `ZEPHYR_RDP_EV_LOG` and a boolean
+ * `ignore_certificate`. It cannot pause for a UI decision. The engine therefore
+ * connects with verification on, captures the fingerprint, and either prompts or
+ * retries with `ignore_certificate` when the stored value matches.
+ */
+interface RdpFingerprintBook {
+    fun find(host: String, port: Int): String?
+    fun put(host: String, port: Int, fingerprint: String)
+    fun remove(host: String, port: Int)
+
+    companion object {
+        fun key(host: String, port: Int): String =
+            host.trim().lowercase(Locale.ROOT) + ":" + port
+
+        fun normalize(raw: String): String {
+            var value = raw.trim()
+            val algo = value.substringBefore(':', missingDelimiterValue = "")
+            if (algo.equals("sha256", ignoreCase = true) || algo.equals("sha1", ignoreCase = true)) {
+                value = value.substringAfter(':')
+            }
+            val hex = buildString(value.length) {
+                for (ch in value) {
+                    if (ch in '0'..'9' || ch in 'a'..'f' || ch in 'A'..'F') append(ch.uppercaseChar())
+                }
+            }
+            if (hex.isEmpty()) return ""
+            return hex.chunked(2).joinToString(":")
+        }
+    }
+}
+
+class MemoryRdpFingerprintBook : RdpFingerprintBook {
+    private val values = LinkedHashMap<String, String>()
+
+    @Synchronized
+    override fun find(host: String, port: Int): String? = values[RdpFingerprintBook.key(host, port)]
+
+    @Synchronized
+    override fun put(host: String, port: Int, fingerprint: String) {
+        val normalized = RdpFingerprintBook.normalize(fingerprint)
+        if (normalized.isEmpty()) return
+        values[RdpFingerprintBook.key(host, port)] = normalized
+    }
+
+    @Synchronized
+    override fun remove(host: String, port: Int) {
+        values.remove(RdpFingerprintBook.key(host, port))
+    }
+}
+
+class FileRdpFingerprintBook(private val file: File) : RdpFingerprintBook {
+    private val lock = Any()
+
+    override fun find(host: String, port: Int): String? = synchronized(lock) {
+        load()[RdpFingerprintBook.key(host, port)]
+    }
+
+    override fun put(host: String, port: Int, fingerprint: String) {
+        val normalized = RdpFingerprintBook.normalize(fingerprint)
+        if (normalized.isEmpty()) return
+        synchronized(lock) {
+            val values = load()
+            values[RdpFingerprintBook.key(host, port)] = normalized
+            save(values)
+        }
+    }
+
+    override fun remove(host: String, port: Int) {
+        synchronized(lock) {
+            val values = load()
+            if (values.remove(RdpFingerprintBook.key(host, port)) != null) save(values)
+        }
+    }
+
+    private fun load(): LinkedHashMap<String, String> {
+        val values = LinkedHashMap<String, String>()
+        if (!file.isFile) return values
+        val properties = Properties()
+        file.inputStream().use { properties.load(it) }
+        for ((rawKey, rawValue) in properties) {
+            val key = (rawKey as? String)?.trim().orEmpty()
+            val value = RdpFingerprintBook.normalize((rawValue as? String).orEmpty())
+            if (key.isNotEmpty() && value.isNotEmpty()) values[key] = value
+        }
+        return values
+    }
+
+    private fun save(values: Map<String, String>) {
+        file.parentFile?.mkdirs()
+        val properties = Properties()
+        for ((key, value) in values) properties[key] = value
+        val staging = File(file.parentFile, file.name + ".tmp")
+        staging.outputStream().use { properties.store(it, "Zephyr One RDP fingerprints") }
+        if (!staging.renameTo(file)) {
+            staging.copyTo(file, overwrite = true)
+            staging.delete()
+        }
+    }
+}

--- a/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngineTest.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngineTest.kt
@@ -1,5 +1,6 @@
 package one.zephyr.mobile.protocol.rdp
 
+import java.io.File
 import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
@@ -121,6 +122,89 @@ class AndroidRdpEngineTest {
         engine.disconnect("s1")
     }
 
+    @Test
+    fun `create returning zero is session create failed`() = runTest {
+        val native = FakeNative(createHandle = 0L)
+        val engine = AndroidRdpEngine(native)
+
+        val outcome = engine.connect(request()) as RdpConnectOutcome.Failed
+
+        assertEquals(AndroidRdpEngine.SESSION_CREATE_FAILED, outcome.error.code)
+        assertEquals(1, native.createCalls)
+        assertEquals(0, native.freeCalls)
+    }
+
+    @Test
+    fun `filesDir constructor installs HOME before JNI create`() = runTest {
+        val native = FakeNative()
+        val homes = mutableListOf<File>()
+        val files = File.createTempFile("rdp-home", "dir").apply {
+            delete()
+            mkdirs()
+            deleteOnExit()
+        }
+        val engine = AndroidRdpEngine(
+            native = native,
+            homeDir = files,
+            installHome = { homes += it },
+        )
+
+        engine.connect(request())
+
+        assertEquals(listOf(files), homes)
+        engine.disconnect("s1")
+    }
+
+    @Test
+    fun `unknown fingerprint becomes a certificate review and is not retried`() = runTest {
+        val native = FakeNative(connectResult = FakeConnect.Reject("sha256:aabbccdd"))
+        val book = MemoryRdpFingerprintBook()
+        val engine = AndroidRdpEngine(native, fingerprints = book)
+
+        val outcome = engine.connect(request()) as RdpConnectOutcome.CertificateReview
+
+        assertEquals("AA:BB:CC:DD", outcome.request.sha256Fingerprint)
+        assertEquals(false, outcome.changed)
+        assertEquals(1, native.createCalls)
+        assertEquals(false, native.config?.ignoreCertificate)
+        assertEquals(null, book.find("server", 3389))
+
+        engine.trustCertificate("s1")
+        assertEquals("AA:BB:CC:DD", book.find("server", 3389))
+    }
+
+    @Test
+    fun `stored fingerprint retries once with ignoreCertificate`() = runTest {
+        val native = FakeNative(connectResult = FakeConnect.RejectThenAccept("aa:bb:cc:dd"))
+        val book = MemoryRdpFingerprintBook().apply { put("server", 3389, "AABBCCDD") }
+        val engine = AndroidRdpEngine(native, fingerprints = book)
+        val password = "secret".toCharArray()
+
+        val outcome = engine.connect(request(password = password))
+
+        assertEquals(RdpConnectOutcome.Connected(1080, 2400, setOf(RdpChannel.CLIPBOARD)), outcome)
+        assertEquals(2, native.createCalls)
+        assertEquals(true, native.config?.ignoreCertificate)
+        assertEquals(listOf("secret", "secret"), native.passwords)
+        assertArrayEquals(CharArray(password.size), password)
+        engine.disconnect("s1")
+    }
+
+    @Test
+    fun `changed fingerprint blocks instead of retrying with ignoreCertificate`() = runTest {
+        val native = FakeNative(connectResult = FakeConnect.Reject("sha256:ddeeff00"))
+        val book = MemoryRdpFingerprintBook().apply { put("server", 3389, "AABBCCDD") }
+        val engine = AndroidRdpEngine(native, fingerprints = book)
+
+        val outcome = engine.connect(request()) as RdpConnectOutcome.CertificateReview
+
+        assertEquals(true, outcome.changed)
+        assertEquals("AA:BB:CC:DD", outcome.previousFingerprint)
+        assertEquals("DD:EE:FF:00", outcome.request.sha256Fingerprint)
+        assertEquals(1, native.createCalls)
+        assertEquals(false, native.config?.ignoreCertificate)
+    }
+
     private fun request(password: CharArray? = null) = RdpConnectRequest(
         sessionId = "s1",
         host = "server",
@@ -142,13 +226,24 @@ class AndroidRdpEngineTest {
         sessionId, host, port, username, domain, password, widthPx, heightPx, channels, drive, quality, fps,
     )
 
-    private class FakeNative(private val available: Boolean = true) : RdpNativeBridge {
+    private sealed interface FakeConnect {
+        data object Accept : FakeConnect
+        data class Reject(val fingerprint: String? = null) : FakeConnect
+        data class RejectThenAccept(val fingerprint: String) : FakeConnect
+    }
+
+    private class FakeNative(
+        private val available: Boolean = true,
+        private val createHandle: Long = 7L,
+        private val connectResult: FakeConnect = FakeConnect.Accept,
+    ) : RdpNativeBridge {
         private val stopped = CountDownLatch(1)
         @Volatile var sink: NativeRdpSink? = null
         @Volatile var config: NativeRdpConfig? = null
         @Volatile var createCalls = 0
         @Volatile var stopCalls = 0
         @Volatile var freeCalls = 0
+        val passwords = mutableListOf<String>()
         val pointerEvents = mutableListOf<String>()
         val unicodeEvents = mutableListOf<Pair<Int, Boolean>>()
 
@@ -159,13 +254,35 @@ class AndroidRdpEngineTest {
             createCalls++
             this.config = config
             this.sink = sink
-            return 7L
+            passwords += config.password?.concatToString() ?: ""
+            config.password?.fill('\u0000')
+            return createHandle
         }
 
         override fun run(handle: Long): Int {
-            sink?.onConnected(1080, 2400)
-            stopped.await()
-            return 0
+            val result = connectResult
+            val accept = when (result) {
+                FakeConnect.Accept -> true
+                is FakeConnect.Reject -> {
+                    result.fingerprint?.let { sink?.onCertificateFingerprint(it) }
+                    false
+                }
+                is FakeConnect.RejectThenAccept -> {
+                    if (!config!!.ignoreCertificate) {
+                        sink?.onCertificateFingerprint(result.fingerprint)
+                        false
+                    } else {
+                        true
+                    }
+                }
+            }
+            if (accept) {
+                sink?.onConnected(1080, 2400)
+                stopped.await()
+                return 0
+            }
+            sink?.onError(-2, "certificate rejected")
+            return -2
         }
 
         override fun stop(handle: Long) { stopCalls++; stopped.countDown() }

--- a/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/RdpAndroidRuntimeTest.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/RdpAndroidRuntimeTest.kt
@@ -1,0 +1,26 @@
+package one.zephyr.mobile.protocol.rdp
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class RdpAndroidRuntimeTest {
+
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    @Test
+    fun `installHome exports filesDir as HOME and creates the directory`() {
+        val files = File(folder.root, "files")
+        val env = mutableMapOf<String, String>()
+
+        val path = RdpAndroidRuntime.installHome(files) { name, value -> env[name] = value }
+
+        assertTrue(files.isDirectory)
+        assertEquals(files.absolutePath, path)
+        assertEquals(files.absolutePath, env[RdpAndroidRuntime.HOME_ENV])
+    }
+}

--- a/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBookTest.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBookTest.kt
@@ -1,0 +1,37 @@
+package one.zephyr.mobile.protocol.rdp
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class RdpFingerprintBookTest {
+
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    @Test
+    fun `normalize strips sha256 prefix and colonates hex`() {
+        assertEquals(
+            "AA:BB:CC:DD",
+            RdpFingerprintBook.normalize("sha256:aabbccdd"),
+        )
+        assertEquals(
+            "AA:BB:CC:DD",
+            RdpFingerprintBook.normalize("AA:bb:CC:dd"),
+        )
+        assertEquals("", RdpFingerprintBook.normalize("not-hex"))
+    }
+
+    @Test
+    fun `file book survives a process restart`() {
+        val file = File(folder.root, "rdp-trust.properties")
+        FileRdpFingerprintBook(file).put("WIN-LAB", 3389, "sha256:aabbccdd")
+
+        val reloaded = FileRdpFingerprintBook(file)
+        assertEquals("AA:BB:CC:DD", reloaded.find("win-lab", 3389))
+        assertNull(reloaded.find("win-lab", 3390))
+    }
+}

--- a/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBookTest.kt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/test/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBookTest.kt
@@ -22,7 +22,10 @@ class RdpFingerprintBookTest {
             "AA:BB:CC:DD",
             RdpFingerprintBook.normalize("AA:bb:CC:dd"),
         )
+        assertEquals("AA:BB:CC:DD", RdpFingerprintBook.normalize("aabb-ccdd"))
         assertEquals("", RdpFingerprintBook.normalize("not-hex"))
+        assertEquals("", RdpFingerprintBook.normalize("aa:bb:c"))
+        assertEquals("", RdpFingerprintBook.normalize(""))
     }
 
     @Test

--- a/zephyr_one/mobile/tests/rdp-android-create-replica.py
+++ b/zephyr_one/mobile/tests/rdp-android-create-replica.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Replica of Android RDP create/HOME/certificate decisions.
+
+Fails if the production sources lose the HOME install or start auto-accepting
+an unknown / changed fingerprint. Independent of Gradle.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ENGINE = ROOT / "android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngine.kt"
+RUNTIME = ROOT / "android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpAndroidRuntime.kt"
+JNI = ROOT / "android/protocol-rdp/src/main/cpp/zephyr_rdp_jni.c"
+APP = ROOT / "android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt"
+CONTAINER = ROOT / "android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt"
+
+
+def normalize(raw: str) -> str:
+    value = raw.strip()
+    algo = value.split(":", 1)[0]
+    if algo.lower() in {"sha256", "sha1"}:
+        value = value.split(":", 1)[1]
+    hex_chars = "".join(ch.upper() for ch in value if ch in "0123456789abcdefABCDEF")
+    if not hex_chars:
+        return ""
+    return ":".join(hex_chars[i : i + 2] for i in range(0, len(hex_chars), 2))
+
+
+def decide(stored: str | None, presented: str | None, create_ok: bool) -> str:
+    if not create_ok:
+        return "create_failed"
+    if presented:
+        presented = normalize(presented)
+    if presented and stored == presented:
+        return "retry_ignore"
+    if presented:
+        return "review_changed" if stored else "review_first"
+    return "connect_failed"
+
+
+def must_contain(path: pathlib.Path, *needles: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    for needle in needles:
+        if needle not in text:
+            raise AssertionError(f"{path.name} missing {needle!r}")
+
+
+def must_not_contain(path: pathlib.Path, *needles: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    for needle in needles:
+        if needle in text:
+            raise AssertionError(f"{path.name} unexpectedly contains {needle!r}")
+
+
+def main() -> int:
+    must_contain(RUNTIME, 'const val HOME_ENV = "HOME"', "android.system.Os", "setenv")
+    must_contain(APP, "RdpAndroidRuntime.installHome(filesDir)")
+    must_contain(CONTAINER, "AndroidRdpEngine(context.filesDir)")
+    must_not_contain(CONTAINER, "AndroidRdpEngine()")
+    must_contain(
+        ENGINE,
+        "SESSION_CREATE_FAILED",
+        "CertificateReview",
+        "ignoreCertificate",
+        "pendingReviews",
+        "request.password?.copyOf()",
+    )
+    must_contain(
+        JNI,
+        "ignoreCertificate",
+        "ZEPHYR_RDP_EV_LOG",
+        "onCertificateFingerprint",
+        "JNI_ABORT",
+    )
+    engine = ENGINE.read_text(encoding="utf-8")
+    if re.search(r"ignoreCertificate\s*=\s*true", engine) and "stored != null && stored == presented" not in engine:
+        raise AssertionError("engine would ignore certificates without a stored match")
+
+    cases = [
+        (None, None, False, "create_failed"),
+        (None, None, True, "connect_failed"),
+        (None, "sha256:aabbccdd", True, "review_first"),
+        ("AA:BB:CC:DD", "sha256:aabbccdd", True, "retry_ignore"),
+        ("AA:BB:CC:DD", "sha256:ddeeff00", True, "review_changed"),
+        ("AA:BB:CC:DD", None, True, "connect_failed"),
+    ]
+    for stored, presented, create_ok, expected in cases:
+        got = decide(stored, presented, create_ok)
+        if got != expected:
+            raise AssertionError(f"{stored!r} {presented!r} {create_ok} -> {got}, want {expected}")
+
+    if normalize("sha256:aabbccdd") != "AA:BB:CC:DD":
+        raise AssertionError("normalize replica drifted")
+    print("rdp-android-create-replica: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr_one/mobile/tests/rdp-android-create-replica.py
+++ b/zephyr_one/mobile/tests/rdp-android-create-replica.py
@@ -21,12 +21,19 @@ CONTAINER = ROOT / "android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppCont
 def normalize(raw: str) -> str:
     value = raw.strip()
     algo = value.split(":", 1)[0]
-    if algo.lower() in {"sha256", "sha1"}:
+    if algo.lower() in {"sha256", "sha1"} and ":" in value:
         value = value.split(":", 1)[1]
-    hex_chars = "".join(ch.upper() for ch in value if ch in "0123456789abcdefABCDEF")
-    if not hex_chars:
+    hex_chars = []
+    for ch in value:
+        if ch in " \t:-":
+            continue
+        if ch in "0123456789abcdefABCDEF":
+            hex_chars.append(ch.upper())
+        else:
+            return ""
+    if not hex_chars or len(hex_chars) % 2:
         return ""
-    return ":".join(hex_chars[i : i + 2] for i in range(0, len(hex_chars), 2))
+    return ":".join("".join(hex_chars[i : i + 2]) for i in range(0, len(hex_chars), 2))
 
 
 def decide(stored: str | None, presented: str | None, create_ok: bool) -> str:
@@ -94,6 +101,12 @@ def main() -> int:
 
     if normalize("sha256:aabbccdd") != "AA:BB:CC:DD":
         raise AssertionError("normalize replica drifted")
+    if normalize("not-hex") != "":
+        raise AssertionError("normalize must reject leftover letters")
+    if normalize("aa:bb:c") != "":
+        raise AssertionError("normalize must reject odd-length hex")
+    book = ROOT / "android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpFingerprintBook.kt"
+    must_contain(book, "else -> return \"\"", "hex.length % 2 != 0")
     print("rdp-android-create-replica: ok")
     return 0
 

--- a/zephyr_one/mobile/tests/rdp-android-engine-replica.py
+++ b/zephyr_one/mobile/tests/rdp-android-engine-replica.py
@@ -24,10 +24,17 @@ def normalize(raw: str | None) -> str:
     algo = value.split(":", 1)[0]
     if algo.lower() in {"sha256", "sha1"} and ":" in value:
         value = value.split(":", 1)[1]
-    hex_chars = "".join(ch.upper() for ch in value if ch in "0123456789abcdefABCDEF")
-    if not hex_chars:
+    hex_chars: list[str] = []
+    for ch in value:
+        if ch in " \t:-":
+            continue
+        if ch in "0123456789abcdefABCDEF":
+            hex_chars.append(ch.upper())
+        else:
+            return ""
+    if not hex_chars or len(hex_chars) % 2:
         return ""
-    return ":".join(hex_chars[i : i + 2] for i in range(0, len(hex_chars), 2))
+    return ":".join("".join(hex_chars[i : i + 2]) for i in range(0, len(hex_chars), 2))
 
 
 class FakeNative:

--- a/zephyr_one/mobile/tests/rdp-android-engine-replica.py
+++ b/zephyr_one/mobile/tests/rdp-android-engine-replica.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Behaviour replica of AndroidRdpEngine.connect / trustCertificate.
+
+Mirrors the Kotlin control flow closely enough that deleting the password
+copy, auto-ignoring an unknown cert, or retrying a changed fingerprint
+makes this file fail. No FreeRDP / Gradle required.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ENGINE = (
+    ROOT
+    / "android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngine.kt"
+)
+
+
+def normalize(raw: str | None) -> str:
+    if not raw:
+        return ""
+    value = raw.strip()
+    algo = value.split(":", 1)[0]
+    if algo.lower() in {"sha256", "sha1"} and ":" in value:
+        value = value.split(":", 1)[1]
+    hex_chars = "".join(ch.upper() for ch in value if ch in "0123456789abcdefABCDEF")
+    if not hex_chars:
+        return ""
+    return ":".join(hex_chars[i : i + 2] for i in range(0, len(hex_chars), 2))
+
+
+class FakeNative:
+    def __init__(self, mode: str, fingerprint: str | None = None, create_ok: bool = True):
+        self.mode = mode
+        self.fingerprint = fingerprint
+        self.create_ok = create_ok
+        self.create_calls = 0
+        self.passwords: list[str] = []
+        self.ignore_flags: list[bool] = []
+
+    def open(self, password: list[str], ignore: bool) -> tuple[str, str | None]:
+        self.create_calls += 1
+        self.passwords.append("".join(password))
+        self.ignore_flags.append(ignore)
+        password[:] = ["\0"] * len(password)
+        if not self.create_ok:
+            return "create_failed", None
+        if self.mode == "accept":
+            return "connected", None
+        if self.mode == "reject":
+            return "connect_failed", self.fingerprint
+        if self.mode == "reject_then_accept":
+            if ignore:
+                return "connected", self.fingerprint
+            return "connect_failed", self.fingerprint
+        raise AssertionError(self.mode)
+
+
+def connect(native: FakeNative, stored: str | None, password: str) -> dict:
+    source = list(password)
+    first_copy = source.copy()
+    first_status, presented = native.open(first_copy, False)
+    presented_n = normalize(presented)
+    if first_status == "connected":
+        source[:] = ["\0"] * len(source)
+        return {"status": "connected", "presented": presented_n}
+    if first_status == "create_failed":
+        source[:] = ["\0"] * len(source)
+        return {"status": "create_failed", "presented": presented_n}
+    if presented_n:
+        if stored and stored == presented_n:
+            second_copy = source.copy()
+            second_status, _ = native.open(second_copy, True)
+            source[:] = ["\0"] * len(source)
+            return {"status": second_status if second_status == "connected" else "retry_failed"}
+        source[:] = ["\0"] * len(source)
+        return {
+            "status": "review_changed" if stored else "review_first",
+            "presented": presented_n,
+            "previous": stored,
+        }
+    source[:] = ["\0"] * len(source)
+    return {"status": "connect_failed", "presented": ""}
+
+
+def must_engine() -> None:
+    text = ENGINE.read_text(encoding="utf-8")
+    for needle in (
+        "request.password?.copyOf()",
+        "stored != null && stored == presented",
+        "ignoreCertificate = ignoreCertificate",
+        "CertificateReview",
+        "SESSION_CREATE_FAILED",
+    ):
+        if needle not in text:
+            raise AssertionError(f"engine missing {needle!r}")
+    compact = "".join(text.split())
+    if "ignoreCertificate=true," in compact:
+        raise AssertionError("NativeRdpConfig hardcodes ignoreCertificate=true")
+    if "ignoreCertificate=ignoreCertificate" not in compact:
+        raise AssertionError("NativeRdpConfig must take the per-attempt flag")
+    if "openNative(request,ignoreCertificate=false)" not in compact:
+        raise AssertionError("first create must verify the certificate")
+    if "openNative(request,ignoreCertificate=true)" not in compact:
+        raise AssertionError("stored-fingerprint retry must set ignoreCertificate=true")
+
+
+def main() -> int:
+    must_engine()
+
+    native = FakeNative("accept")
+    got = connect(native, None, "secret")
+    assert got["status"] == "connected", got
+    assert native.create_calls == 1
+    assert native.passwords == ["secret"]
+
+    native = FakeNative("accept", create_ok=False)
+    got = connect(native, None, "secret")
+    assert got["status"] == "create_failed", got
+    assert native.create_calls == 1
+
+    native = FakeNative("reject", fingerprint="sha256:aabbccdd")
+    got = connect(native, None, "secret")
+    assert got == {"status": "review_first", "presented": "AA:BB:CC:DD", "previous": None}, got
+    assert native.create_calls == 1
+    assert native.ignore_flags == [False]
+
+    native = FakeNative("reject_then_accept", fingerprint="aa:bb:cc:dd")
+    got = connect(native, "AA:BB:CC:DD", "secret")
+    assert got["status"] == "connected", got
+    assert native.create_calls == 2
+    assert native.passwords == ["secret", "secret"]
+    assert native.ignore_flags == [False, True]
+
+    native = FakeNative("reject", fingerprint="sha256:ddeeff00")
+    got = connect(native, "AA:BB:CC:DD", "secret")
+    assert got["status"] == "review_changed", got
+    assert got["presented"] == "DD:EE:FF:00"
+    assert native.create_calls == 1
+    assert native.ignore_flags == [False]
+
+    print("rdp-android-engine-replica: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
+++ b/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -36,4 +37,40 @@ test('CI packages the Android FreeRDP JNI library into the APK', () => {
   assert.match(workflow, /build-freerdp-android\.sh arm64-v8a/);
   assert.match(workflow, /ZEPHYR_ANDROID_FREERDP_ROOT/);
   assert.match(workflow, /lib\/arm64-v8a\/libzephyr_rdp_android\.so/);
+});
+
+test('Android installs filesDir as HOME before FreeRDP create', () => {
+  const runtime = read(path.join(ROOT, 'android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/RdpAndroidRuntime.kt'));
+  assert.match(runtime, /android\.system\.Os/);
+  assert.match(runtime, /setenv/);
+  assert.match(runtime, /HOME/);
+  const application = read(path.join(ROOT, 'android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt'));
+  assert.match(application, /RdpAndroidRuntime\.installHome\(filesDir\)/);
+  const container = read(path.join(ROOT, 'android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt'));
+  assert.match(container, /AndroidRdpEngine\(context\.filesDir\)/);
+  assert.doesNotMatch(container, /AndroidRdpEngine\(\)/);
+});
+
+test('JNI create fails closed when HOME is missing and surfaces the certificate fingerprint', () => {
+  const engine = read(path.join(ROOT, 'android/protocol-rdp/src/main/kotlin/one/zephyr/mobile/protocol/rdp/AndroidRdpEngine.kt'));
+  assert.match(engine, /SESSION_CREATE_FAILED/);
+  assert.match(engine, /CertificateReview/);
+  assert.match(engine, /ignoreCertificate/);
+  assert.match(engine, /stored != null && stored == presented/);
+  const jni = read(path.join(ROOT, 'android/protocol-rdp/src/main/cpp/zephyr_rdp_jni.c'));
+  assert.match(jni, /ignoreCertificate/);
+  assert.match(jni, /ZEPHYR_RDP_EV_LOG/);
+  assert.match(jni, /onCertificateFingerprint/);
+});
+
+test('create/HOME replica rejects a missing HOME install and unknown-cert auto-accept', () => {
+  const replica = path.join(ROOT, 'tests/rdp-android-create-replica.py');
+  const result = spawnSync('python3', [replica], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});
+
+test('engine replica keeps the password across a stored-fingerprint retry', () => {
+  const replica = path.join(ROOT, 'tests/rdp-android-engine-replica.py');
+  const result = spawnSync('python3', [replica], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
 });


### PR DESCRIPTION
## 现象

Android 打开 RDP 立刻失败，错误码 `rdp_session_create_failed`。这不是连不上服务器：`native.create()` 在 `zephyr_rdp_new()` 阶段就返回了 0。

## 根因

FreeRDP 3.30 `freerdp_settings_new()` 在客户端模式里强制：

```c
path = GetKnownPath(KNOWN_PATH_HOME);
if (!rc || !freerdp_settings_get_string(settings, FreeRDP_HomePath))
    goto out_fail;
```

WinPR 的 `GetPath_HOME()` 只读环境变量 `HOME`。Android 进程默认没有这个变量，所以 settings 组装失败，JNI `create()` 返回 0。官方 aFreeRDP 在 `LibFreeRDP.freerdp_new` 里会 `setenv("HOME", filesDir)`；我们漏了这一步。

次因：证书校验开着，自签 Windows 主机连上后也会立刻被拒，而且 JNI 只把指纹打到 `ZEPHYR_RDP_EV_LOG`，Kotlin 没接，UI 无法审查/记住。

## 修复

1. `RdpAndroidRuntime.installHome(filesDir)`：进程启动和引擎构造时把 `HOME` 设成应用 filesDir。
2. `AppContainer` 改为 `AndroidRdpEngine(context.filesDir)`，不再走无 HOME 的默认构造。
3. JNI 把 `ZEPHYR_RDP_EV_LOG` 转成 `onCertificateFingerprint`。未知指纹进入 `CertificateReview`；已记住的相同指纹才二次 `create(ignoreCertificate=true)`；指纹变了不自动放行。
4. 每次 `create()` 复制一份密码，JNI `copy_password` 改为 `JNI_ABORT`，避免第二次 create 带上空密码。

## 验证

沙箱 JVM 无法执行（`Failed to mark memory page as executable`），本机跑了：

- `python3 tests/rdp-android-create-replica.py`
- `python3 tests/rdp-android-engine-replica.py`
- `node --test tests/rdp-local-engine.test.mjs tests/rdp-operation-page.test.mjs`（13/13）

变异：删掉 Application 的 HOME 安装、删掉 `password?.copyOf()`、第一次 create 改成 `ignoreCertificate=true`，replica 都会挂。

请 CI 跑 contracts + Android JVM 单测 + assemblePrerelease。全绿后再合 main。