### PR TITLE
fix(mobile): bound dialogs and remove tools add

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -1169,7 +1169,6 @@ private fun ToolsDestination(
             language = languageLabel,
             ai = AiWorkspaceBinding.settingsSummary(prefs),
         ),
-        onAddTool = { onOpenTool(ToolEntry.PROXY) },
         onOpenBatchExecution = onOpenBatch,
         onOpenDocker = { onOpenTool(ToolEntry.DOCKER) },
         onOpenMonitor = { onOpenTool(ToolEntry.MONITOR) },

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
@@ -34,6 +36,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlin.math.min
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.delay
@@ -246,10 +249,11 @@ fun AlertDialog(
             decorFitsSystemWindows = false,
         ),
     ) {
-        Box(
-            modifier
+        BoxWithConstraints(
+            modifier = modifier
                 .fillMaxSize()
                 .background(palette.surfaces.scrim)
+                .imePadding()
                 .clickable(
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() },
@@ -257,29 +261,39 @@ fun AlertDialog(
                 ),
             contentAlignment = Alignment.BottomCenter,
         ) {
+            val availableHeight = min(maxHeight.value - 20f, 640f).coerceAtLeast(120f).dp
             Column(
                 Modifier
                     .fillMaxWidth()
+                    .heightIn(max = availableHeight)
                     .padding(start = 10.dp, end = 10.dp, bottom = 10.dp)
                     .navigationBarsPadding()
-                    .heightIn(max = 640.dp)
-                    .verticalScroll(rememberScrollState())
                     .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) {},
             ) {
                 Column(
                     Modifier
                         .fillMaxWidth()
+                        .weight(1f, fill = false)
                         .clip(RoundedCornerShape(ZephyrRadius.lg))
-                        .background(palette.surfaces.floating)
-                        .padding(top = 16.dp, bottom = 8.dp),
+                        .background(palette.surfaces.floating),
                 ) {
                     if (title != null) {
-                        Box(Modifier.fillMaxWidth().padding(horizontal = 20.dp), contentAlignment = Alignment.Center) {
+                        Box(
+                            Modifier.fillMaxWidth().padding(top = 16.dp, start = 20.dp, end = 20.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
                             ProvideContentColor(palette.onBackground, title)
                         }
                     }
                     if (text != null) {
-                        Box(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp), contentAlignment = Alignment.Center) {
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .weight(1f, fill = false)
+                                .verticalScroll(rememberScrollState())
+                                .padding(horizontal = 20.dp, vertical = 8.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
                             ProvideContentColor(palette.onFloatingMuted, text)
                         }
                     }

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import one.zephyr.mobile.model.ActionGate
-import one.zephyr.mobile.ui.chrome.HeaderAddButton
 import one.zephyr.mobile.ui.chrome.RootPageHeader
 import one.zephyr.mobile.ui.island.islandContentBottomInset
 import one.zephyr.mobile.ui.theme.ZephyrRadius
@@ -70,7 +69,6 @@ data class ToolsRootSummaries(
 fun ToolsRootRoute(
     inventory: ToolsInventory,
     summaries: ToolsRootSummaries,
-    onAddTool: () -> Unit,
     onOpenBatchExecution: () -> Unit,
     onOpenDocker: () -> Unit,
     onOpenMonitor: () -> Unit,
@@ -95,7 +93,6 @@ fun ToolsRootRoute(
     ToolsRootScreen(
         inventory = inventory,
         summaries = summaries,
-        onAddTool = onAddTool,
         onOpenTool = { entry ->
             when (entry) {
                 ToolEntry.BATCH_EXEC -> onOpenBatchExecution()
@@ -127,15 +124,12 @@ fun ToolsRootRoute(
 fun ToolsRootScreen(
     inventory: ToolsInventory,
     summaries: ToolsRootSummaries,
-    onAddTool: () -> Unit,
     onOpenTool: (ToolEntry) -> Unit,
     onUnavailableTool: (ToolEntry, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.fillMaxSize()) {
-        RootPageHeader(title = stringResource(R.string.tools_root_title)) {
-            HeaderAddButton(stringResource(R.string.tools_root_add), onAddTool)
-        }
+        RootPageHeader(title = stringResource(R.string.tools_root_title))
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(horizontal = ZephyrSpacing.lg),
             contentPadding = PaddingValues(bottom = islandContentBottomInset()),

--- a/zephyr_one/mobile/android/feature-tools/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-tools/src/main/res/values-en/strings.xml
@@ -2,7 +2,6 @@
 <!-- English UI. values/ is zh-Hans. -->
 <resources>
     <string name="tools_root_title">Tools</string>
-    <string name="tools_root_add">Add tool</string>
     <string name="tools_section_remote">Remote ops</string>
     <string name="tools_section_resources">Resources</string>
     <string name="tools_section_ai">AI</string>

--- a/zephyr_one/mobile/android/feature-tools/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-tools/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
 -->
 <resources>
     <string name="tools_root_title">工具</string>
-    <string name="tools_root_add">添加工具</string>
     <string name="tools_section_remote">远程操作</string>
     <string name="tools_section_resources">资源</string>
     <string name="tools_section_ai">AI</string>

--- a/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
+++ b/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+const overlays = read('android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt');
+const tools = read('android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt');
+const root = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const alertStart = overlays.indexOf('fun AlertDialog(');
+const alert = overlays.slice(alertStart);
+
+test('alert dialog is bounded by the actual available window', () => {
+  assert.match(alert, /decorFitsSystemWindows = false/);
+  assert.match(alert, /BoxWithConstraints/);
+  assert.match(alert, /\.imePadding\(\)/);
+  assert.match(alert, /val availableHeight = min\(maxHeight\.value - 20f, 640f\)/);
+  assert.match(alert, /\.heightIn\(max = availableHeight\)/);
+  assert.match(alert, /\.navigationBarsPadding\(\)/);
+});
+
+test('alert text scrolls while confirm and cancel actions stay fixed', () => {
+  const scrollIndex = alert.indexOf('.verticalScroll(rememberScrollState())');
+  const confirmIndex = alert.indexOf('ProvideContentColor(palette.status.error, confirmButton)');
+  const dismissIndex = alert.indexOf('ProvideContentColor(palette.onBackground, dismissButton)');
+  assert.ok(scrollIndex > 0);
+  assert.ok(confirmIndex > scrollIndex);
+  assert.ok(dismissIndex > confirmIndex);
+  assert.match(alert, /\.weight\(1f, fill = false\)[\s\S]*\.verticalScroll/);
+  assert.doesNotMatch(alert, /\.heightIn\(max = 640\.dp\)[\s\S]{0,80}\.verticalScroll/);
+});
+
+test('tools root has no redundant add button or callback', () => {
+  assert.match(tools, /RootPageHeader\(title = stringResource\(R\.string\.tools_root_title\)\)/);
+  assert.doesNotMatch(tools, /HeaderAddButton/);
+  assert.doesNotMatch(tools, /onAddTool/);
+  assert.doesNotMatch(root, /onAddTool =/);
+  assert.doesNotMatch(read('android/feature-tools/src/main/res/values/strings.xml'), /tools_root_add/);
+  assert.doesNotMatch(read('android/feature-tools/src/main/res/values-en/strings.xml'), /tools_root_add/);
+});


### PR DESCRIPTION
## 修复

- 通用 ActionSheet/AlertDialog 按当前实际窗口高度动态限高，同时避让 IME 与系统导航栏
- 只让正文区域滚动，确认/取消操作固定在可视范围内，修复 SSH 首次主机指纹弹窗底部越界
- 删除工具根页右上角无实际必要的加号按钮、回调和中英文资源

## 本地验证

- `node --test zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs`：3/3
- 相关 terminal dock / Android AI 合同：8/8
- `git diff --check`

Android 真编译与 JVM 测试交由 Zephyr One Mobile CI。