### PR TITLE
fix(mobile): stop unit-test hangs at their source

### DIFF
--- a/.github/workflows/zephyr-one-mobile.yml
+++ b/.github/workflows/zephyr-one-mobile.yml
@@ -184,8 +184,13 @@ jobs:
             exit "$status"
           fi
 
+      # Run test tasks serially inside one warm Gradle invocation. With project parallelism enabled,
+      # core-ui could fail while feature-sessions had already entered a leaked coroutine; Gradle then
+      # waited for the leak and hid the useful assertion behind the job timeout. --no-parallel makes
+      # the first failed module stop the graph. The root build gives every Test task its own 90-second
+      # deadline and failFast=true, so a future leak is named and cancelled by Gradle itself.
       - name: Unit tests
-        timeout-minutes: 15
+        timeout-minutes: 6
         env:
           ZEPHYR_ANDROID_FREERDP_ROOT: ${{ github.workspace }}/zephyr_one/native/freerdp-core/.freerdp-android
         shell: bash
@@ -193,7 +198,8 @@ jobs:
         run: |
           set -o pipefail
           status=0
-          stdbuf -oL -eL gradle --stacktrace --console=plain \
+          stdbuf -oL -eL gradle --stacktrace --console=plain --no-parallel --max-workers=2 \
+            -Pzephyr.unitTestTimeoutSeconds=90 \
             testReleaseUnitTest \
             -x :app:testReleaseUnitTest \
             :app:testPrereleaseUnitTest \

