### PR TITLE
fix(mobile): Android RDP SIGABRT in FreeRDP TlsAlloc (bionic pthread_key_t)

### DIFF
--- a/.github/workflows/zephyr-one-mobile.yml
+++ b/.github/workflows/zephyr-one-mobile.yml
@@ -138,7 +138,7 @@ jobs:
           test -d "$ANDROID_NDK_HOME"
           sh zephyr_one/native/freerdp-core/scripts/build-freerdp-android.sh arm64-v8a
           test -f "$ZEPHYR_ANDROID_FREERDP_ROOT/arm64-v8a/.zephyr-freerdp-tag"
-          test "$(cat "$ZEPHYR_ANDROID_FREERDP_ROOT/arm64-v8a/.zephyr-freerdp-tag")" = '3.30.0+cliprdr-reassembly-limit-v1'
+          test "$(cat "$ZEPHYR_ANDROID_FREERDP_ROOT/arm64-v8a/.zephyr-freerdp-tag")" = '3.30.0+cliprdr-reassembly-limit-v1+tlsalloc-bionic-v1'
 
       # Gradle is provisioned by the action rather than by a committed wrapper.
       # The wrapper JAR is a binary artefact, and adding one that no human in

--- a/zephyr_one/mobile/android/protocol-rdp/src/main/cpp/CMakeLists.txt
+++ b/zephyr_one/mobile/android/protocol-rdp/src/main/cpp/CMakeLists.txt
@@ -19,8 +19,8 @@ if(NOT EXISTS "${FREERDP_STAMP}")
 endif()
 file(READ "${FREERDP_STAMP}" FREERDP_STAMP_VALUE)
 string(STRIP "${FREERDP_STAMP_VALUE}" FREERDP_STAMP_VALUE)
-if(NOT FREERDP_STAMP_VALUE STREQUAL "3.30.0+cliprdr-reassembly-limit-v1")
-    message(FATAL_ERROR "FreeRDP ${ANDROID_ABI} must be 3.30.0+cliprdr-reassembly-limit-v1")
+if(NOT FREERDP_STAMP_VALUE STREQUAL "3.30.0+cliprdr-reassembly-limit-v1+tlsalloc-bionic-v1")
+    message(FATAL_ERROR "FreeRDP ${ANDROID_ABI} must be 3.30.0+cliprdr-reassembly-limit-v1+tlsalloc-bionic-v1")
 endif()
 
 set(REQUIRED_ARCHIVES

--- a/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
+++ b/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
@@ -74,3 +74,15 @@ test('engine replica keeps the password across a stored-fingerprint retry', () =
   const result = spawnSync('python3', [replica], { encoding: 'utf8' });
   assert.equal(result.status, 0, result.stdout + result.stderr);
 });
+
+test('Android FreeRDP drops the TlsAlloc sign assertion for bionic pthread_key_t', () => {
+  const patch = read(path.join(ROOT, '../../zephyr_one/native/freerdp-core/patches/freerdp-3.30.0-tlsalloc-bionic-assert.patch'));
+  assert.match(patch, /winpr\/libwinpr\/thread\/tls\.c/);
+  assert.match(patch, /^\+\s*return \(DWORD\)key/m);
+  assert.doesNotMatch(patch, /^\+\s*return WINPR_ASSERTING_INT_CAST\(DWORD, key\)/m);
+  const script = read(path.join(ROOT, '../../zephyr_one/native/freerdp-core/scripts/build-freerdp-android.sh'));
+  assert.match(script, /TLS_PATCH_FILE=.*tlsalloc-bionic-assert\.patch/);
+  assert.match(script, /tlsalloc-bionic-v1/);
+  const workflow = read(path.join(ROOT, '../../.github/workflows/zephyr-one-mobile.yml'));
+  assert.match(workflow, /tlsalloc-bionic-v1/);
+});

--- a/zephyr_one/native/freerdp-core/patches/freerdp-3.30.0-tlsalloc-bionic-assert.patch
+++ b/zephyr_one/native/freerdp-core/patches/freerdp-3.30.0-tlsalloc-bionic-assert.patch
@@ -1,0 +1,13 @@
+diff --git a/winpr/libwinpr/thread/tls.c b/winpr/libwinpr/thread/tls.c
+index 416bebd..6472e97 100644
+--- a/winpr/libwinpr/thread/tls.c
++++ b/winpr/libwinpr/thread/tls.c
+@@ -42,7 +42,7 @@ DWORD TlsAlloc(void)
+ 		return TLS_OUT_OF_INDEXES;
+ 	if (key > UINT32_MAX)
+ 		return TLS_OUT_OF_INDEXES;
+-	return WINPR_ASSERTING_INT_CAST(DWORD, key);
++	return (DWORD)key;
+ }
+ 
+ LPVOID TlsGetValue(DWORD dwTlsIndex)

--- a/zephyr_one/native/freerdp-core/scripts/build-freerdp-android.sh
+++ b/zephyr_one/native/freerdp-core/scripts/build-freerdp-android.sh
@@ -6,7 +6,7 @@ set -eu
 
 TAG="3.30.0"
 COMMIT="6b107f0aadbabc47941c5a5b893b88c01792af6d"
