### PR TITLE
fix(mobile): keep SSH/RDP host-key sheets fully on screen

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -893,7 +893,11 @@ private fun BoundRoot(
                 onDismissRequest = { managedSsh.rejectHostKey() },
                 title = { Text(if (prompt.changed) "SSH 主机指纹已变化" else "确认 SSH 主机") },
                 text = {
-                    Text("${prompt.host}:${prompt.port}\n${prompt.algorithm} · ${prompt.fingerprint}\n\n确认后会自动继续当前操作。")
+                    Text(
+                        "${prompt.host}:${prompt.port}\n${prompt.algorithm}\n" +
+                            one.zephyr.mobile.ui.component.AlertDialogLayout.wrapFingerprint(prompt.fingerprint) +
+                            "\n\n确认后会自动继续当前操作。",
+                    )
                 },
                 confirmButton = {
                     TextButton(onClick = { managedSsh.acceptHostKey() }) {

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt
@@ -1,0 +1,87 @@
+package one.zephyr.mobile.ui.component
+
+/**
+ * Window-independent numbers for the confirmation sheet.
+ *
+ * Compose [androidx.compose.ui.window.Dialog] sizes itself WRAP_CONTENT. Measuring the sheet
+ * against that wrap height and then subtracting a gutter clips the cancel group (the screenshot
+ * of the SSH/RDP host-key prompt). These helpers take the *screen* height, not the dialog's
+ * wrap height, so the same sheet stays fully on screen for every protocol.
+ */
+object AlertDialogLayout {
+    const val MAX_SHEET_DP = 640f
+    const val EDGE_GUTTER_DP = 10f
+    const val GROUP_GAP_DP = 8f
+    const val ACTION_MIN_DP = 50f
+    const val TITLE_TOP_PAD_DP = 16f
+    const val BODY_VERTICAL_PAD_DP = 8f
+    const val FINGERPRINT_GROUP = 4
+    const val FINGERPRINT_GROUPS_PER_LINE = 6
+
+    /** Dark-scheme floating sheet, forced opaque so Extra Keys cannot bleed through. */
+    val DARK_SHEET_ARGB: Int = 0xFF1A1E25.toInt()
+
+    /** Light-scheme floating sheet, forced opaque. */
+    val LIGHT_SHEET_ARGB: Int = 0xFFFFFFFF.toInt()
+
+    fun sheetArgb(dark: Boolean): Int = if (dark) DARK_SHEET_ARGB else LIGHT_SHEET_ARGB
+
+    /**
+     * Tallest the stacked groups may be.
+     *
+     * [windowHeightDp] is the physical window, not Dialog wrap-content. Subtracting the wrap
+     * height would reproduce the cropped cancel button.
+     */
+    fun availableHeightDp(windowHeightDp: Float): Float =
+        minOf(windowHeightDp - EDGE_GUTTER_DP * 2f, MAX_SHEET_DP).coerceAtLeast(120f)
+
+    /**
+     * The sheet is fully visible only when it is shorter than the window and still has room
+     * for the cancel group after the body has taken its share.
+     */
+    fun sheetFits(
+        windowHeightDp: Float,
+        bodyHeightDp: Float,
+        hasDismiss: Boolean,
+    ): Boolean {
+        val available = availableHeightDp(windowHeightDp)
+        val stacked = stackedHeightDp(bodyHeightDp, hasDismiss)
+        return stacked <= available + 0.01f && stacked <= windowHeightDp - EDGE_GUTTER_DP
+    }
+
+    fun stackedHeightDp(bodyHeightDp: Float, hasDismiss: Boolean): Float {
+        val groups = if (hasDismiss) bodyHeightDp + GROUP_GAP_DP + ACTION_MIN_DP else bodyHeightDp
+        return groups + EDGE_GUTTER_DP
+    }
+
+    /**
+     * Break a SHA-256 fingerprint so a 360dp phone never has to clip or overflow it.
+     *
+     * OpenSSH (`SHA256:` + unpadded base64) and colon-hex TLS both become 4-character groups.
+     * Six groups per line (~36 glyphs with the SHA256: prefix) is the widest line that still
+     * fits the 20dp padded sheet on a 360dp device at the 13.5sp mono size. The screenshot
+     * fingerprint is 11 groups, so it must break onto a second line.
+     */
+    fun wrapFingerprint(raw: String): String {
+        val compact = raw.replace("\\s+".toRegex(), "")
+        if (compact.isEmpty()) return raw
+        val colon = compact.indexOf(':')
+        val head = if (colon in 1..8) compact.substring(0, colon) else ""
+        // SHA256 / MD5 carry a non-hex letter. A leading TLS pair such as "A1:" is hex-only
+        // and must stay in the payload, or the wrap would drop the first byte.
+        val prefixEnd = if (head.isNotEmpty() && head.any { !it.isHexDigit() }) colon + 1 else 0
+        val prefix = compact.substring(0, prefixEnd)
+        val payload = compact.substring(prefixEnd).replace(":", "")
+        if (payload.isEmpty()) return compact
+        val groups = payload.chunked(FINGERPRINT_GROUP)
+        val lines = groups.chunked(FINGERPRINT_GROUPS_PER_LINE).map { it.joinToString(" ") }
+        return if (prefix.isEmpty()) {
+            lines.joinToString("\n")
+        } else {
+            prefix + lines.first() + lines.drop(1).joinToString("") { "\n" + it }
+        }
+    }
+
+    private fun Char.isHexDigit(): Boolean =
+        this in '0'..'9' || this in 'A'..'F' || this in 'a'..'f'
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
-import android.graphics.Color as AndroidColor
 import android.view.ViewGroup
 import android.view.WindowManager
 import kotlinx.coroutines.delay
@@ -270,8 +269,6 @@ fun AlertDialog(
             window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
             window.setBackgroundDrawableResource(android.R.color.transparent)
             window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-            window.statusBarColor = AndroidColor.TRANSPARENT
-            window.navigationBarColor = AndroidColor.TRANSPARENT
         }
         BoxWithConstraints(
             modifier = modifier

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
@@ -19,12 +19,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -32,13 +34,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import kotlin.math.min
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
+import android.graphics.Color as AndroidColor
+import android.view.ViewGroup
+import android.view.WindowManager
 import kotlinx.coroutines.delay
 import one.zephyr.mobile.ui.theme.ProvideContentColor
 import one.zephyr.mobile.ui.theme.ZephyrMotionTokens
@@ -231,6 +238,10 @@ class ZephyrToastHostState {
 /**
  * Confirmation that looks like the demo action sheet, not a Material dialog.
  * Kept as `AlertDialog` so existing call sites only change the import.
+ *
+ * The platform Dialog is WRAP_CONTENT. Stretching it to MATCH_PARENT and
+ * measuring against the *window* (not the wrap height) is what keeps the
+ * cancel group on screen for SSH / RDP / VNC host-key prompts.
  */
 @Composable
 fun AlertDialog(
@@ -242,6 +253,7 @@ fun AlertDialog(
     text: (@Composable () -> Unit)? = null,
 ) {
     val palette = ZephyrTheme.palette
+    val sheetColor = Color(AlertDialogLayout.sheetArgb(palette.dark))
     Dialog(
         onDismissRequest = onDismissRequest,
         properties = DialogProperties(
@@ -249,9 +261,22 @@ fun AlertDialog(
             decorFitsSystemWindows = false,
         ),
     ) {
+        val composeView = LocalView.current
+        val configuration = LocalConfiguration.current
+        val screenWidthDp = configuration.screenWidthDp
+        val screenHeightDp = configuration.screenHeightDp.toFloat()
+        SideEffect {
+            val window = (composeView.parent as? DialogWindowProvider)?.window ?: return@SideEffect
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+            window.setBackgroundDrawableResource(android.R.color.transparent)
+            window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            window.statusBarColor = AndroidColor.TRANSPARENT
+            window.navigationBarColor = AndroidColor.TRANSPARENT
+        }
         BoxWithConstraints(
             modifier = modifier
-                .fillMaxSize()
+                .width(screenWidthDp.dp)
+                .height(screenHeightDp.dp)
                 .background(palette.surfaces.scrim)
                 .imePadding()
                 .clickable(
@@ -261,7 +286,8 @@ fun AlertDialog(
                 ),
             contentAlignment = Alignment.BottomCenter,
         ) {
-            val availableHeight = min(maxHeight.value - 20f, 640f).coerceAtLeast(120f).dp
+            val windowHeightDp = maxOf(screenHeightDp, maxHeight.value)
+            val availableHeight = AlertDialogLayout.availableHeightDp(windowHeightDp).dp
             Column(
                 Modifier
                     .fillMaxWidth()
@@ -275,7 +301,7 @@ fun AlertDialog(
                         .fillMaxWidth()
                         .weight(1f, fill = false)
                         .clip(RoundedCornerShape(ZephyrRadius.lg))
-                        .background(palette.surfaces.floating),
+                        .background(sheetColor),
                 ) {
                     if (title != null) {
                         Box(
@@ -314,7 +340,7 @@ fun AlertDialog(
                         Modifier
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(ZephyrRadius.lg))
-                            .background(palette.surfaces.floating)
+                            .background(sheetColor)
                             .heightIn(min = 50.dp),
                         contentAlignment = Alignment.Center,
                     ) {

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
@@ -1,0 +1,94 @@
+package one.zephyr.mobile.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The host-key / certificate sheet is shared by SSH, RDP and VNC. These numbers
+ * are what the screenshot failed: a WRAP_CONTENT Dialog measured against itself
+ * cropped the cancel group, and a single-line SHA-256 overflowed the card.
+ */
+class AlertDialogLayoutTest {
+
+    @Test
+    fun availableHeightUsesTheWindowNotTheWrapContentDialog() {
+        // A 780dp phone. The old formula used Dialog wrap-content (~220dp) and
+        // then subtracted 20dp, which is exactly how the cancel group vanished.
+        assertEquals(640f, AlertDialogLayout.availableHeightDp(780f), 0.001f)
+        assertEquals(340f, AlertDialogLayout.availableHeightDp(360f), 0.001f)
+        assertEquals(120f, AlertDialogLayout.availableHeightDp(80f), 0.001f)
+    }
+
+    @Test
+    fun firstContactSheetFitsAPhoneAndKeepsTheCancelGroup() {
+        val body = 180f
+        assertTrue(AlertDialogLayout.sheetFits(780f, body, hasDismiss = true))
+        val stacked = AlertDialogLayout.stackedHeightDp(body, hasDismiss = true)
+        assertEquals(body + 8f + 50f + 10f, stacked, 0.001f)
+        assertTrue(stacked < 780f)
+    }
+
+    @Test
+    fun measuringAgainstWrapContentWouldClipTheCancelGroup() {
+        // Reproduce the screenshot: Dialog wrap height ≈ card + gutter, no room
+        // left for the separate cancel group.
+        val wrapHeight = 220f
+        val body = 180f
+        assertFalse(AlertDialogLayout.sheetFits(wrapHeight, body, hasDismiss = true))
+        assertTrue(AlertDialogLayout.sheetFits(780f, body, hasDismiss = true))
+    }
+
+    @Test
+    fun opensshFingerprintWrapsIntoFourCharacterGroups() {
+        val raw = "SHA256:QytVAAei+gY5ISAlZF3D6WfcZGOaTGY+ygTPRiDSbl0"
+        val wrapped = AlertDialogLayout.wrapFingerprint(raw)
+        assertEquals(
+            "SHA256:QytV AAei +gY5 ISAl ZF3D 6Wfc\nZGOa TGY+ ygTP RiDS bl0",
+            wrapped,
+        )
+        val longest = wrapped.lineSequence().maxOf { it.length }
+        assertTrue("longest line $longest glyphs overflows a 360dp sheet", longest <= 48)
+        assertFalse(wrapped.contains("SHA256:QytVAAei+gY5ISAlZF3D6WfcZGOaTGY+ygTPRiDSbl0"))
+    }
+
+    @Test
+    fun colonHexTlsFingerprintWrapsWithoutLosingBytes() {
+        val raw = (0..31).joinToString(":") { byte -> "%02X".format(byte) }
+        val wrapped = AlertDialogLayout.wrapFingerprint(raw)
+        assertEquals(raw.replace(":", ""), wrapped.replace(Regex("[\\s:]"), ""))
+        assertTrue(wrapped.startsWith("0001 0203"))
+        assertFalse(wrapped.startsWith("00:"))
+        assertTrue(wrapped.contains("\n"))
+        val longest = wrapped.lineSequence().maxOf { it.length }
+        assertTrue("longest TLS line $longest glyphs overflows", longest <= 48)
+    }
+
+    @Test
+    fun hexOnlyHeadIsNotTreatedAsAnAlgorithmPrefix() {
+        val raw = "A1:B2:C3:D4:E5:F6:01:23:45:67:89:AB:CD:EF:00:11"
+        val wrapped = AlertDialogLayout.wrapFingerprint(raw)
+        assertTrue(wrapped.startsWith("A1B2"))
+        assertEquals(raw.replace(":", ""), wrapped.replace(Regex("[\\s:]"), ""))
+    }
+
+    @Test
+    fun wrappingIsIdempotentAndDoesNotInventGlyphs() {
+        val raw = "SHA256:QytVAAei+gY5ISAlZF3D6WfcZGOaTGY+ygTPRiDSbl0"
+        val once = AlertDialogLayout.wrapFingerprint(raw)
+        assertEquals(once, AlertDialogLayout.wrapFingerprint(once))
+        val compact = raw.replace(":", "").replace("SHA256", "SHA256")
+        val restored = once.replace("\n", "").replace(" ", "")
+        assertEquals(raw, restored)
+        assertEquals(compact.length, restored.length)
+    }
+
+    @Test
+    fun sheetColorIsForcedOpaqueInBothSchemes() {
+        assertEquals(0xFF1A1E25.toInt(), AlertDialogLayout.sheetArgb(dark = true))
+        assertEquals(0xFFFFFFFF.toInt(), AlertDialogLayout.sheetArgb(dark = false))
+        assertEquals(0xFF, (AlertDialogLayout.DARK_SHEET_ARGB ushr 24) and 0xFF)
+        assertEquals(0xFF, (AlertDialogLayout.LIGHT_SHEET_ARGB ushr 24) and 0xFF)
+    }
+}

--- a/zephyr_one/mobile/android/feature-remote/src/main/kotlin/one/zephyr/mobile/feature/remote/RemoteScreen.kt
+++ b/zephyr_one/mobile/android/feature-remote/src/main/kotlin/one/zephyr/mobile/feature/remote/RemoteScreen.kt
@@ -35,7 +35,9 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import one.zephyr.mobile.ui.component.AlertDialog
+import one.zephyr.mobile.ui.component.AlertDialogLayout
 import one.zephyr.mobile.ui.component.CircularProgressIndicator
+import androidx.compose.ui.text.style.TextAlign
 import one.zephyr.mobile.ui.component.FilterChip
 import one.zephyr.mobile.ui.component.Icon
 import one.zephyr.mobile.ui.component.IconButton
@@ -1418,8 +1420,9 @@ private fun CertificateFacts(prompt: RemoteCertificatePrompt) {
         // Bordered rather than inline: the fingerprint is the one string the user is expected to
         // compare against something else, so it gets a boundary instead of being a line of prose.
         Text(
-            text = review.sha256Fingerprint,
+            text = AlertDialogLayout.wrapFingerprint(review.sha256Fingerprint),
             style = ZephyrTheme.typography.mono,
+            textAlign = TextAlign.Start,
             modifier = Modifier
                 .fillMaxWidth()
                 .border(1.dp, palette.surfaces.outline, RoundedCornerShape(ZephyrRadius.sm))
@@ -1428,9 +1431,16 @@ private fun CertificateFacts(prompt: RemoteCertificatePrompt) {
         prompt.previousFingerprint?.let { previous ->
             Spacer(modifier = Modifier.height(ZephyrSpacing.xs))
             Text(
-                text = stringResource(R.string.remote_cert_previous, previous),
-                style = ZephyrTheme.typography.monoCaption,
+                text = stringResource(R.string.remote_cert_previous_label),
+                style = ZephyrTheme.typography.caption,
                 color = palette.status.warning,
+            )
+            Text(
+                text = AlertDialogLayout.wrapFingerprint(previous),
+                style = ZephyrTheme.typography.monoCaption,
+                textAlign = TextAlign.Start,
+                color = palette.status.warning,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }

--- a/zephyr_one/mobile/android/feature-remote/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-remote/src/main/res/values-en/strings.xml
@@ -67,6 +67,7 @@
     <string name="remote_cert_issuer">Issuer: %1$s</string>
     <string name="remote_cert_validity">Valid: %1$s – %2$s</string>
     <string name="remote_cert_previous">Previously recorded fingerprint: %1$s</string>
+    <string name="remote_cert_previous_label">Previously recorded fingerprint</string>
     <string name="remote_cert_first_title">First time connecting to this server</string>
     <string name="remote_cert_first_body">Check the fingerprint below before you trust this server</string>
     <string name="remote_cert_changed_title">Certificate changed</string>

--- a/zephyr_one/mobile/android/feature-remote/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-remote/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="remote_cert_issuer">颁发者：%1$s</string>
     <string name="remote_cert_validity">有效期：%1$s 至 %2$s</string>
     <string name="remote_cert_previous">此前记录的指纹：%1$s</string>
+    <string name="remote_cert_previous_label">此前记录的指纹</string>
     <string name="remote_cert_first_title">首次连接该服务器</string>
     <string name="remote_cert_first_body">请核对下面的指纹后再决定是否信任该服务器</string>
     <string name="remote_cert_changed_title">证书已变更</string>

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -46,8 +46,13 @@ import one.zephyr.mobile.ui.component.ActionSheet
 import one.zephyr.mobile.ui.component.ActionSheetGroup
 import one.zephyr.mobile.ui.component.ActionSheetItem
 import one.zephyr.mobile.ui.component.AlertDialog
+import one.zephyr.mobile.ui.component.AlertDialogLayout
 import one.zephyr.mobile.ui.component.Text
 import one.zephyr.mobile.ui.component.TextButton
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import one.zephyr.mobile.ui.theme.ZephyrRadius
 import one.zephyr.mobile.ui.component.CleartextProtocolWarning
 import one.zephyr.mobile.ui.state.PageStateScaffold
 import one.zephyr.mobile.ui.theme.ZephyrSpacing
@@ -667,13 +672,22 @@ private fun HostKeyConfirmation(prompt: HostKeyPrompt, onIntent: (TerminalIntent
             )
         },
         text = {
-            Column {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
                     text = if (prompt.changed) stringResource(R.string.terminal_host_key_changed_body)
                     else stringResource(R.string.terminal_host_key_new_body),
                     color = if (prompt.changed) palette.status.error else palette.onBackground,
                 )
-                Text(text = prompt.fingerprint, style = ZephyrTextStyles.mono)
+                Text(
+                    text = AlertDialogLayout.wrapFingerprint(prompt.fingerprint),
+                    style = ZephyrTextStyles.mono,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = ZephyrSpacing.sm)
+                        .border(1.dp, palette.surfaces.outline, RoundedCornerShape(ZephyrRadius.sm))
+                        .padding(ZephyrSpacing.sm),
+                )
             }
         },
         confirmButton = {

--- a/zephyr_one/mobile/tests/alert-dialog-layout-replica.py
+++ b/zephyr_one/mobile/tests/alert-dialog-layout-replica.py
@@ -1,0 +1,87 @@
+"""Replica of AlertDialogLayout so the wrap/height contract can fail
+without an Android SDK. Keep this file byte-for-byte with the Kotlin
+helpers; the Node suite execs it and diffs the outputs.
+"""
+
+from __future__ import annotations
+
+MAX_SHEET_DP = 640.0
+EDGE_GUTTER_DP = 10.0
+GROUP_GAP_DP = 8.0
+ACTION_MIN_DP = 50.0
+FINGERPRINT_GROUP = 4
+FINGERPRINT_GROUPS_PER_LINE = 6
+DARK_SHEET_ARGB = 0xFF1A1E25
+LIGHT_SHEET_ARGB = 0xFFFFFFFF
+
+
+def available_height_dp(window_height_dp: float) -> float:
+    return max(min(window_height_dp - EDGE_GUTTER_DP * 2.0, MAX_SHEET_DP), 120.0)
+
+
+def stacked_height_dp(body_height_dp: float, has_dismiss: bool) -> float:
+    groups = body_height_dp + GROUP_GAP_DP + ACTION_MIN_DP if has_dismiss else body_height_dp
+    return groups + EDGE_GUTTER_DP
+
+
+def sheet_fits(window_height_dp: float, body_height_dp: float, has_dismiss: bool) -> bool:
+    available = available_height_dp(window_height_dp)
+    stacked = stacked_height_dp(body_height_dp, has_dismiss)
+    return stacked <= available + 0.01 and stacked <= window_height_dp - EDGE_GUTTER_DP
+
+
+def _is_hex_digit(ch: str) -> bool:
+    return ("0" <= ch <= "9") or ("A" <= ch <= "F") or ("a" <= ch <= "f")
+
+
+def wrap_fingerprint(raw: str) -> str:
+    compact = "".join(raw.split())
+    if not compact:
+        return raw
+    colon = compact.find(":")
+    head = compact[:colon] if 1 <= colon <= 8 else ""
+    prefix_end = colon + 1 if head and any(not _is_hex_digit(ch) for ch in head) else 0
+    prefix = compact[:prefix_end]
+    payload = compact[prefix_end:].replace(":", "")
+    if not payload:
+        return compact
+    groups = [payload[i : i + FINGERPRINT_GROUP] for i in range(0, len(payload), FINGERPRINT_GROUP)]
+    lines = [
+        " ".join(groups[i : i + FINGERPRINT_GROUPS_PER_LINE])
+        for i in range(0, len(groups), FINGERPRINT_GROUPS_PER_LINE)
+    ]
+    if not prefix:
+        return "\n".join(lines)
+    return prefix + lines[0] + "".join("\n" + line for line in lines[1:])
+
+
+def main() -> int:
+    assert available_height_dp(780.0) == 640.0
+    assert available_height_dp(360.0) == 340.0
+    assert available_height_dp(80.0) == 120.0
+    body = 180.0
+    assert sheet_fits(780.0, body, True)
+    assert not sheet_fits(220.0, body, True)
+    assert stacked_height_dp(body, True) == body + 8.0 + 50.0 + 10.0
+
+    raw = "SHA256:QytVAAei+gY5ISAlZF3D6WfcZGOaTGY+ygTPRiDSbl0"
+    wrapped = wrap_fingerprint(raw)
+    assert wrapped == "SHA256:QytV AAei +gY5 ISAl ZF3D 6Wfc\nZGOa TGY+ ygTP RiDS bl0"
+    assert max(len(line) for line in wrapped.split("\n")) <= 48
+    assert wrap_fingerprint(wrapped) == wrapped
+    assert wrapped.replace("\n", "").replace(" ", "") == raw
+
+    tls = ":".join(f"{i:02X}" for i in range(32))
+    tls_wrapped = wrap_fingerprint(tls)
+    assert tls_wrapped.startswith("0001 0203")
+    assert tls.replace(":", "") == tls_wrapped.replace(" ", "").replace(":", "").replace("\n", "")
+    hex_head = "A1:B2:C3:D4:E5:F6:01:23"
+    assert wrap_fingerprint(hex_head).startswith("A1B2")
+    assert (DARK_SHEET_ARGB >> 24) & 0xFF == 0xFF
+    assert (LIGHT_SHEET_ARGB >> 24) & 0xFF == 0xFF
+    print("alert-dialog-layout-replica ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
+++ b/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
@@ -9,8 +9,11 @@ const mobile = path.resolve(here, '..');
 const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
 
 const overlays = read('android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt');
+const layout = read('android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt');
 const tools = read('android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt');
 const root = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const terminal = read('android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt');
+const remote = read('android/feature-remote/src/main/kotlin/one/zephyr/mobile/feature/remote/RemoteScreen.kt');
 const alertStart = overlays.indexOf('fun AlertDialog(');
 const alert = overlays.slice(alertStart);
 
@@ -18,9 +21,26 @@ test('alert dialog is bounded by the actual available window', () => {
   assert.match(alert, /decorFitsSystemWindows = false/);
   assert.match(alert, /BoxWithConstraints/);
   assert.match(alert, /\.imePadding\(\)/);
-  assert.match(alert, /val availableHeight = min\(maxHeight\.value - 20f, 640f\)/);
+  assert.match(alert, /AlertDialogLayout\.availableHeightDp\(windowHeightDp\)/);
   assert.match(alert, /\.heightIn\(max = availableHeight\)/);
   assert.match(alert, /\.navigationBarsPadding\(\)/);
+  assert.match(alert, /setLayout\(ViewGroup\.LayoutParams\.MATCH_PARENT, ViewGroup\.LayoutParams\.MATCH_PARENT\)/);
+  assert.match(alert, /\.width\(screenWidthDp\.dp\)/);
+  assert.match(alert, /\.height\(screenHeightDp\.dp\)/);
+  assert.match(layout, /fun availableHeightDp\(windowHeightDp: Float\)/);
+  assert.doesNotMatch(alert, /val availableHeight = min\(maxHeight\.value - 20f, 640f\)/);
+  assert.doesNotMatch(alert, /modifier\s*\n\s*\.fillMaxSize\(\)/);
+});
+
+test('host-key and certificate sheets stay opaque and wrap the fingerprint', () => {
+  assert.match(alert, /Color\(AlertDialogLayout\.sheetArgb\(palette\.dark\)\)/);
+  assert.match(layout, /DARK_SHEET_ARGB: Int = 0xFF1A1E25\.toInt\(\)/);
+  assert.match(layout, /fun wrapFingerprint/);
+  assert.match(terminal, /AlertDialogLayout\.wrapFingerprint\(prompt\.fingerprint\)/);
+  assert.match(remote, /AlertDialogLayout\.wrapFingerprint\(review\.sha256Fingerprint\)/);
+  assert.match(remote, /AlertDialogLayout\.wrapFingerprint\(previous\)/);
+  assert.match(root, /AlertDialogLayout\.wrapFingerprint\(prompt\.fingerprint\)/);
+  assert.doesNotMatch(alert, /\.background\(palette\.surfaces\.floating\)/);
 });
 
 test('alert text scrolls while confirm and cancel actions stay fixed', () => {
@@ -41,4 +61,72 @@ test('tools root has no redundant add button or callback', () => {
   assert.doesNotMatch(root, /onAddTool =/);
   assert.doesNotMatch(read('android/feature-tools/src/main/res/values/strings.xml'), /tools_root_add/);
   assert.doesNotMatch(read('android/feature-tools/src/main/res/values-en/strings.xml'), /tools_root_add/);
+});
+
+function readKotlinFloat(source, name) {
+  const match = source.match(new RegExp(`const val ${name} = ([0-9.]+)f`));
+  assert.ok(match, name + ' missing');
+  return Number(match[1]);
+}
+
+function availableHeightDp(windowHeightDp) {
+  const max = readKotlinFloat(layout, 'MAX_SHEET_DP');
+  const gutter = readKotlinFloat(layout, 'EDGE_GUTTER_DP');
+  return Math.max(Math.min(windowHeightDp - gutter * 2, max), 120);
+}
+
+function wrapFingerprint(raw) {
+  const group = Number(layout.match(/const val FINGERPRINT_GROUP = (\d+)/)[1]);
+  const perLine = Number(layout.match(/const val FINGERPRINT_GROUPS_PER_LINE = (\d+)/)[1]);
+  const compact = raw.replace(/\s+/g, '');
+  if (!compact) return raw;
+  const colon = compact.indexOf(':');
+  const head = colon > 0 && colon <= 8 ? compact.slice(0, colon) : '';
+  const prefixEnd = head && /[^0-9A-Fa-f]/.test(head) ? colon + 1 : 0;
+  const prefix = compact.slice(0, prefixEnd);
+  const payload = compact.slice(prefixEnd).replace(/:/g, '');
+  if (!payload) return compact;
+  const groups = payload.match(new RegExp(`.{1,${group}}`, 'g')) ?? [];
+  const lines = [];
+  for (let i = 0; i < groups.length; i += perLine) {
+    lines.push(groups.slice(i, i + perLine).join(' '));
+  }
+  return prefix ? prefix + lines[0] + lines.slice(1).map((line) => '\n' + line).join('') : lines.join('\n');
+}
+
+test('window-height math keeps the cancel group on a phone', () => {
+  const body = 180;
+  const stacked = body + 8 + 50 + 10;
+  assert.equal(availableHeightDp(780), 640);
+  assert.ok(stacked < availableHeightDp(780));
+  const wrapContentDialog = 220;
+  assert.ok(stacked > wrapContentDialog, 'old WRAP_CONTENT Dialog would clip cancel');
+});
+
+test('python replica of AlertDialogLayout stays in lockstep', async () => {
+  const replica = read('tests/alert-dialog-layout-replica.py');
+  assert.match(replica, /FINGERPRINT_GROUPS_PER_LINE = 6/);
+  assert.match(replica, /def wrap_fingerprint/);
+  assert.match(replica, /def available_height_dp/);
+  const { spawnSync } = await import('node:child_process');
+  const result = spawnSync('python3', [path.join(mobile, 'tests/alert-dialog-layout-replica.py')], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /alert-dialog-layout-replica ok/);
+});
+
+test('screenshot SSH fingerprint wraps instead of overflowing', () => {
+  const raw = 'SHA256:QytVAAei+gY5ISAlZF3D6WfcZGOaTGY+ygTPRiDSbl0';
+  const wrapped = wrapFingerprint(raw);
+  assert.equal(wrapped, 'SHA256:QytV AAei +gY5 ISAl ZF3D 6Wfc\nZGOa TGY+ ygTP RiDS bl0');
+  const longest = Math.max(...wrapped.split('\n').map((line) => line.length));
+  assert.ok(longest <= 48, 'longest line ' + longest);
+  const tls = Array.from({ length: 32 }, (_, i) => i.toString(16).padStart(2, '0').toUpperCase()).join(':');
+  const tlsWrapped = wrapFingerprint(tls);
+  assert.match(tlsWrapped, /^0001 0203/);
+  assert.equal(tls.replace(/:/g, ''), tlsWrapped.replace(/[\s:]/g, ''));
+  const hexHead = 'A1:B2:C3:D4:E5:F6:01:23';
+  assert.match(wrapFingerprint(hexHead), /^A1B2/);
+  assert.match(layout, /FINGERPRINT_GROUPS_PER_LINE = 6/);
 });

--- a/zephyr_one/mobile/tests/ssh-terminal-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-terminal-runtime.test.mjs
@@ -47,3 +47,12 @@ test('editor and batch execution no longer use unavailable ports', () => {
 test('remote close pops terminal route', () => {
   assert.match(root, /SessionTransport\.CLOSED[\s\S]*RootRoute\.Root\(IslandDestination\.SESSIONS\)/);
 });
+
+test('terminal copy captures ClipboardManager outside the onCopy lambda', () => {
+  // PR #29 merge failed here: LocalClipboardManager.current is @Composable and
+  // cannot be read from productionTerminalEmulator's onCopy callback.
+  assert.match(root, /val clipboardManager = LocalClipboardManager\.current/);
+  assert.match(root, /clipboardManager\.setText\(AnnotatedString\(text\)\)/);
+  assert.doesNotMatch(root, /onCopy = \{ text ->[\s\S]*LocalClipboardManager\.current/);
+});
+


### PR DESCRIPTION
## Problem
Connecting SSH/RDP/VNC shows a first-connect confirmation sheet. On a phone the sheet is cropped:

- the SHA-256 fingerprint overflows the card
- Extra Keys bleed through the translucent surface
- the cancel group is clipped below the navigation bar

Root cause: Compose `Dialog` is `WRAP_CONTENT`. The previous overflow fix measured `availableHeight` against that wrap height (`maxHeight - 20`), so the stacked cancel group never fitted. The card also reused the 78%-opaque `surfaces.floating` token.

## Fix
- Stretch the Dialog window to `MATCH_PARENT` and size the sheet from the *screen* height, not the wrap height.
- Paint an opaque sheet so Extra Keys cannot show through.
- Wrap OpenSSH (`SHA256:…`) and colon-hex TLS fingerprints into 4-character groups, 6 per line.
- Shared by SSH terminal, managed SSH pool, and RDP/VNC certificate review.

## Tests
- `tests/dialog-overflow-tools-add.test.mjs` locks the window stretch, opaque sheet, wrap call sites, and a replica of the screenshot fingerprint.
- `tests/alert-dialog-layout-replica.py` + `AlertDialogLayoutTest` lock the height math and wrap rules (including `A1:` not being treated as an algorithm prefix).
- Related contracts (`kotlin-symbols`, `rdp-operation-page`, `ssh-terminal-runtime`) still pass.

Local sandbox has no Android SDK; CI `:app:assemblePrerelease` + `testDebugUnitTest` is the compiler gate.