--- a/zephyr_one/mobile/android/build.gradle.kts
+++ b/zephyr_one/mobile/android/build.gradle.kts
@@ -1,7 +1,24 @@
+import org.gradle.api.tasks.testing.Test
+import java.time.Duration
+
 // AGP and the Kotlin Gradle plugin reach every project through the buildSrc script
 // classpath, so they must not be re-declared with a version here: Gradle rejects a
 // versioned request for a plugin that is already on the classpath. Only plugins that
 // buildSrc does not supply are pinned in this block.
 plugins {
     alias(libs.plugins.ksp) apply false
+}
+
+// CI opts into a hard deadline for every module's Test task. This is deliberately a project
+// property rather than a local default: developers may debug interactively, while CI must never
+// let a leaked coroutine or non-daemon test thread occupy a runner indefinitely.
+providers.gradleProperty("zephyr.unitTestTimeoutSeconds").orNull?.let { raw ->
+    val seconds = raw.toLongOrNull()?.takeIf { it > 0L }
+        ?: throw GradleException("zephyr.unitTestTimeoutSeconds must be a positive integer")
+    allprojects {
+        tasks.withType<Test>().configureEach {
+            failFast = true
+            timeout.set(Duration.ofSeconds(seconds))
+        }
+    }
 }

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
@@ -79,8 +79,10 @@ class AlertDialogLayoutTest {
         val once = AlertDialogLayout.wrapFingerprint(raw)
         assertEquals(once, AlertDialogLayout.wrapFingerprint(once))
         val restored = once.replace("\n", "").replace(" ", "")
-        assertEquals(raw.replace(":", ""), restored)
-        assertEquals(raw.replace(":", "").length, restored.length)
+        // The algorithm separator is part of the OpenSSH fingerprint. Only payload separators in
+        // colon-hex TLS fingerprints are removed by wrapFingerprint.
+        assertEquals(raw, restored)
+        assertEquals(raw.length, restored.length)
     }
 
     @Test

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -113,6 +113,7 @@ class TerminalViewModel(
     private val secretProvider: suspend (Connection) -> TerminalCredentials,
     private val clock: () -> Long = System::currentTimeMillis,
     private val emulatorDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val latencyRefreshMs: Long = LATENCY_REFRESH_MS,
 ) : ViewModel() {
 
     /**
@@ -401,10 +402,11 @@ class TerminalViewModel(
     private fun startLatencyProbe() {
         latencyJob?.cancel()
         latencyJob = viewModelScope.launch {
-            while (isActive) {
+            do {
                 registry.setLatency(sessionId, runCatching { host.measureLatency(sessionId) }.getOrNull())
-                delay(LATENCY_REFRESH_MS)
-            }
+                if (latencyRefreshMs <= 0L) break
+                delay(latencyRefreshMs)
+            } while (isActive)
         }
     }
 

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt
@@ -132,6 +132,8 @@ class TerminalViewModelTest {
             private set
         var trusted = 0
             private set
+        var latencyMeasurements = 0
+            private set
 
         override suspend fun open(request: TerminalOpenRequest): TerminalOpenOutcome {
             opens++
@@ -155,6 +157,11 @@ class TerminalViewModelTest {
         override suspend fun trustHostKey(sessionId: String) {
             trusted++
         }
+
+        override suspend fun measureLatency(sessionId: String): Long? {
+            latencyMeasurements++
+            return 12L
+        }
     }
 
     // ---- harness ---------------------------------------------------------------------------------
@@ -165,6 +172,7 @@ class TerminalViewModelTest {
         host: TerminalHost = FakeHost(),
         emulator: TerminalEmulator = FakeEmulator(),
         credentials: TerminalCredentials = TerminalCredentials(),
+        latencyRefreshMs: Long = 0L,
     ): TerminalViewModel = TerminalViewModel(
         sessionId = SESSION,
         connectionId = "c1",
@@ -175,6 +183,9 @@ class TerminalViewModelTest {
         secretProvider = { credentials },
         clock = { NOW },
         emulatorDispatcher = mainDispatcher,
+        // A connected ViewModel deliberately owns a repeating production probe. A non-positive
+        // test interval keeps the immediate measurement but disables recurrence.
+        latencyRefreshMs = latencyRefreshMs,
     )
 
     /** stateIn(WhileSubscribed) produces nothing without a collector. */
@@ -672,6 +683,25 @@ class TerminalViewModelTest {
         assertEquals(SessionTransport.CLOSED, registry.find(SESSION)?.transport)
         assertEquals(NOW, registry.find(SESSION)?.endedAt ?: 0L)
         assertEquals(listOf(SESSION), host.closedSessions)
+    }
+
+    @Test
+    fun latencyProbeRepeatsAtItsIntervalAndStopsWhenDisconnected() = runTest(mainDispatcher) {
+        val host = FakeHost()
+        val subject = subject(host = host, latencyRefreshMs = 5_000L)
+        subscribe(subject)
+        subject.connect()
+        runCurrent()
+
+        assertEquals(1, host.latencyMeasurements)
+        advanceTimeBy(5_000L)
+        runCurrent()
+        assertEquals(2, host.latencyMeasurements)
+
+        subject.disconnect()
+        advanceTimeBy(15_000L)
+        runCurrent()
+        assertEquals(2, host.latencyMeasurements)
     }
 
     @Test

--- a/zephyr_one/mobile/tests/android-unit-test-liveness.test.mjs
+++ b/zephyr_one/mobile/tests/android-unit-test-liveness.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+test('terminal latency loop is controllable and its JVM tests cannot spin virtual time forever', () => {
+  const source = read('android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt');
+  const unit = read('android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModelTest.kt');
+
+  assert.match(source, /private val latencyRefreshMs: Long = LATENCY_REFRESH_MS/);
+  assert.match(source, /if \(latencyRefreshMs <= 0L\) break/);
+  assert.match(source, /delay\(latencyRefreshMs\)/);
+  assert.match(source, /latencyJob\?\.cancel\(\)/);
+  assert.match(unit, /latencyRefreshMs: Long = 0L/);
+  assert.match(unit, /latencyProbeRepeatsAtItsIntervalAndStopsWhenDisconnected/);
+  assert.match(unit, /latencyRefreshMs = 5_000L/);
+});
+
+test('aggregate command still covers every current test module', () => {
+  const workflow = fs.readFileSync(path.join(ROOT, '../../.github/workflows/zephyr-one-mobile.yml'), 'utf8');
+  const settings = read('android/settings.gradle.kts');
+  const included = [...settings.matchAll(/include\(":([^"]+)"\)/g)].map((match) => match[1]);
+  const testedModules = fs.readdirSync(path.join(ROOT, 'android'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((module) => {
+      const dir = path.join(ROOT, 'android', module, 'src/test');
+      if (!fs.existsSync(dir)) return false;
+      const stack = [dir];
+      while (stack.length) {
+        const current = stack.pop();
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+          const full = path.join(current, entry.name);
+          if (entry.isDirectory()) stack.push(full);
+          else if (/Test\.(kt|java)$/.test(entry.name)) return true;
+        }
+      }
+      return false;
+    })
+    .sort();
+
+  const androidLibraries = testedModules.filter((module) =>
+    !['app', 'core-contracts', 'core-model', 'protocol-telnet', 'protocol-zft2'].includes(module),
+  );
+  assert.ok(androidLibraries.every((module) => included.includes(module)));
+  assert.match(workflow, /testReleaseUnitTest/);
+  for (const module of ['app', 'core-contracts', 'core-model', 'protocol-telnet', 'protocol-zft2']) {
+    assert.match(workflow, new RegExp(`:${module}:test`));
+  }
+  assert.equal(testedModules.length, 19);
+});

--- a/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
+++ b/zephyr_one/mobile/tests/rdp-local-engine.test.mjs
@@ -105,16 +105,21 @@ test('Android FreeRDP uses built-in NTLM crypto instead of an unavailable OpenSS
   assert.match(workflow, /ntlm-internal-crypto-v1/);
 });
 
-test('Android CI compiles once and reuses that variant for unit tests', () => {
+test('Android CI reuses release classes and bounds every unit-test module', () => {
   const workflow = read(path.join(ROOT, '../../.github/workflows/zephyr-one-mobile.yml'));
-  // `--no-daemon testDebugUnitTest` after assemblePrerelease recompiled the
-  // tree as debug and sat for 20+ minutes. Keep the daemon, reuse release
-  // classes, and never invoke the debug test task.
+  const rootBuild = read(path.join(ROOT, 'android/build.gradle.kts'));
+  // `--no-daemon testDebugUnitTest` after assemblePrerelease recompiled the tree as debug.
+  // Parallel test tasks also let a leaked module hide an earlier assertion until job timeout.
   assert.doesNotMatch(workflow, /gradle --no-daemon/);
   assert.match(workflow, /:app:assemblePrerelease/);
   assert.match(workflow, /testReleaseUnitTest/);
   assert.match(workflow, /-x :app:testReleaseUnitTest/);
   assert.match(workflow, /:app:testPrereleaseUnitTest/);
   assert.doesNotMatch(workflow, /gradle[^\n]*testDebugUnitTest/);
-  assert.match(workflow, /--console=plain/);
+  assert.match(workflow, /--no-parallel --max-workers=2/);
+  assert.match(workflow, /-Pzephyr\.unitTestTimeoutSeconds=90/);
+  assert.match(workflow, /timeout-minutes: 6/);
+  assert.match(rootBuild, /tasks\.withType<Test>\(\)\.configureEach/);
+  assert.match(rootBuild, /failFast = true/);
+  assert.match(rootBuild, /timeout\.set\(Duration\.ofSeconds\(seconds\)\)/);
 });


### PR DESCRIPTION
## Root cause

`cd0bdd4` changed terminal latency sampling into an infinite `viewModelScope` loop. `TerminalViewModelTest` runs that scope on a virtual-time dispatcher and never disposed most subjects, so `feature-sessions:testReleaseUnitTest` advanced the repeating 5-second delay forever. At the same time Gradle project parallelism let `core-ui` fail while the leaked sessions test kept the aggregate invocation alive, converting the useful assertion into a 15-minute timeout.

## Fix

- make the latency refresh interval injectable; normal JVM tests perform one immediate sample
- add a deterministic regression proving production refresh repeats and disconnect cancels it
- run the aggregate test graph with `--no-parallel --max-workers=2`
- configure every Gradle `Test` task with `failFast=true` and a CI-provided 90-second timeout
- cap the Unit tests workflow step at 6 minutes
- fix the OpenSSH fingerprint idempotence assertion (the algorithm colon is preserved)
- add contracts that lock liveness, full 19-module coverage and CI bounds

## Verification

- 19 focused Node/replica contracts pass
- Gradle cannot run in the local Android sandbox because this device JVM fails executable-page initialization; GitHub Actions is the authoritative Kotlin/Gradle run