-PATCH_REV="cliprdr-reassembly-limit-v1"
+PATCH_REV="cliprdr-reassembly-limit-v1+tlsalloc-bionic-v1"
 STAMP_VALUE="$TAG+$PATCH_REV"
 OPENSSL_VER="3.3.2"
 CJSON_VER="1.7.18"
@@ -16,6 +16,7 @@ ABI="${1:-arm64-v8a}"
 HERE="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
 CRATE="$(CDPATH= cd -- "$HERE/.." && pwd)"
 PATCH_FILE="$CRATE/patches/freerdp-3.30.0-cliprdr-reassembly-limit.patch"
+TLS_PATCH_FILE="$CRATE/patches/freerdp-3.30.0-tlsalloc-bionic-assert.patch"
 PREFIX="${ZEPHYR_ANDROID_FREERDP_ROOT:-$CRATE/.freerdp-android}"
 ABI_PREFIX="$PREFIX/$ABI"
 JOBS="${ZEPHYR_FREERDP_JOBS:-$(nproc 2>/dev/null || echo 4)}"
@@ -139,6 +140,17 @@ fi
 grep -q '^#define FREERDP_ZEPHYR_CLIPRDR_REASSEMBLY_LIMIT 1$' \
   "$SRC/include/freerdp/client/channels.h" || {
   echo "ERROR: cliprdr patch was not applied" >&2
+  exit 2
+}
+
+TLS_PATCH_INPUT="$WORKDIR/freerdp-tlsalloc-bionic.lf.patch"
+tr -d '\015' < "$TLS_PATCH_FILE" > "$TLS_PATCH_INPUT"
+if grep -q 'WINPR_ASSERTING_INT_CAST(DWORD, key)' "$SRC/winpr/libwinpr/thread/tls.c"; then
+  git -C "$SRC" apply --check --unidiff-zero --whitespace=error-all "$TLS_PATCH_INPUT"
+  git -C "$SRC" apply --unidiff-zero --whitespace=error-all "$TLS_PATCH_INPUT"
+fi
+grep -q 'WINPR_ASSERTING_INT_CAST(DWORD, key)' "$SRC/winpr/libwinpr/thread/tls.c" && {
+  echo "ERROR: tlsalloc bionic patch was not applied" >&2
   exit 2
 }
 


### PR DESCRIPTION
## 现象

Android 打开 RDP 立刻闪退（SIGABRT），不是在连接阶段，是在 `zephyr_rdp_new` 里：

```
Abort message: '[pid=...] - [winpr_int_assert]: (((((var) > 0) && ((DWORD)((var)) > 0)) || (((var) <= 0) && (DWORD)((var)) <= 0))) [winpr/libwinpr/thread/tls.c:TlsAlloc:45]'
```

栈顶：`Java_..._create` → `zephyr_rdp_new` → ... → `TlsAlloc` → `abort`。

## 根因（FreeRDP 3.30 回归，非本仓库代码）

FreeRDP 3.30 的 `winpr/libwinpr/thread/tls.c` `TlsAlloc`：

```c
return WINPR_ASSERTING_INT_CAST(DWORD, key);
```

`WINPR_ASSERTING_INT_CAST` 断言 `(key > 0 && (DWORD)key > 0) || (key <= 0 && (DWORD)key <= 0)`——要求 `key` 非负。但 bionic 的 `pthread_key_t` 是 **`int`，且第 31 位是合法的有效标志位**（`bionic/libc/bionic/pthread_key.cpp` 的 `KeyInValidRange`），`pthread_key_create` 返回的合法 key **经常是"负 int"**。于是断言失败 → SIGABRT。

上游同款崩溃：FreeRDP#13103，Android 上 `TlsAlloc` 一进就崩，发生在任何连接建立之前。

## 修复

新增 patch `freerdp-3.30.0-tlsalloc-bionic-assert.patch`：把 `WINPR_ASSERTING_INT_CAST(DWORD, key)` 换成 `(DWORD)key`。key 是 opaque 句柄，`TlsGetValue/TlsSetValue/TlsFree` 都是 `(pthread_key_t)dwTlsIndex` 原样转回，`(DWORD)key` 无损 round-trip，去掉符号断言即可。

`build-freerdp-android.sh` 应用该 patch 并把 stamp 升到 `+tlsalloc-bionic-v1`（cache key 因 `patches/**` hash 自动失效，CI 会重编 FreeRDP）；`zephyr-one-mobile.yml` 校验新 stamp。

## 验证

- 契约：`rdp-local-engine.test.mjs` 新增用例锁定 patch（删 patch / 恢复断言 / 改回旧 stamp 都会红），8/8 过。
- patch 在干净 FreeRDP 3.30.0（pinned `6b107f0a`）上 `git apply --check` 通过。

请 CI 全绿后合 main。合完我会发 pre16（pre15 是修 HOME 但没触发 FreeRDP 运行时的版本，这个才是 RDP 能真正连上的第一个包）。