### PR TITLE
feat(mobile): SSH drawer Docker/monitor/SFTP parity

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
@@ -472,15 +472,19 @@ internal fun OpsDestination(
         section = section,
         onBack = onBack,
         shellFor = { connectionId ->
-            one.zephyr.mobile.feature.tools.RemoteShell { command ->
-                when (val outcome = exec.exec(connectionId, command, timeoutSeconds = 300)) {
-                    is one.zephyr.mobile.feature.tools.ExecOutcome.Completed ->
-                        one.zephyr.mobile.feature.tools.RemoteShellResult(outcome.exitCode, outcome.stdout, outcome.stderr)
-                    one.zephyr.mobile.feature.tools.ExecOutcome.TimedOut ->
-                        error("远程命令超时")
-                    is one.zephyr.mobile.feature.tools.ExecOutcome.Failed ->
-                        error(outcome.error.message)
+            object : one.zephyr.mobile.feature.tools.RemoteShell {
+                override suspend fun run(command: String): one.zephyr.mobile.feature.tools.RemoteShellResult {
+                    return when (val outcome = exec.exec(connectionId, command, timeoutSeconds = 300)) {
+                        is one.zephyr.mobile.feature.tools.ExecOutcome.Completed ->
+                            one.zephyr.mobile.feature.tools.RemoteShellResult(outcome.exitCode, outcome.stdout, outcome.stderr)
+                        one.zephyr.mobile.feature.tools.ExecOutcome.TimedOut ->
+                            error("远程命令超时")
+                        is one.zephyr.mobile.feature.tools.ExecOutcome.Failed ->
+                            error(outcome.error.message)
+                    }
                 }
+
+                override fun stream(command: String) = exec.execStream(connectionId, command)
             }
         },
         onMessage = onMessage,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
@@ -462,10 +462,29 @@ internal fun OpsDestination(
     account: AccountContainer,
     ownerUserId: String,
     section: OpsSection,
+    exec: one.zephyr.mobile.feature.tools.SshExecPort,
     onBack: () -> Unit,
+    onMessage: (String) -> Unit,
 ) {
     val connections by account.connections.observeAll(ownerUserId).collectAsState(initial = emptyList())
-    DockerMonitorScreen(connections = connections, section = section, onBack = onBack)
+    DockerMonitorScreen(
+        connections = connections,
+        section = section,
+        onBack = onBack,
+        shellFor = { connectionId ->
+            one.zephyr.mobile.feature.tools.RemoteShell { command ->
+                when (val outcome = exec.exec(connectionId, command, timeoutSeconds = 300)) {
+                    is one.zephyr.mobile.feature.tools.ExecOutcome.Completed ->
+                        one.zephyr.mobile.feature.tools.RemoteShellResult(outcome.exitCode, outcome.stdout, outcome.stderr)
+                    one.zephyr.mobile.feature.tools.ExecOutcome.TimedOut ->
+                        error("远程命令超时")
+                    is one.zephyr.mobile.feature.tools.ExecOutcome.Failed ->
+                        error(outcome.error.message)
+                }
+            }
+        },
+        onMessage = onMessage,
+    )
 }
 
 @Composable

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/LiveSshExecPort.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/LiveSshExecPort.kt
@@ -1,12 +1,19 @@
 package one.zephyr.mobile.app
 
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import one.zephyr.mobile.data.session.SessionRegistry
 import one.zephyr.mobile.data.session.SessionTransport
 import one.zephyr.mobile.feature.tools.ExecOutcome
+import one.zephyr.mobile.feature.tools.RemoteShellChunk
 import one.zephyr.mobile.feature.tools.SshExecPort
 import one.zephyr.mobile.model.MobileError
 import one.zephyr.mobile.protocol.ssh.SshEngine
+import one.zephyr.mobile.protocol.ssh.SshExecEvent
+
 
 /** Reuses a live terminal session or automatically opens a managed SSH session. */
 internal class LiveSshExecPort(
@@ -38,14 +45,44 @@ internal class LiveSshExecPort(
                 )
             },
             onFailure = { failure ->
+                val connecting = existing == null
                 ExecOutcome.Failed(
                     MobileError.local(
-                        code = "ssh_exec_failed",
-                        message = failure.message ?: "SSH 远程执行失败",
+                        code = if (connecting) "ssh_connect_failed" else "ssh_exec_failed",
+                        message = if (connecting) {
+                            "自动连接失败：${failure.message ?: "无法建立 SSH"}"
+                        } else {
+                            failure.message ?: "SSH 远程执行失败"
+                        },
                         retryable = true,
                     ),
                 )
             },
         )
+    }
+
+    override fun execStream(connectionId: String, command: String): Flow<RemoteShellChunk> = callbackFlow {
+        val existing = sessions.rows.value.firstOrNull {
+            it.connectionId == connectionId && it.transport == SessionTransport.CONNECTED
+        }
+        val lease = if (existing == null) managed.acquire(connectionId) else null
+        val sessionId = existing?.sessionId ?: lease!!.sessionId
+        val job = launch {
+            try {
+                engine.execStream(sessionId, command).collect { event ->
+                    when (event) {
+                        is SshExecEvent.Stdout -> trySend(RemoteShellChunk.Output(event.bytes.toString(Charsets.UTF_8)))
+                        is SshExecEvent.Stderr -> trySend(RemoteShellChunk.Output(event.bytes.toString(Charsets.UTF_8)))
+                        is SshExecEvent.Closed -> trySend(RemoteShellChunk.Closed(event.exitCode))
+                    }
+                }
+            } finally {
+                close()
+            }
+        }
+        awaitClose {
+            job.cancel()
+            launch { lease?.close() }
+        }
     }
 }

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt
@@ -155,6 +155,42 @@ class SshjSftpPort(
         )
     }
 
+    override fun execStream(
+        handle: SftpSessionHandle,
+        command: String,
+    ): kotlinx.coroutines.flow.Flow<one.zephyr.mobile.feature.notes.RemoteExecChunk> =
+        kotlinx.coroutines.flow.flow {
+            engine.execStream(session(handle), command).collect { event ->
+                when (event) {
+                    is one.zephyr.mobile.protocol.ssh.SshExecEvent.Stdout ->
+                        emit(one.zephyr.mobile.feature.notes.RemoteExecChunk.Output(event.bytes.toString(Charsets.UTF_8), stderr = false))
+                    is one.zephyr.mobile.protocol.ssh.SshExecEvent.Stderr ->
+                        emit(one.zephyr.mobile.feature.notes.RemoteExecChunk.Output(event.bytes.toString(Charsets.UTF_8), stderr = true))
+                    is one.zephyr.mobile.protocol.ssh.SshExecEvent.Closed ->
+                        emit(one.zephyr.mobile.feature.notes.RemoteExecChunk.Closed(event.exitCode))
+                }
+            }
+        }
+
+    override suspend fun readStream(
+        handle: SftpSessionHandle,
+        path: String,
+        resumeFromBytes: Long,
+        onChunk: suspend (offset: Long, bytes: ByteArray, total: Long) -> Unit,
+    ): RemoteWriteReceipt {
+        val version = engine.readFileStream(session(handle), path, resumeFromBytes, onChunk).getOrThrow()
+        return RemoteWriteReceipt(version.path, version.modifiedAt, "")
+    }
+
+    override suspend fun writeStream(
+        handle: SftpSessionHandle,
+        path: String,
+        next: suspend () -> ByteArray?,
+    ): RemoteWriteReceipt {
+        val version = engine.writeFileStream(session(handle), path, expected = null, next = next).getOrThrow()
+        return RemoteWriteReceipt(version.path, version.modifiedAt, "")
+    }
+
     private fun SftpEntry.remote() = RemoteEntry(
         name, path, isDirectory, size, modifiedAt, permissions.toString(8), isSymlink,
     )

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt
@@ -4,6 +4,7 @@ import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import one.zephyr.mobile.feature.notes.DownloadProgress
 import one.zephyr.mobile.feature.notes.RemoteEntry
+import one.zephyr.mobile.feature.notes.RemoteExecResult
 import one.zephyr.mobile.feature.notes.RemoteFileRead
 import one.zephyr.mobile.feature.notes.RemoteStat
 import one.zephyr.mobile.feature.notes.RemoteWriteReceipt
@@ -57,8 +58,18 @@ class SshjSftpPort(
         }
 
     override suspend fun read(handle: SftpSessionHandle, path: String, maxBytes: Long): RemoteFileRead {
-        val file = engine.readFile(session(handle), path, maxBytes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()).getOrThrow()
-        return RemoteFileRead(file.path, file.bytes, file.modifiedAt, sha256(file.bytes), truncated = false)
+        val file = engine.readFile(
+            session(handle),
+            path,
+            maxBytes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+        ).getOrThrow()
+        return RemoteFileRead(
+            file.path,
+            file.bytes,
+            file.modifiedAt,
+            sha256(file.bytes),
+            truncated = file.bytes.size.toLong() < file.size,
+        )
     }
 
     override suspend fun write(
@@ -102,6 +113,26 @@ class SshjSftpPort(
         engine.delete(session(handle), path, recursive).getOrThrow()
     }
 
+    override suspend fun chmod(handle: SftpSessionHandle, path: String, mode: Int) {
+        engine.chmod(session(handle), path, mode).getOrThrow()
+    }
+
+    override suspend fun readRange(
+        handle: SftpSessionHandle,
+        path: String,
+        offset: Long,
+        maxBytes: Int,
+    ): RemoteFileRead {
+        val file = engine.readFileRange(session(handle), path, offset, maxBytes).getOrThrow()
+        return RemoteFileRead(
+            file.path,
+            file.bytes,
+            file.modifiedAt,
+            sha256(file.bytes),
+            truncated = offset + file.bytes.size < file.size,
+        )
+    }
+
     override suspend fun upload(handle: SftpSessionHandle, path: String, bytes: ByteArray): RemoteWriteReceipt {
         val version = engine.writeFile(session(handle), path, bytes).getOrThrow()
         return RemoteWriteReceipt(version.path, version.modifiedAt, sha256(bytes))
@@ -114,6 +145,15 @@ class SshjSftpPort(
         resumeFromBytes: Long,
         onProgress: (DownloadProgress) -> Unit,
     ): Long = throw UnsupportedOperationException("SAF download sink is not available in this adapter")
+
+    override suspend fun exec(handle: SftpSessionHandle, command: String): RemoteExecResult {
+        val result = engine.exec(session(handle), command).getOrThrow()
+        return RemoteExecResult(
+            exitCode = result.exitCode,
+            stdout = result.stdout.toString(Charsets.UTF_8),
+            stderr = result.stderr.toString(Charsets.UTF_8),
+        )
+    }
 
     private fun SftpEntry.remote() = RemoteEntry(
         name, path, isDirectory, size, modifiedAt, permissions.toString(8), isSymlink,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -733,7 +733,9 @@ private fun BoundRoot(
                 account = account,
                 ownerUserId = ownerUserId,
                 section = current.section,
+                exec = LiveSshExecPort(sshEngine, account.sessions, managedSsh),
                 onBack = { route = RootRoute.Root(IslandDestination.TOOLS) },
+                onMessage = notice,
             )
             is RootRoute.ResourceList -> ResourceListDestination(
                 account = account,

--- a/zephyr_one/mobile/android/feature-notes/build.gradle.kts
+++ b/zephyr_one/mobile/android/feature-notes/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":core-ui"))
     implementation(project(":core-sync"))
     implementation(project(":core-data"))
+    implementation(project(":protocol-ssh"))
     implementation(libs.kotlinx.coroutines.android)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
@@ -1,39 +1,80 @@
 package one.zephyr.mobile.feature.notes
 
+import android.graphics.BitmapFactory
+import android.media.MediaPlayer
+import android.net.Uri
+import android.view.ViewGroup
+import android.widget.VideoView
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.launch
 import one.zephyr.mobile.model.MobileApiException
+import one.zephyr.mobile.protocol.ssh.SshFileKinds
 import one.zephyr.mobile.ui.component.*
 import one.zephyr.mobile.ui.icon.ZephyrIcons
 import one.zephyr.mobile.ui.theme.ZephyrTheme
+import java.io.File
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
 
-private const val EDIT_READ_LIMIT = 512L * 1024L
-private const val EDIT_WRITE_LIMIT = 1024 * 1024
+private const val EDIT_WRITE_LIMIT = 2 * 1024 * 1024
 
 private data class BrowserFile(
     val path: String,
     val text: String,
     val baseline: RemoteFileRead,
+    val encoding: FileEncoding = FileEncoding.UTF8,
+    val lineEnding: String = if (text.contains("\r\n")) "crlf" else "lf",
     val dirty: Boolean = false,
 )
 
+private data class PreviewState(
+    val path: String,
+    val kind: SftpOpenKind,
+    val bytes: ByteArray,
+    val sizeBytes: Long,
+)
+
+private data class TransferJob(
+    val label: String,
+    val progress: Float,
+    val detail: String,
+)
+
+private sealed interface SftpDialog {
+    data class PromptName(val title: String, val initial: String, val confirm: String, val onConfirm: (String) -> Unit) : SftpDialog
+    data class Confirm(val title: String, val body: String, val danger: Boolean = false, val onConfirm: () -> Unit) : SftpDialog
+    data class Properties(val title: String, val lines: List<Pair<String, String>>) : SftpDialog
+    data class Chmod(val path: String, val initial: String) : SftpDialog
+    data class PasteConflict(val names: List<String>) : SftpDialog
+    data class SaveConflict(val path: String) : SftpDialog
+}
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SftpBrowserPane(
     port: SftpPort,
@@ -43,22 +84,93 @@ fun SftpBrowserPane(
     onDirtyChanged: (Boolean) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     var handle by remember(connectionId, port) { mutableStateOf<SftpSessionHandle?>(null) }
     var path by remember(connectionId) { mutableStateOf(".") }
+    var pathDraft by remember { mutableStateOf(".") }
     var entries by remember { mutableStateOf<List<RemoteEntry>>(emptyList()) }
     var loading by remember { mutableStateOf(true) }
     var error by remember { mutableStateOf<String?>(null) }
     var revision by remember { mutableIntStateOf(0) }
+    var query by remember { mutableStateOf("") }
+    var showHidden by remember { mutableStateOf(false) }
+    var sortKey by remember { mutableStateOf(FileSortKey.NAME) }
+    var selecting by remember { mutableStateOf(false) }
+    var selected by remember { mutableStateOf<Set<String>>(emptySet()) }
     var editor by remember { mutableStateOf<BrowserFile?>(null) }
+    var preview by remember { mutableStateOf<PreviewState?>(null) }
     var pendingClose by remember { mutableStateOf(false) }
+    var dialog by remember { mutableStateOf<SftpDialog?>(null) }
+    var clipboard by remember { mutableStateOf<SftpClipboard?>(null) }
+    var transfer by remember { mutableStateOf<TransferJob?>(null) }
+    var busy by remember { mutableStateOf(false) }
+    var moreOpen by remember { mutableStateOf(false) }
     LaunchedEffect(editor?.dirty) { onDirtyChanged(editor?.dirty == true) }
 
-    BackHandler(enabled = editor != null) {
-        if (editor?.dirty == true) pendingClose = true else editor = null
+    val overlayOpen = editor != null || preview != null
+    BackHandler(enabled = overlayOpen || selecting) {
+        when {
+            editor?.dirty == true -> pendingClose = true
+            editor != null -> editor = null
+            preview != null -> preview = null
+            selecting -> {
+                selecting = false
+                selected = emptySet()
+            }
+        }
     }
 
     DisposableEffect(connectionId, port) {
         onDispose { handle?.let { scope.launch { port.close(it) } } }
+    }
+
+    fun currentHandle(): SftpSessionHandle = handle ?: error("SFTP 会话已断开")
+
+    fun refresh() {
+        revision++
+    }
+
+    val uploadLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        scope.launch {
+            runOp(onMessage, { busy = it }, { transfer = it }) {
+                val active = currentHandle()
+                uris.forEachIndexed { index, uri ->
+                    val name = queryDisplayName(context, uri) ?: "upload-${index + 1}"
+                    transfer = TransferJob("上传 $name", index.toFloat() / uris.size, "${index + 1}/${uris.size}")
+                    val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                        ?: error("无法读取 $name")
+                    if (bytes.size > EDIT_WRITE_LIMIT) error("$name 超过 ${SftpOpenPolicy.formatBytes(EDIT_WRITE_LIMIT.toLong())}，当前版本请改用较小文件")
+                    port.upload(active, RemotePath.join(path, name), bytes)
+                }
+                onMessage("已上传 ${uris.size} 个文件")
+                refresh()
+            }
+        }
+    }
+    var downloadTarget by remember { mutableStateOf<RemoteEntry?>(null) }
+    val downloadLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { uri ->
+        val entry = downloadTarget
+        downloadTarget = null
+        if (uri == null || entry == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            runOp(onMessage, { busy = it }, { transfer = it }) {
+                val active = currentHandle()
+                context.contentResolver.openOutputStream(uri)?.use { output ->
+                    var offset = 0L
+                    val total = entry.sizeBytes.coerceAtLeast(1L)
+                    while (offset < entry.sizeBytes || entry.sizeBytes == 0L) {
+                        val chunk = port.readRange(active, entry.path, offset, 256 * 1024)
+                        if (chunk.bytes.isEmpty()) break
+                        output.write(chunk.bytes)
+                        offset += chunk.bytes.size
+                        transfer = TransferJob("下载 ${entry.name}", (offset.toFloat() / total).coerceIn(0f, 1f), SftpOpenPolicy.formatBytes(offset))
+                        if (chunk.bytes.size < 256 * 1024) break
+                    }
+                } ?: error("无法写入本机文件")
+                onMessage("已下载 ${entry.name}")
+            }
+        }
     }
 
     LaunchedEffect(connectionId, revision) {
@@ -68,151 +180,721 @@ fun SftpBrowserPane(
             val active = handle ?: port.open(connectionId).also {
                 handle = it
                 path = runCatching { port.canonicalPath(it, ".") }.getOrDefault("/")
+                pathDraft = path
             }
             val listed = port.list(active, path)
+            path = runCatching { port.canonicalPath(active, path) }.getOrDefault(path)
+            pathDraft = path
             entries = listed.sortedWith(compareByDescending<RemoteEntry> { it.isDirectory }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+            selected = selected.intersect(listed.map { it.path }.toSet())
         }.onFailure { error = it.displayMessage() }
         loading = false
     }
 
-    if (editor != null) {
-        SftpTextEditor(
-            file = editor!!,
-            onChange = { editor = editor!!.copy(text = it, dirty = true) },
-            onBack = { if (editor!!.dirty) pendingClose = true else editor = null },
-            onSave = {
-                scope.launch {
-                    val current = editor ?: return@launch
-                    val bytes = current.text.toByteArray(Charsets.UTF_8)
-                    if (bytes.size > EDIT_WRITE_LIMIT) {
-                        onMessage("文件超过 1 MiB，拒绝保存")
-                        return@launch
-                    }
-                    runCatching {
-                        port.write(
-                            handle ?: error("SFTP 会话已断开"), current.path, bytes,
-                            current.baseline.mtimeMs, current.baseline.sha256, force = false,
-                        )
-                    }.onSuccess { receipt ->
-                        editor = current.copy(
-                            baseline = RemoteFileRead(current.path, bytes, receipt.mtimeMs, receipt.sha256),
-                            dirty = false,
-                        )
-                        onMessage("已保存")
-                    }.onFailure { onMessage(it.displayMessage()) }
-                }
-            },
+    val visible = remember(entries, query, showHidden, sortKey) {
+        SftpBrowserStates.filterAndSort(
+            entries,
+            SftpBrowserInput(
+                connectionId = connectionId,
+                directory = path,
+                entries = entries,
+                query = query,
+                showHidden = showHidden,
+                sortKey = sortKey,
+            ),
         )
-    } else {
-        Column(modifier.fillMaxSize()) {
-            SftpPathBar(
-                path = path,
-                canGoUp = path != "/" && path != ".",
-                onUp = { path = parentPath(path); revision++ },
-                onRefresh = { revision++ },
-            )
-            when {
-                loading -> SftpEmpty("正在连接并读取 $path…")
-                error != null -> SftpError(error!!, onRetry = { revision++ })
-                entries.isEmpty() -> SftpEmpty("$path · 空目录")
-                else -> LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 24.dp)) {
-                    items(entries, key = { it.path }) { entry ->
-                        SftpEntryRow(entry) {
-                            if (entry.isDirectory) {
-                                path = entry.path
-                                revision++
-                            } else {
-                                scope.launch {
-                                    runCatching {
-                                        val read = port.read(handle ?: error("SFTP 会话已断开"), entry.path, EDIT_READ_LIMIT)
-                                        require(!read.truncated) { "文件超过 512 KiB，拒绝编辑" }
-                                        val text = decodeUtf8Text(read.bytes)
-                                        BrowserFile(entry.path, text, read)
-                                    }.onSuccess { editor = it }.onFailure { onMessage(it.displayMessage()) }
+    }
+
+    fun selectedEntries(): List<RemoteEntry> {
+        val picked = entries.filter { it.path in selected }
+        return picked.ifEmpty { emptyList() }
+    }
+
+    fun openEntry(entry: RemoteEntry) {
+        if (selecting) {
+            selected = if (entry.path in selected) selected - entry.path else selected + entry.path
+            if (selected.isEmpty()) selecting = false
+            return
+        }
+        val kind = SftpOpenPolicy.kindOf(entry)
+        if (kind == SftpOpenKind.DIRECTORY) {
+            path = entry.path
+            pathDraft = entry.path
+            refresh()
+            return
+        }
+        SftpOpenPolicy.rejectReason(kind, entry.sizeBytes)?.let {
+            onMessage(it)
+            return
+        }
+        scope.launch {
+            runOp(onMessage, { busy = it }, { transfer = it }) {
+                when (kind) {
+                    SftpOpenKind.TEXT -> {
+                        val read = port.read(currentHandle(), entry.path, SftpOpenPolicy.TEXT_EDIT_LIMIT)
+                        require(!read.truncated) { "文件超过 ${SftpOpenPolicy.formatBytes(SftpOpenPolicy.TEXT_EDIT_LIMIT)}，拒绝编辑" }
+                        require(!FileEncoding.looksBinary(read.bytes)) { "检测到二进制内容，拒绝编辑" }
+                        val encoding = FileEncoding.guess(read.bytes)
+                        editor = BrowserFile(entry.path, encoding.decode(read.bytes), read, encoding)
+                    }
+                    SftpOpenKind.IMAGE, SftpOpenKind.MEDIA -> {
+                        val read = port.readRange(
+                            currentHandle(),
+                            entry.path,
+                            0L,
+                            SftpOpenPolicy.previewLimit(kind).toInt(),
+                        )
+                        preview = PreviewState(entry.path, kind, read.bytes, entry.sizeBytes)
+                    }
+                    SftpOpenKind.ARCHIVE -> {
+                        dialog = SftpDialog.PromptName(
+                            title = "解压到",
+                            initial = RemotePath.join(path, RemotePath.nameOf(entry.path).removeSuffix(SshFileKinds.archiveExtensionOf(entry.name)).ifBlank { entry.name + "-out" }),
+                            confirm = "解压",
+                        ) { target ->
+                            scope.launch {
+                                runOp(onMessage, { busy = it }, { transfer = it }) {
+                                    port.exec(currentHandle(), SshFileKinds.extractCommand(entry.path, target)).requireOk("解压")
+                                    onMessage("已解压到 $target")
+                                    refresh()
                                 }
                             }
+                        }
+                    }
+                    SftpOpenKind.BINARY -> showProperties(currentHandle(), port, listOf(entry)) { dialog = it }
+                    SftpOpenKind.DIRECTORY -> Unit
+                }
+            }
+        }
+    }
+
+    fun runNamed(title: String, initial: String, confirm: String, block: suspend (String) -> Unit) {
+        dialog = SftpDialog.PromptName(title, initial, confirm) { value ->
+            scope.launch { runOp(onMessage, { busy = it }, { transfer = it }) { block(value) } }
+        }
+    }
+
+    fun createFolder() = runNamed("新建文件夹", "new-folder", "创建") { name ->
+        require(RemotePath.isValidLeafName(name)) { "名称无效" }
+        port.createDirectory(currentHandle(), RemotePath.join(path, name))
+        onMessage("已创建文件夹")
+        refresh()
+    }
+
+    fun createFile() = runNamed("新建文件", "untitled.txt", "创建") { name ->
+        require(RemotePath.isValidLeafName(name)) { "名称无效" }
+        port.createFile(currentHandle(), RemotePath.join(path, name))
+        onMessage("已创建文件")
+        refresh()
+    }
+
+    fun renameSelected() {
+        val entry = selectedEntries().singleOrNull() ?: return
+        runNamed("重命名", entry.name, "确定") { name ->
+            require(RemotePath.isValidLeafName(name)) { "名称无效" }
+            port.rename(currentHandle(), entry.path, RemotePath.join(path, name))
+            onMessage("已重命名")
+            selected = emptySet()
+            selecting = false
+            refresh()
+        }
+    }
+
+    fun deleteSelected() {
+        val targets = selectedEntries()
+        if (targets.isEmpty()) return
+        dialog = SftpDialog.Confirm(
+            title = "删除 ${targets.size} 项？",
+            body = targets.joinToString("\n") { it.name },
+            danger = true,
+        ) {
+            scope.launch {
+                runOp(onMessage, { busy = it }, { transfer = it }) {
+                    targets.forEach { entry ->
+                        if (entry.isDirectory) {
+                            port.exec(currentHandle(), SshFileKinds.recursiveDeleteCommand(entry.path)).requireOk("删除")
+                        } else {
+                            port.delete(currentHandle(), entry.path, recursive = false)
+                        }
+                    }
+                    onMessage("已删除")
+                    selected = emptySet()
+                    selecting = false
+                    refresh()
+                }
+            }
+        }
+    }
+
+    fun copyOrCut(cut: Boolean) {
+        val targets = selectedEntries()
+        if (targets.isEmpty()) return
+        clipboard = SftpClipboard(
+            mode = if (cut) SftpClipboardMode.CUT else SftpClipboardMode.COPY,
+            paths = targets.map { it.path },
+            sourceDirectory = path,
+        )
+        onMessage(if (cut) "已剪切 ${targets.size} 项" else "已复制 ${targets.size} 项")
+    }
+
+    fun pasteClipboard() {
+        val clip = clipboard ?: return
+        val existing = entries.map { it.name }.toSet()
+        val names = clip.paths.map(RemotePath::nameOf)
+        if (names.any { it in existing }) {
+            dialog = SftpDialog.PasteConflict(names.filter { it in existing })
+            return
+        }
+        applyPaste(
+            clip, SftpPasteConflictMode.COMPATIBLE, existing, port, path, currentHandle(),
+            onMessage, { busy = it }, { transfer = it },
+            {
+                if (clip.mode == SftpClipboardMode.CUT) clipboard = null
+                refresh()
+            },
+            scope,
+        )
+    }
+
+    fun compressSelected() {
+        val targets = selectedEntries()
+        if (targets.isEmpty()) return
+        val defaultName = (if (targets.size == 1) targets.first().name else RemotePath.nameOf(path).ifBlank { "archive" }) + ".tar.gz"
+        runNamed("压缩到", RemotePath.join(path, defaultName), "压缩") { target ->
+            port.exec(currentHandle(), SshFileKinds.compressCommand(targets.map { it.path }, target)).requireOk("压缩")
+            onMessage("已压缩到 $target")
+            refresh()
+        }
+    }
+
+    fun chmodSelected() {
+        val entry = selectedEntries().singleOrNull() ?: return
+        dialog = SftpDialog.Chmod(entry.path, entry.permissions.ifBlank { "644" })
+    }
+
+    fun downloadSelected() {
+        val entry = selectedEntries().singleOrNull() ?: return
+        if (entry.isDirectory) {
+            onMessage("目录请先压缩再下载")
+            return
+        }
+        downloadTarget = entry
+        downloadLauncher.launch(entry.name)
+    }
+
+    fun showSelectedProperties() {
+        val targets = selectedEntries()
+        if (targets.isEmpty()) return
+        scope.launch {
+            runOp(onMessage, { busy = it }, { transfer = it }) {
+                showProperties(currentHandle(), port, targets) { dialog = it }
+            }
+        }
+    }
+
+    Box(modifier.fillMaxSize()) {
+        when {
+            editor != null -> SftpTextEditor(
+                file = editor!!,
+                onChange = { text, encoding, ending ->
+                    editor = editor!!.copy(text = text, encoding = encoding, lineEnding = ending, dirty = true)
+                },
+                onBack = { if (editor!!.dirty) pendingClose = true else editor = null },
+                onSave = {
+                    val current = editor ?: return@SftpTextEditor
+                    scope.launch {
+                        runOp(onMessage, { busy = it }, { transfer = it }) {
+                            val normalized = if (current.lineEnding == "crlf") {
+                                current.text.replace("\r\n", "\n").replace("\n", "\r\n")
+                            } else {
+                                current.text.replace("\r\n", "\n")
+                            }
+                            val bytes = current.encoding.encode(normalized)
+                            if (bytes.size > EDIT_WRITE_LIMIT) error("文件超过 2 MiB，拒绝保存")
+                            val receipt = runCatching {
+                                port.write(
+                                    currentHandle(), current.path, bytes,
+                                    current.baseline.mtimeMs, current.baseline.sha256, force = false,
+                                )
+                            }.getOrElse { failure ->
+                                if (failure.message?.contains("已变化") == true || failure is one.zephyr.mobile.protocol.ssh.SshRemoteFileConflict) {
+                                    dialog = SftpDialog.SaveConflict(current.path)
+                                    return@runOp
+                                }
+                                throw failure
+                            }
+                            editor = current.copy(
+                                baseline = RemoteFileRead(current.path, bytes, receipt.mtimeMs, receipt.sha256),
+                                dirty = false,
+                            )
+                            onMessage("已保存")
+                        }
+                    }
+                },
+            )
+            preview != null -> SftpPreviewPane(
+                preview = preview!!,
+                cacheDir = context.cacheDir,
+                onBack = { preview = null },
+                onMessage = onMessage,
+            )
+            else -> Column(Modifier.fillMaxSize()) {
+                SftpPathBar(
+                    path = pathDraft,
+                    canGoUp = path != "/" && path != ".",
+                    busy = busy || loading,
+                    onPathChange = { pathDraft = it },
+                    onGo = {
+                        path = pathDraft.ifBlank { "/" }
+                        refresh()
+                    },
+                    onUp = { path = parentPath(path); pathDraft = path; refresh() },
+                    onRefresh = { refresh() },
+                    moreOpen = moreOpen,
+                    onToggleMore = { moreOpen = !moreOpen },
+                    onHidden = { showHidden = !showHidden; moreOpen = false },
+                    hiddenOn = showHidden,
+                    sortKey = sortKey,
+                    onSort = { sortKey = it; moreOpen = false },
+                    onNewFolder = { moreOpen = false; createFolder() },
+                    onNewFile = { moreOpen = false; createFile() },
+                    onUpload = { moreOpen = false; uploadLauncher.launch("*/*") },
+                    canPaste = clipboard != null,
+                    onPaste = { moreOpen = false; pasteClipboard() },
+                )
+                SftpSearchBar(query = query, onQuery = { query = it }, selecting = selecting, selectedCount = selected.size)
+                SftpActionBar(
+                    selecting = selecting,
+                    selectedCount = selected.size,
+                    canPaste = clipboard != null,
+                    onSelect = { selecting = !selecting; if (!selecting) selected = emptySet() },
+                    onCopy = { copyOrCut(false) },
+                    onCut = { copyOrCut(true) },
+                    onPaste = { pasteClipboard() },
+                    onRename = { renameSelected() },
+                    onDelete = { deleteSelected() },
+                    onCompress = { compressSelected() },
+                    onChmod = { chmodSelected() },
+                    onDownload = { downloadSelected() },
+                    onProperties = { showSelectedProperties() },
+                )
+                transfer?.let { job ->
+                    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp)) {
+                        Text(job.label, color = ZephyrTheme.palette.onFloatingMuted, fontSize = 11.sp)
+                        LinearProgress(progress = job.progress, modifier = Modifier.padding(top = 4.dp))
+                        Text(job.detail, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 10.sp)
+                    }
+                }
+                when {
+                    loading -> SftpEmpty("正在连接并读取 $path…")
+                    error != null -> SftpError(error!!, onRetry = { refresh() })
+                    visible.isEmpty() -> SftpEmpty(if (query.isNotBlank()) "没有匹配 $query 的项目" else "$path · 空目录")
+                    else -> LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 24.dp)) {
+                        items(visible, key = { it.path }) { entry ->
+                            SftpEntryRow(
+                                entry = entry,
+                                selected = entry.path in selected,
+                                selecting = selecting,
+                                onClick = { openEntry(entry) },
+                                onLongClick = {
+                                    selecting = true
+                                    selected = selected + entry.path
+                                },
+                            )
                         }
                     }
                 }
             }
         }
-    }
 
-    if (pendingClose) {
-        AlertDialog(
-            onDismissRequest = { pendingClose = false },
-            title = { Text("放弃未保存修改？") },
-            text = { Text("返回文件列表会丢失当前修改。") },
-            confirmButton = { TextButton(onClick = { pendingClose = false; editor = null }) { Text("放弃") } },
-            dismissButton = { TextButton(onClick = { pendingClose = false }) { Text("继续编辑") } },
-        )
+        if (pendingClose) {
+            AlertDialog(
+                onDismissRequest = { pendingClose = false },
+                title = { Text("放弃未保存修改？") },
+                text = { Text("返回文件列表会丢失当前修改。") },
+                confirmButton = { TextButton(onClick = { pendingClose = false; editor = null }) { Text("放弃") } },
+                dismissButton = { TextButton(onClick = { pendingClose = false }) { Text("继续编辑") } },
+            )
+        }
+
+        when (val current = dialog) {
+            is SftpDialog.PromptName -> NamePromptDialog(
+                title = current.title,
+                initial = current.initial,
+                confirm = current.confirm,
+                onDismiss = { dialog = null },
+                onConfirm = { dialog = null; current.onConfirm(it) },
+            )
+            is SftpDialog.Confirm -> AlertDialog(
+                onDismissRequest = { dialog = null },
+                title = { Text(current.title) },
+                text = { Text(current.body) },
+                confirmButton = {
+                    TextButton(onClick = { dialog = null; current.onConfirm() }) {
+                        Text(if (current.danger) "删除" else "确定")
+                    }
+                },
+                dismissButton = { TextButton(onClick = { dialog = null }) { Text("取消") } },
+            )
+            is SftpDialog.Properties -> AlertDialog(
+                onDismissRequest = { dialog = null },
+                title = { Text(current.title) },
+                text = {
+                    Column {
+                        current.lines.forEach { (label, value) ->
+                            Text("$label  $value", fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                        }
+                    }
+                },
+                confirmButton = { TextButton(onClick = { dialog = null }) { Text("关闭") } },
+            )
+            is SftpDialog.Chmod -> NamePromptDialog(
+                title = "权限（八进制）",
+                initial = current.initial,
+                confirm = "应用",
+                onDismiss = { dialog = null },
+                onConfirm = { mode ->
+                    dialog = null
+                    scope.launch {
+                        runOp(onMessage, { busy = it }, { transfer = it }) {
+                            port.chmod(currentHandle(), current.path, SshFileKinds.decodeOctalMode(mode))
+                            onMessage("已修改权限")
+                            refresh()
+                        }
+                    }
+                },
+            )
+            is SftpDialog.PasteConflict -> {
+                val clip = clipboard
+                AlertDialog(
+                    onDismissRequest = { dialog = null },
+                    title = { Text("目标已存在同名项目") },
+                    text = { Text(current.names.joinToString("\n") + "\n\n覆盖 / 跳过 / 自动改名（兼容）") },
+                    confirmButton = {
+                        Column {
+                            TextButton(onClick = {
+                                dialog = null
+                                if (clip != null) applyPaste(
+                                    clip, SftpPasteConflictMode.OVERWRITE, entries.map { it.name }.toSet(),
+                                    port, path, currentHandle(), onMessage, { busy = it }, { transfer = it },
+                                    { if (clip.mode == SftpClipboardMode.CUT) clipboard = null; refresh() }, scope,
+                                )
+                            }) { Text("覆盖") }
+                            TextButton(onClick = {
+                                dialog = null
+                                if (clip != null) applyPaste(
+                                    clip, SftpPasteConflictMode.SKIP, entries.map { it.name }.toSet(),
+                                    port, path, currentHandle(), onMessage, { busy = it }, { transfer = it },
+                                    { if (clip.mode == SftpClipboardMode.CUT) clipboard = null; refresh() }, scope,
+                                )
+                            }) { Text("跳过") }
+                            TextButton(onClick = {
+                                dialog = null
+                                if (clip != null) applyPaste(
+                                    clip, SftpPasteConflictMode.COMPATIBLE, entries.map { it.name }.toSet(),
+                                    port, path, currentHandle(), onMessage, { busy = it }, { transfer = it },
+                                    { if (clip.mode == SftpClipboardMode.CUT) clipboard = null; refresh() }, scope,
+                                )
+                            }) { Text("兼容") }
+                        }
+                    },
+                    dismissButton = { TextButton(onClick = { dialog = null }) { Text("取消") } },
+                )
+            }
+            is SftpDialog.SaveConflict -> AlertDialog(
+                onDismissRequest = { dialog = null },
+                title = { Text("远端文件已变化") },
+                text = { Text("保存会覆盖其他人刚写入的内容。") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        dialog = null
+                        val currentFile = editor ?: return@TextButton
+                        scope.launch {
+                            runOp(onMessage, { busy = it }, { transfer = it }) {
+                                val bytes = currentFile.encoding.encode(currentFile.text)
+                                val receipt = port.write(currentHandle(), currentFile.path, bytes, null, null, force = true)
+                                editor = currentFile.copy(
+                                    baseline = RemoteFileRead(currentFile.path, bytes, receipt.mtimeMs, receipt.sha256),
+                                    dirty = false,
+                                )
+                                onMessage("已强制覆盖保存")
+                            }
+                        }
+                    }) { Text("覆盖远端") }
+                },
+                dismissButton = { TextButton(onClick = { dialog = null }) { Text("继续编辑") } },
+            )
+            null -> Unit
+        }
+    }
+}
+
+private suspend fun showProperties(
+    handle: SftpSessionHandle,
+    port: SftpPort,
+    targets: List<RemoteEntry>,
+    show: (SftpDialog) -> Unit,
+) {
+    val lines = ArrayList<Pair<String, String>>()
+    var totalSize = 0L
+    var files = 0
+    var dirs = 0
+    for (entry in targets) {
+        val tree = runCatching {
+            val raw = port.exec(handle, SshFileKinds.treePropertiesCommand(entry.path)).requireOk("属性")
+            SshFileKinds.parseTreeProperties(raw)
+        }.getOrNull()
+        if (tree != null) {
+            totalSize += tree.sizeBytes
+            files += tree.fileCount
+            dirs += tree.dirCount
+            if (targets.size == 1) {
+                lines += "名称" to entry.name
+                lines += "路径" to entry.path
+                lines += "类型" to when {
+                    entry.isDirectory -> "目录"
+                    entry.isSymlink -> "符号链接"
+                    else -> "文件"
+                }
+                lines += "大小" to SftpOpenPolicy.formatBytes(tree.sizeBytes)
+                lines += "文件" to tree.fileCount.toString()
+                lines += "目录" to tree.dirCount.toString()
+                lines += "修改" to SftpOpenPolicy.formatTime((if (tree.mtimeSec > 0) tree.mtimeSec * 1000L else entry.mtimeMs))
+                if (entry.permissions.isNotBlank()) lines += "权限" to entry.permissions
+            }
+        } else if (targets.size == 1) {
+            lines += "名称" to entry.name
+            lines += "路径" to entry.path
+            lines += "大小" to SftpOpenPolicy.formatBytes(entry.sizeBytes)
+            lines += "修改" to SftpOpenPolicy.formatTime(entry.mtimeMs)
+        }
+    }
+    if (targets.size > 1) {
+        lines += "项目" to targets.size.toString()
+        lines += "合计大小" to SftpOpenPolicy.formatBytes(totalSize)
+        lines += "文件" to files.toString()
+        lines += "目录" to dirs.toString()
+    }
+    show(SftpDialog.Properties(if (targets.size == 1) "属性 · ${targets.first().name}" else "属性 · ${targets.size} 项", lines))
+}
+
+@Composable
+private fun SftpPathBar(
+    path: String,
+    canGoUp: Boolean,
+    busy: Boolean,
+    onPathChange: (String) -> Unit,
+    onGo: () -> Unit,
+    onUp: () -> Unit,
+    onRefresh: () -> Unit,
+    moreOpen: Boolean,
+    onToggleMore: () -> Unit,
+    onHidden: () -> Unit,
+    hiddenOn: Boolean,
+    sortKey: FileSortKey,
+    onSort: (FileSortKey) -> Unit,
+    onNewFolder: () -> Unit,
+    onNewFile: () -> Unit,
+    onUpload: () -> Unit,
+    canPaste: Boolean,
+    onPaste: () -> Unit,
+) {
+    Column(Modifier.fillMaxWidth().background(ZephyrTheme.palette.surfaces.content)) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            IconButton(onClick = onUp, enabled = canGoUp && !busy) { Icon(ZephyrIcons.Back, "返回上一级") }
+            BasicTextField(
+                value = path,
+                onValueChange = onPathChange,
+                singleLine = true,
+                textStyle = androidx.compose.ui.text.TextStyle(
+                    color = ZephyrTheme.palette.onFloating,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 12.sp,
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
+                    .background(ZephyrTheme.palette.surfaces.elevated)
+                    .padding(horizontal = 8.dp, vertical = 7.dp),
+            )
+            TextButton(onClick = onGo, enabled = !busy) { Text("跳转") }
+            IconButton(onClick = onRefresh, enabled = !busy) { Icon(ZephyrIcons.Refresh, "刷新") }
+            Box {
+                IconButton(onClick = onToggleMore) { Icon(ZephyrIcons.More, "更多") }
+                DropdownMenu(expanded = moreOpen, onDismissRequest = onToggleMore) {
+                    DropdownMenuItem({ Text("新建文件夹") }, onNewFolder)
+                    DropdownMenuItem({ Text("新建文件") }, onNewFile)
+                    DropdownMenuItem({ Text("上传文件") }, onUpload)
+                    DropdownMenuItem({ Text("粘贴") }, onPaste, enabled = canPaste)
+                    DropdownMenuItem({ Text(if (hiddenOn) "隐藏点文件" else "显示点文件") }, onHidden)
+                    DropdownMenuItem({ Text("按名称排序") }, { onSort(FileSortKey.NAME) })
+                    DropdownMenuItem({ Text("按大小排序") }, { onSort(FileSortKey.SIZE) })
+                    DropdownMenuItem({ Text("按时间排序") }, { onSort(FileSortKey.MTIME) })
+                    @Suppress("UNUSED_VARIABLE")
+                    val keepSort = sortKey
+                }
+            }
+        }
     }
 }
 
 @Composable
-private fun SftpPathBar(path: String, canGoUp: Boolean, onUp: () -> Unit, onRefresh: () -> Unit) {
+private fun SftpSearchBar(query: String, onQuery: (String) -> Unit, selecting: Boolean, selectedCount: Int) {
     Row(
-        Modifier.fillMaxWidth().background(ZephyrTheme.palette.surfaces.content).padding(horizontal = 8.dp, vertical = 7.dp),
+        Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQuery,
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+            placeholder = { Text("搜索当前目录…", color = ZephyrTheme.palette.onFloatingSubtle) },
+        )
+        if (selecting) {
+            Text("已选 $selectedCount", color = ZephyrTheme.palette.brand.accent, fontSize = 11.sp, modifier = Modifier.padding(start = 8.dp))
+        }
+    }
+}
+
+@Composable
+private fun SftpActionBar(
+    selecting: Boolean,
+    selectedCount: Int,
+    canPaste: Boolean,
+    onSelect: () -> Unit,
+    onCopy: () -> Unit,
+    onCut: () -> Unit,
+    onPaste: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    onCompress: () -> Unit,
+    onChmod: () -> Unit,
+    onDownload: () -> Unit,
+    onProperties: () -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        IconButton(onClick = onUp, enabled = canGoUp) {
-            Icon(ZephyrIcons.Back, "返回上一级")
+        MiniChip(if (selecting) "取消选择" else "选择", onSelect)
+        if (selectedCount > 0) {
+            MiniChip("复制", onCopy)
+            MiniChip("剪切", onCut)
+            MiniChip("重命名", onRename, enabled = selectedCount == 1)
+            MiniChip("删除", onDelete)
+            MiniChip("压缩", onCompress)
+            MiniChip("权限", onChmod, enabled = selectedCount == 1)
+            MiniChip("下载", onDownload, enabled = selectedCount == 1)
+            MiniChip("属性", onProperties)
         }
-        Text(
-            path, modifier = Modifier.weight(1f), maxLines = 1,
-            color = ZephyrTheme.palette.onFloating, fontFamily = FontFamily.Monospace, fontSize = 12.sp,
-        )
-        IconButton(onClick = onRefresh) {
-            Icon(ZephyrIcons.Refresh, "刷新")
-        }
+        MiniChip("粘贴", onPaste, enabled = canPaste)
     }
 }
 
 @Composable
-private fun SftpEntryRow(entry: RemoteEntry, onClick: () -> Unit) {
+private fun MiniChip(label: String, onClick: () -> Unit, enabled: Boolean = true) {
+    AssistChip(onClick = onClick, enabled = enabled, label = { Text(label, fontSize = 11.sp) })
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SftpEntryRow(
+    entry: RemoteEntry,
+    selected: Boolean,
+    selecting: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    val kind = SftpOpenPolicy.kindOf(entry)
+    val icon = when (kind) {
+        SftpOpenKind.DIRECTORY -> ZephyrIcons.File
+        SftpOpenKind.IMAGE -> ZephyrIcons.Camera
+        SftpOpenKind.MEDIA -> ZephyrIcons.Volume
+        SftpOpenKind.ARCHIVE -> ZephyrIcons.Inbox
+        SftpOpenKind.TEXT -> ZephyrIcons.Notes
+        SftpOpenKind.BINARY -> ZephyrIcons.File
+    }
+    val tint = when {
+        selected -> ZephyrTheme.palette.brand.accent
+        kind == SftpOpenKind.DIRECTORY -> ZephyrTheme.palette.protocol.sftp
+        else -> ZephyrTheme.palette.onFloatingMuted
+    }
+    val meta = buildString {
+        append(if (entry.isDirectory) "目录" else SftpOpenPolicy.formatBytes(entry.sizeBytes))
+        if (entry.permissions.isNotBlank()) append(" · ").append(entry.permissions)
+        val time = SftpOpenPolicy.formatTime(entry.mtimeMs)
+        if (time != "—") append(" · ").append(time)
+    }
     Row(
-        Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 12.dp),
+        Modifier
+            .fillMaxWidth()
+            .background(if (selected) ZephyrTheme.palette.brand.accent.copy(alpha = 0.12f) else Color.Transparent)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Icon(
-            if (entry.isDirectory) ZephyrIcons.File else ZephyrIcons.Notes,
-            null,
-            tint = if (entry.isDirectory) ZephyrTheme.palette.protocol.sftp else ZephyrTheme.palette.onFloatingMuted,
-            modifier = Modifier.size(20.dp),
-        )
+        Icon(icon, null, tint = tint, modifier = Modifier.size(20.dp))
         Column(Modifier.weight(1f)) {
             Text(entry.name, color = ZephyrTheme.palette.onFloating, maxLines = 1, fontWeight = FontWeight.Medium)
-            Text(
-                if (entry.isDirectory) "目录" else formatRemoteSize(entry.sizeBytes),
-                color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp,
-            )
+            Text(meta, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp, maxLines = 1)
         }
-        Text("›", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 18.sp)
+        Text(if (selecting && selected) "✓" else "›", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 18.sp)
     }
 }
 
 @Composable
-private fun SftpTextEditor(file: BrowserFile, onChange: (String) -> Unit, onBack: () -> Unit, onSave: () -> Unit) {
+private fun SftpTextEditor(
+    file: BrowserFile,
+    onChange: (String, FileEncoding, String) -> Unit,
+    onBack: () -> Unit,
+    onSave: () -> Unit,
+) {
     Column(Modifier.fillMaxSize()) {
         Row(
             Modifier.fillMaxWidth().background(ZephyrTheme.palette.surfaces.content).padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            IconButton(onClick = onBack) {
-                Icon(ZephyrIcons.Back, "返回文件列表")
-            }
+            IconButton(onClick = onBack) { Icon(ZephyrIcons.Back, "返回文件列表") }
             Column(Modifier.weight(1f)) {
                 Text(file.path.substringAfterLast('/'), color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold)
                 Text(if (file.dirty) "未保存" else file.path, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 10.sp, maxLines = 1)
             }
             PrimaryButton(onClick = onSave, enabled = file.dirty) { Text("保存") }
         }
+        Row(
+            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FileEncoding.entries.forEach { encoding ->
+                FilterChip(
+                    selected = file.encoding == encoding,
+                    onClick = { onChange(encoding.decode(file.baseline.bytes), encoding, file.lineEnding) },
+                    enabled = encoding.isAvailable,
+                    label = { Text(encoding.label, fontSize = 11.sp) },
+                )
+            }
+            FilterChip(
+                selected = file.lineEnding == "lf",
+                onClick = { onChange(file.text, file.encoding, "lf") },
+                label = { Text("LF", fontSize = 11.sp) },
+            )
+            FilterChip(
+                selected = file.lineEnding == "crlf",
+                onClick = { onChange(file.text, file.encoding, "crlf") },
+                label = { Text("CRLF", fontSize = 11.sp) },
+            )
+        }
         BasicTextField(
             value = file.text,
-            onValueChange = onChange,
+            onValueChange = { onChange(it, file.encoding, file.lineEnding) },
             modifier = Modifier.fillMaxSize().background(ZephyrTheme.palette.surfaces.background).padding(14.dp),
             textStyle = androidx.compose.ui.text.TextStyle(
                 color = ZephyrTheme.palette.onFloating,
@@ -222,6 +904,113 @@ private fun SftpTextEditor(file: BrowserFile, onChange: (String) -> Unit, onBack
             ),
         )
     }
+}
+
+@Composable
+private fun SftpPreviewPane(
+    preview: PreviewState,
+    cacheDir: File,
+    onBack: () -> Unit,
+    onMessage: (String) -> Unit,
+) {
+    Column(Modifier.fillMaxSize().background(ZephyrTheme.palette.surfaces.background)) {
+        Row(
+            Modifier.fillMaxWidth().background(ZephyrTheme.palette.surfaces.content).padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) { Icon(ZephyrIcons.Back, "关闭预览") }
+            Column(Modifier.weight(1f)) {
+                Text(preview.path.substringAfterLast('/'), color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "${if (preview.kind == SftpOpenKind.IMAGE) "图片预览" else "媒体预览"} · ${SftpOpenPolicy.formatBytes(preview.sizeBytes)}",
+                    color = ZephyrTheme.palette.onFloatingSubtle,
+                    fontSize = 10.sp,
+                )
+            }
+        }
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            when (preview.kind) {
+                SftpOpenKind.IMAGE -> {
+                    val bitmap = remember(preview.bytes) {
+                        runCatching { BitmapFactory.decodeByteArray(preview.bytes, 0, preview.bytes.size) }.getOrNull()
+                    }
+                    if (bitmap != null) {
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = preview.path,
+                            modifier = Modifier.fillMaxSize().padding(12.dp),
+                            contentScale = ContentScale.Fit,
+                        )
+                    } else {
+                        Text("无法解码该图片格式，请下载后用系统应用打开", color = ZephyrTheme.palette.onFloatingSubtle)
+                    }
+                }
+                SftpOpenKind.MEDIA -> {
+                    val mediaFile = remember(preview.path, preview.bytes) {
+                        val ext = SshFileKinds.extensionOf(preview.path).ifBlank { "bin" }
+                        File(cacheDir, "sftp-preview-${preview.path.hashCode()}.$ext").apply {
+                            writeBytes(preview.bytes)
+                        }
+                    }
+                    DisposableEffect(mediaFile) { onDispose { mediaFile.delete() } }
+                    if (SshFileKinds.isVideo(preview.path)) {
+                        AndroidView(
+                            factory = { context ->
+                                VideoView(context).apply {
+                                    layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+                                    setVideoURI(Uri.fromFile(mediaFile))
+                                    setOnErrorListener { _, _, _ ->
+                                        onMessage("该视频编码当前设备无法播放")
+                                        true
+                                    }
+                                    setOnPreparedListener { it.isLooping = false; start() }
+                                }
+                            },
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        val player = remember {
+                            MediaPlayer().apply {
+                                setDataSource(mediaFile.absolutePath)
+                                setOnErrorListener { _, _, _ ->
+                                    onMessage("该音频编码当前设备无法播放")
+                                    true
+                                }
+                                prepare()
+                                start()
+                            }
+                        }
+                        DisposableEffect(player) { onDispose { player.release() } }
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(ZephyrIcons.Volume, null, tint = ZephyrTheme.palette.brand.accent, modifier = Modifier.size(48.dp))
+                            Text("正在播放 ${preview.path.substringAfterLast('/')}", color = ZephyrTheme.palette.onFloating, modifier = Modifier.padding(top = 12.dp))
+                        }
+                    }
+                }
+                else -> Text("不支持预览", color = ZephyrTheme.palette.onFloatingSubtle)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NamePromptDialog(
+    title: String,
+    initial: String,
+    confirm: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var value by remember(initial) { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            OutlinedTextField(value = value, onValueChange = { value = it }, singleLine = true)
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(value.trim()) }, enabled = value.isNotBlank()) { Text(confirm) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } },
+    )
 }
 
 @Composable
@@ -262,9 +1051,51 @@ internal fun decodeUtf8Text(bytes: ByteArray): String {
 private fun Throwable.displayMessage(): String =
     (this as? MobileApiException)?.error?.message ?: message ?: "SFTP 操作失败"
 
-private fun formatRemoteSize(bytes: Long): String = when {
-    bytes >= 1024L * 1024L * 1024L -> "${bytes / (1024L * 1024L * 1024L)} GiB"
-    bytes >= 1024L * 1024L -> "${bytes / (1024L * 1024L)} MiB"
-    bytes >= 1024L -> "${bytes / 1024L} KiB"
-    else -> "$bytes B"
+private fun queryDisplayName(context: android.content.Context, uri: Uri): String? {
+    val cursor = context.contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)
+    return cursor?.use {
+        if (it.moveToFirst()) it.getString(0) else null
+    }
+}
+
+private suspend fun runOp(
+    onMessage: (String) -> Unit,
+    setBusy: (Boolean) -> Unit,
+    setTransfer: (TransferJob?) -> Unit,
+    block: suspend () -> Unit,
+) {
+    setBusy(true)
+    try {
+        block()
+    } catch (error: Throwable) {
+        onMessage(error.displayMessage())
+    } finally {
+        setBusy(false)
+        setTransfer(null)
+    }
+}
+
+private fun applyPaste(
+    clip: SftpClipboard,
+    mode: SftpPasteConflictMode,
+    existing: Set<String>,
+    port: SftpPort,
+    directory: String,
+    handle: SftpSessionHandle,
+    onMessage: (String) -> Unit,
+    setBusy: (Boolean) -> Unit,
+    setTransfer: (TransferJob?) -> Unit,
+    onDone: () -> Unit,
+    scope: kotlinx.coroutines.CoroutineScope,
+) {
+    scope.launch {
+        runOp(onMessage, setBusy, setTransfer) {
+            val plan = SftpClipboardOps.planPaste(clip, directory, existing, mode)
+            val command = SftpClipboardOps.commandFor(plan, cut = clip.mode == SftpClipboardMode.CUT)
+                ?: error("没有可粘贴的项目")
+            port.exec(handle, command).requireOk("粘贴")
+            onMessage("已粘贴 ${plan.copies.size} 项")
+            onDone()
+        }
+    }
 }

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
@@ -111,7 +111,7 @@ fun SftpBrowserPane(
     var selected by remember { mutableStateOf<Set<String>>(emptySet()) }
     var editors by remember { mutableStateOf<List<BrowserFile>>(emptyList()) }
     var editorIndex by remember { mutableIntStateOf(0) }
-    val editor get() = editors.getOrNull(editorIndex)
+    val editor = editors.getOrNull(editorIndex)
     var preview by remember { mutableStateOf<PreviewState?>(null) }
     var pendingClose by remember { mutableStateOf(false) }
     var dialog by remember { mutableStateOf<SftpDialog?>(null) }
@@ -124,23 +124,6 @@ fun SftpBrowserPane(
     var moreOpen by remember { mutableStateOf(false) }
     var bundleTarget by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(editors.any { it.dirty }) { onDirtyChanged(editors.any { it.dirty }) }
-
-    val overlayOpen = editors.isNotEmpty() || preview != null
-    BackHandler(enabled = overlayOpen || selecting) {
-        when {
-            editor?.dirty == true -> pendingClose = true
-            editors.isNotEmpty() -> closeEditor(force = false)
-            preview != null -> preview = null
-            selecting -> {
-                selecting = false
-                selected = emptySet()
-            }
-        }
-    }
-
-    DisposableEffect(connectionId, port) {
-        onDispose { handle?.let { scope.launch { port.close(it) } } }
-    }
 
     fun currentHandle(): SftpSessionHandle = handle ?: error("SFTP 会话已断开")
 
@@ -183,6 +166,23 @@ fun SftpBrowserPane(
         val next = editors.toMutableList().also { it.removeAt(index) }
         editors = next
         editorIndex = editorIndex.coerceAtMost((next.size - 1).coerceAtLeast(0))
+    }
+
+    val overlayOpen = editors.isNotEmpty() || preview != null
+    BackHandler(enabled = overlayOpen || selecting) {
+        when {
+            editor?.dirty == true -> pendingClose = true
+            editors.isNotEmpty() -> closeEditor(force = false)
+            preview != null -> preview = null
+            selecting -> {
+                selecting = false
+                selected = emptySet()
+            }
+        }
+    }
+
+    DisposableEffect(connectionId, port) {
+        onDispose { handle?.let { scope.launch { port.close(it) } } }
     }
 
     fun pushTransfer(job: SftpTransferOps.Transfer) {

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.horizontalScroll
@@ -18,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,14 +51,21 @@ private data class BrowserFile(
     val baseline: RemoteFileRead,
     val encoding: FileEncoding = FileEncoding.UTF8,
     val lineEnding: String = if (text.contains("\r\n")) "crlf" else "lf",
+    val tabSize: Int = 4,
+    val wrap: Boolean = true,
     val dirty: Boolean = false,
-)
+    val undo: List<String> = emptyList(),
+    val redo: List<String> = emptyList(),
+) {
+    val title: String get() = path.substringAfterLast('/').ifBlank { path }
+}
 
 private data class PreviewState(
     val path: String,
     val kind: SftpOpenKind,
     val bytes: ByteArray,
     val sizeBytes: Long,
+    val cacheFile: File? = null,
 )
 
 private data class TransferJob(
@@ -80,6 +89,9 @@ fun SftpBrowserPane(
     port: SftpPort,
     connectionId: String,
     modifier: Modifier = Modifier,
+    connectionName: String = "",
+    clipboard: SftpClipboard? = null,
+    onClipboard: (SftpClipboard?) -> Unit = {},
     onMessage: (String) -> Unit = {},
     onDirtyChanged: (Boolean) -> Unit = {},
 ) {
@@ -97,21 +109,27 @@ fun SftpBrowserPane(
     var sortKey by remember { mutableStateOf(FileSortKey.NAME) }
     var selecting by remember { mutableStateOf(false) }
     var selected by remember { mutableStateOf<Set<String>>(emptySet()) }
-    var editor by remember { mutableStateOf<BrowserFile?>(null) }
+    var editors by remember { mutableStateOf<List<BrowserFile>>(emptyList()) }
+    var editorIndex by remember { mutableIntStateOf(0) }
+    val editor get() = editors.getOrNull(editorIndex)
     var preview by remember { mutableStateOf<PreviewState?>(null) }
     var pendingClose by remember { mutableStateOf(false) }
     var dialog by remember { mutableStateOf<SftpDialog?>(null) }
-    var clipboard by remember { mutableStateOf<SftpClipboard?>(null) }
+    var localClipboard by remember { mutableStateOf(clipboard) }
+    LaunchedEffect(clipboard) { localClipboard = clipboard }
+    var connecting by remember { mutableStateOf(false) }
+    var transfers by remember { mutableStateOf<List<SftpTransferOps.Transfer>>(emptyList()) }
     var transfer by remember { mutableStateOf<TransferJob?>(null) }
     var busy by remember { mutableStateOf(false) }
     var moreOpen by remember { mutableStateOf(false) }
-    LaunchedEffect(editor?.dirty) { onDirtyChanged(editor?.dirty == true) }
+    var bundleTarget by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(editors.any { it.dirty }) { onDirtyChanged(editors.any { it.dirty }) }
 
-    val overlayOpen = editor != null || preview != null
+    val overlayOpen = editors.isNotEmpty() || preview != null
     BackHandler(enabled = overlayOpen || selecting) {
         when {
             editor?.dirty == true -> pendingClose = true
-            editor != null -> editor = null
+            editors.isNotEmpty() -> closeEditor(force = false)
             preview != null -> preview = null
             selecting -> {
                 selecting = false
@@ -126,8 +144,50 @@ fun SftpBrowserPane(
 
     fun currentHandle(): SftpSessionHandle = handle ?: error("SFTP 会话已断开")
 
+    fun setClip(value: SftpClipboard?) {
+        localClipboard = value
+        onClipboard(value)
+    }
+
     fun refresh() {
         revision++
+    }
+
+    fun reconnect() {
+        val old = handle
+        handle = null
+        if (old != null) {
+            scope.launch { runCatching { port.close(old) } }
+        }
+        revision++
+    }
+
+    fun upsertEditor(file: BrowserFile) {
+        val existing = editors.indexOfFirst { it.path == file.path }
+        editors = if (existing >= 0) editors.toMutableList().also { it[existing] = file } else editors + file
+        editorIndex = if (existing >= 0) existing else editors.lastIndex
+    }
+
+    fun updateActive(transform: (BrowserFile) -> BrowserFile) {
+        val current = editor ?: return
+        upsertEditor(transform(current))
+    }
+
+    fun closeEditor(force: Boolean, index: Int = editorIndex) {
+        val target = editors.getOrNull(index) ?: return
+        if (target.dirty && !force) {
+            editorIndex = index
+            pendingClose = true
+            return
+        }
+        val next = editors.toMutableList().also { it.removeAt(index) }
+        editors = next
+        editorIndex = editorIndex.coerceAtMost((next.size - 1).coerceAtLeast(0))
+    }
+
+    fun pushTransfer(job: SftpTransferOps.Transfer) {
+        transfers = listOf(job) + transfers.filterNot { it.id == job.id }.take(7)
+        transfer = TransferJob(job.label, job.fraction, job.detail.ifBlank { SftpOpenPolicy.formatBytes(job.loaded) })
     }
 
     val uploadLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
@@ -137,11 +197,35 @@ fun SftpBrowserPane(
                 val active = currentHandle()
                 uris.forEachIndexed { index, uri ->
                     val name = queryDisplayName(context, uri) ?: "upload-${index + 1}"
-                    transfer = TransferJob("上传 $name", index.toFloat() / uris.size, "${index + 1}/${uris.size}")
-                    val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-                        ?: error("无法读取 $name")
-                    if (bytes.size > EDIT_WRITE_LIMIT) error("$name 超过 ${SftpOpenPolicy.formatBytes(EDIT_WRITE_LIMIT.toLong())}，当前版本请改用较小文件")
-                    port.upload(active, RemotePath.join(path, name), bytes)
+                    val remote = RemotePath.join(path, name)
+                    val total = querySize(context, uri)
+                    val id = "up-$name-${System.currentTimeMillis()}"
+                    pushTransfer(SftpTransferOps.Transfer(id, "上传 $name", SftpTransferOps.Direction.UPLOAD, remote, total = total, detail = "${index + 1}/${uris.size}"))
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        val buffer = ByteArray(SftpTransferOps.STREAM_CHUNK)
+                        var loaded = 0L
+                        port.writeStream(active, remote) {
+                            val read = input.read(buffer)
+                            if (read <= 0) null else {
+                                loaded += read
+                                pushTransfer(
+                                    SftpTransferOps.Transfer(
+                                        id, "上传 $name", SftpTransferOps.Direction.UPLOAD, remote,
+                                        loaded = loaded, total = total,
+                                        detail = SftpOpenPolicy.formatBytes(loaded),
+                                    ),
+                                )
+                                buffer.copyOf(read)
+                            }
+                        }
+                    } ?: error("无法读取 $name")
+                    pushTransfer(
+                        SftpTransferOps.Transfer(
+                            id, "上传 $name", SftpTransferOps.Direction.UPLOAD, remote,
+                            loaded = total, total = total,
+                            status = SftpTransferOps.Status.DONE, detail = "完成",
+                        ),
+                    )
                 }
                 onMessage("已上传 ${uris.size} 个文件")
                 refresh()
@@ -151,24 +235,22 @@ fun SftpBrowserPane(
     var downloadTarget by remember { mutableStateOf<RemoteEntry?>(null) }
     val downloadLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { uri ->
         val entry = downloadTarget
+        val bundle = bundleTarget
         downloadTarget = null
-        if (uri == null || entry == null) return@rememberLauncherForActivityResult
+        bundleTarget = null
+        if (uri == null) return@rememberLauncherForActivityResult
         scope.launch {
             runOp(onMessage, { busy = it }, { transfer = it }) {
                 val active = currentHandle()
-                context.contentResolver.openOutputStream(uri)?.use { output ->
-                    var offset = 0L
-                    val total = entry.sizeBytes.coerceAtLeast(1L)
-                    while (offset < entry.sizeBytes || entry.sizeBytes == 0L) {
-                        val chunk = port.readRange(active, entry.path, offset, 256 * 1024)
-                        if (chunk.bytes.isEmpty()) break
-                        output.write(chunk.bytes)
-                        offset += chunk.bytes.size
-                        transfer = TransferJob("下载 ${entry.name}", (offset.toFloat() / total).coerceIn(0f, 1f), SftpOpenPolicy.formatBytes(offset))
-                        if (chunk.bytes.size < 256 * 1024) break
-                    }
-                } ?: error("无法写入本机文件")
-                onMessage("已下载 ${entry.name}")
+                if (bundle != null) {
+                    streamDownload(port, active, bundle, uri, context, "打包下载", { pushTransfer(it) })
+                    runCatching { port.exec(active, SftpTransferOps.cleanupCommand(bundle)) }
+                    onMessage("已打包下载")
+                    return@runOp
+                }
+                val target = entry ?: return@runOp
+                streamDownload(port, active, target.path, uri, context, target.name, { pushTransfer(it) }, target.sizeBytes)
+                onMessage("已下载 ${target.name}")
             }
         }
     }
@@ -176,19 +258,29 @@ fun SftpBrowserPane(
     LaunchedEffect(connectionId, revision) {
         loading = true
         error = null
+        connecting = handle == null
         runCatching {
             val active = handle ?: port.open(connectionId).also {
                 handle = it
                 path = runCatching { port.canonicalPath(it, ".") }.getOrDefault("/")
                 pathDraft = path
             }
+            connecting = false
             val listed = port.list(active, path)
             path = runCatching { port.canonicalPath(active, path) }.getOrDefault(path)
             pathDraft = path
             entries = listed.sortedWith(compareByDescending<RemoteEntry> { it.isDirectory }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.name })
             selected = selected.intersect(listed.map { it.path }.toSet())
-        }.onFailure { error = it.displayMessage() }
+        }.onFailure {
+            connecting = false
+            error = if (handle == null) {
+                "无法自动连接${if (connectionName.isBlank()) "" else " $connectionName"}：${it.displayMessage()}"
+            } else {
+                it.displayMessage()
+            }
+        }
         loading = false
+        connecting = false
     }
 
     val visible = remember(entries, query, showHidden, sortKey) {
@@ -231,20 +323,34 @@ fun SftpBrowserPane(
             runOp(onMessage, { busy = it }, { transfer = it }) {
                 when (kind) {
                     SftpOpenKind.TEXT -> {
+                        val existing = editors.indexOfFirst { it.path == entry.path }
+                        if (existing >= 0) {
+                            editorIndex = existing
+                            return@runOp
+                        }
                         val read = port.read(currentHandle(), entry.path, SftpOpenPolicy.TEXT_EDIT_LIMIT)
                         require(!read.truncated) { "文件超过 ${SftpOpenPolicy.formatBytes(SftpOpenPolicy.TEXT_EDIT_LIMIT)}，拒绝编辑" }
                         require(!FileEncoding.looksBinary(read.bytes)) { "检测到二进制内容，拒绝编辑" }
                         val encoding = FileEncoding.guess(read.bytes)
-                        editor = BrowserFile(entry.path, encoding.decode(read.bytes), read, encoding)
+                        upsertEditor(BrowserFile(entry.path, encoding.decode(read.bytes), read, encoding))
                     }
-                    SftpOpenKind.IMAGE, SftpOpenKind.MEDIA -> {
+                    SftpOpenKind.IMAGE -> {
                         val read = port.readRange(
                             currentHandle(),
                             entry.path,
                             0L,
-                            SftpOpenPolicy.previewLimit(kind).toInt(),
+                            SftpOpenPolicy.IMAGE_PREVIEW_LIMIT.toInt(),
                         )
                         preview = PreviewState(entry.path, kind, read.bytes, entry.sizeBytes)
+                    }
+                    SftpOpenKind.MEDIA -> {
+                        val cache = File(context.cacheDir, "sftp-preview-${entry.path.hashCode()}.${SshFileKinds.extensionOf(entry.path).ifBlank { "bin" }}")
+                        cache.outputStream().use { output ->
+                            port.readStream(currentHandle(), entry.path, 0L) { _, bytes, _ ->
+                                output.write(bytes)
+                            }
+                        }
+                        preview = PreviewState(entry.path, kind, ByteArray(0), entry.sizeBytes, cacheFile = cache)
                     }
                     SftpOpenKind.ARCHIVE -> {
                         dialog = SftpDialog.PromptName(
@@ -329,16 +435,19 @@ fun SftpBrowserPane(
     fun copyOrCut(cut: Boolean) {
         val targets = selectedEntries()
         if (targets.isEmpty()) return
-        clipboard = SftpClipboard(
-            mode = if (cut) SftpClipboardMode.CUT else SftpClipboardMode.COPY,
-            paths = targets.map { it.path },
-            sourceDirectory = path,
+        setClip(
+            SftpClipboard(
+                mode = if (cut) SftpClipboardMode.CUT else SftpClipboardMode.COPY,
+                paths = targets.map { it.path },
+                sourceDirectory = path,
+                sourceConnectionId = connectionId,
+            ),
         )
         onMessage(if (cut) "已剪切 ${targets.size} 项" else "已复制 ${targets.size} 项")
     }
 
     fun pasteClipboard() {
-        val clip = clipboard ?: return
+        val clip = localClipboard ?: return
         val existing = entries.map { it.name }.toSet()
         val names = clip.paths.map(RemotePath::nameOf)
         if (names.any { it in existing }) {
@@ -346,14 +455,45 @@ fun SftpBrowserPane(
             return
         }
         applyPaste(
-            clip, SftpPasteConflictMode.COMPATIBLE, existing, port, path, currentHandle(),
+            clip, SftpPasteConflictMode.COMPATIBLE, existing, port, path, currentHandle(), connectionId,
             onMessage, { busy = it }, { transfer = it },
             {
-                if (clip.mode == SftpClipboardMode.CUT) clipboard = null
+                if (clip.mode == SftpClipboardMode.CUT) setClip(null)
                 refresh()
             },
             scope,
         )
+    }
+
+    fun openSelected() {
+        val targets = selectedEntries().filter { !it.isDirectory }
+        if (targets.isEmpty()) {
+            onMessage("请先勾选要打开的文件")
+            return
+        }
+        selecting = false
+        selected = emptySet()
+        scope.launch {
+            runOp(onMessage, { busy = it }, { transfer = it }) {
+                var opened = 0
+                targets.forEach { entry ->
+                    val kind = SftpOpenPolicy.kindOf(entry)
+                    if (kind != SftpOpenKind.TEXT) return@forEach
+                    SftpOpenPolicy.rejectReason(kind, entry.sizeBytes)?.let { return@forEach }
+                    if (editors.any { it.path == entry.path }) {
+                        opened += 1
+                        return@forEach
+                    }
+                    val read = port.read(currentHandle(), entry.path, SftpOpenPolicy.TEXT_EDIT_LIMIT)
+                    if (read.truncated || FileEncoding.looksBinary(read.bytes)) return@forEach
+                    val encoding = FileEncoding.guess(read.bytes)
+                    upsertEditor(BrowserFile(entry.path, encoding.decode(read.bytes), read, encoding))
+                    opened += 1
+                }
+                if (opened == 0) error("没有可同时打开的文本文件")
+                onMessage("已打开 $opened 个文件")
+            }
+        }
     }
 
     fun compressSelected() {
@@ -373,13 +513,24 @@ fun SftpBrowserPane(
     }
 
     fun downloadSelected() {
-        val entry = selectedEntries().singleOrNull() ?: return
-        if (entry.isDirectory) {
-            onMessage("目录请先压缩再下载")
+        val targets = selectedEntries()
+        if (targets.isEmpty()) return
+        if (targets.size == 1 && !targets.first().isDirectory) {
+            downloadTarget = targets.first()
+            downloadLauncher.launch(targets.first().name)
             return
         }
-        downloadTarget = entry
-        downloadLauncher.launch(entry.name)
+        scope.launch {
+            runOp(onMessage, { busy = it }, { transfer = it }) {
+                val name = SftpTransferOps.bundleName()
+                val remote = SftpTransferOps.remoteTempPath(name)
+                val id = "bundle-$name"
+                pushTransfer(SftpTransferOps.Transfer(id, "打包 $name", SftpTransferOps.Direction.ARCHIVE, remote, detail = "压缩中"))
+                port.exec(currentHandle(), SftpTransferOps.bundleCommand(targets.map { it.path }, remote)).requireOk("打包")
+                bundleTarget = remote
+                downloadLauncher.launch(name)
+            }
+        }
     }
 
     fun showSelectedProperties() {
@@ -395,11 +546,53 @@ fun SftpBrowserPane(
     Box(modifier.fillMaxSize()) {
         when {
             editor != null -> SftpTextEditor(
-                file = editor!!,
-                onChange = { text, encoding, ending ->
-                    editor = editor!!.copy(text = text, encoding = encoding, lineEnding = ending, dirty = true)
+                files = editors,
+                activeIndex = editorIndex,
+                onSelect = { editorIndex = it },
+                onCloseTab = { closeEditor(force = false, index = it) },
+                onChange = { text, encoding, ending, tabSize, wrap ->
+                    updateActive { current ->
+                        val history = (current.undo + current.text).takeLast(40)
+                        current.copy(
+                            text = text,
+                            encoding = encoding,
+                            lineEnding = ending,
+                            tabSize = tabSize,
+                            wrap = wrap,
+                            dirty = true,
+                            undo = history,
+                            redo = emptyList(),
+                        )
+                    }
                 },
-                onBack = { if (editor!!.dirty) pendingClose = true else editor = null },
+                onUndo = {
+                    updateActive { current ->
+                        val previous = current.undo.lastOrNull() ?: return@updateActive current
+                        current.copy(
+                            text = previous,
+                            undo = current.undo.dropLast(1),
+                            redo = current.redo + current.text,
+                            dirty = true,
+                        )
+                    }
+                },
+                onRedo = {
+                    updateActive { current ->
+                        val next = current.redo.lastOrNull() ?: return@updateActive current
+                        current.copy(
+                            text = next,
+                            redo = current.redo.dropLast(1),
+                            undo = current.undo + current.text,
+                            dirty = true,
+                        )
+                    }
+                },
+                onFormat = {
+                    updateActive { current ->
+                        current.copy(text = SftpEditorSupport.formatDocument(current.text, current.tabSize), dirty = true)
+                    }
+                },
+                onBack = { closeEditor(force = false) },
                 onSave = {
                     val current = editor ?: return@SftpTextEditor
                     scope.launch {
@@ -410,7 +603,9 @@ fun SftpBrowserPane(
                                 current.text.replace("\r\n", "\n")
                             }
                             val bytes = current.encoding.encode(normalized)
-                            if (bytes.size > EDIT_WRITE_LIMIT) error("文件超过 2 MiB，拒绝保存")
+                            if (bytes.size > SftpOpenPolicy.TEXT_EDIT_LIMIT) {
+                                error("文件超过 ${SftpOpenPolicy.formatBytes(SftpOpenPolicy.TEXT_EDIT_LIMIT)}，拒绝保存")
+                            }
                             val receipt = runCatching {
                                 port.write(
                                     currentHandle(), current.path, bytes,
@@ -423,13 +618,33 @@ fun SftpBrowserPane(
                                 }
                                 throw failure
                             }
-                            editor = current.copy(
-                                baseline = RemoteFileRead(current.path, bytes, receipt.mtimeMs, receipt.sha256),
-                                dirty = false,
+                            upsertEditor(
+                                current.copy(
+                                    baseline = RemoteFileRead(current.path, bytes, receipt.mtimeMs, receipt.sha256),
+                                    dirty = false,
+                                    undo = emptyList(),
+                                    redo = emptyList(),
+                                ),
                             )
                             onMessage("已保存")
                         }
                     }
+                },
+                onWorkspaceSearch = { query ->
+                    scope.launch {
+                        runOp(onMessage, { busy = it }, { transfer = it }) {
+                            val raw = port.exec(currentHandle(), SftpEditorSupport.workspaceSearchCommand(path, query)).requireOk("搜目录")
+                            val (hits, scanned) = SftpEditorSupport.parseWorkspaceHits(raw)
+                            dialog = SftpDialog.Properties(
+                                "搜目录 · $query · $scanned 个文件",
+                                hits.take(80).map { "${it.path}:${it.line}" to it.text },
+                            )
+                        }
+                    }
+                },
+                onOpenHit = { pathToOpen ->
+                    val name = RemotePath.nameOf(pathToOpen)
+                    openEntry(RemoteEntry(name, pathToOpen, false, 0L, 0L))
                 },
             )
             preview != null -> SftpPreviewPane(
@@ -459,15 +674,16 @@ fun SftpBrowserPane(
                     onNewFolder = { moreOpen = false; createFolder() },
                     onNewFile = { moreOpen = false; createFile() },
                     onUpload = { moreOpen = false; uploadLauncher.launch("*/*") },
-                    canPaste = clipboard != null,
+                    canPaste = localClipboard != null,
                     onPaste = { moreOpen = false; pasteClipboard() },
                 )
                 SftpSearchBar(query = query, onQuery = { query = it }, selecting = selecting, selectedCount = selected.size)
                 SftpActionBar(
                     selecting = selecting,
                     selectedCount = selected.size,
-                    canPaste = clipboard != null,
+                    canPaste = localClipboard != null,
                     onSelect = { selecting = !selecting; if (!selecting) selected = emptySet() },
+                    onOpen = { openSelected() },
                     onCopy = { copyOrCut(false) },
                     onCut = { copyOrCut(true) },
                     onPaste = { pasteClipboard() },
@@ -478,16 +694,33 @@ fun SftpBrowserPane(
                     onDownload = { downloadSelected() },
                     onProperties = { showSelectedProperties() },
                 )
-                transfer?.let { job ->
+                if (transfers.isNotEmpty()) {
                     Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp)) {
-                        Text(job.label, color = ZephyrTheme.palette.onFloatingMuted, fontSize = 11.sp)
-                        LinearProgress(progress = job.progress, modifier = Modifier.padding(top = 4.dp))
-                        Text(job.detail, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 10.sp)
+                        Text("传输", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                        transfers.take(5).forEach { job ->
+                            Text(job.label, color = ZephyrTheme.palette.onFloatingMuted, fontSize = 11.sp, modifier = Modifier.padding(top = 6.dp))
+                            LinearProgress(progress = job.fraction, modifier = Modifier.padding(top = 4.dp))
+                            Text(
+                                (if (job.detail.isNotBlank()) job.detail + " · " else "") + job.status.name.lowercase(),
+                                color = ZephyrTheme.palette.onFloatingSubtle,
+                                fontSize = 10.sp,
+                            )
+                        }
+                    }
+                } else {
+                    transfer?.let { job ->
+                        Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp)) {
+                            Text(job.label, color = ZephyrTheme.palette.onFloatingMuted, fontSize = 11.sp)
+                            LinearProgress(progress = job.progress, modifier = Modifier.padding(top = 4.dp))
+                            Text(job.detail, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 10.sp)
+                        }
                     }
                 }
                 when {
-                    loading -> SftpEmpty("正在连接并读取 $path…")
-                    error != null -> SftpError(error!!, onRetry = { refresh() })
+                    connecting || (loading && handle == null) ->
+                        SftpEmpty("正在自动连接${if (connectionName.isBlank()) "" else " $connectionName"}…")
+                    loading -> SftpEmpty("正在读取 $path…")
+                    error != null -> SftpError(error!!, onRetry = { reconnect() })
                     visible.isEmpty() -> SftpEmpty(if (query.isNotBlank()) "没有匹配 $query 的项目" else "$path · 空目录")
                     else -> LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 24.dp)) {
                         items(visible, key = { it.path }) { entry ->
@@ -512,7 +745,7 @@ fun SftpBrowserPane(
                 onDismissRequest = { pendingClose = false },
                 title = { Text("放弃未保存修改？") },
                 text = { Text("返回文件列表会丢失当前修改。") },
-                confirmButton = { TextButton(onClick = { pendingClose = false; editor = null }) { Text("放弃") } },
+                confirmButton = { TextButton(onClick = { pendingClose = false; closeEditor(force = true) }) { Text("放弃") } },
                 dismissButton = { TextButton(onClick = { pendingClose = false }) { Text("继续编辑") } },
             )
         }
@@ -540,9 +773,20 @@ fun SftpBrowserPane(
                 onDismissRequest = { dialog = null },
                 title = { Text(current.title) },
                 text = {
-                    Column {
+                    Column(Modifier.verticalScroll(rememberScrollState())) {
                         current.lines.forEach { (label, value) ->
-                            Text("$label  $value", fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                            val jump = label.contains(':') && label.startsWith("/")
+                            Text(
+                                "$label  $value",
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 12.sp,
+                                color = if (jump) ZephyrTheme.palette.brand.accent else ZephyrTheme.palette.onFloating,
+                                modifier = if (jump) Modifier.clickable {
+                                    dialog = null
+                                    val pathToOpen = label.substringBefore(':')
+                                    openEntry(RemoteEntry(RemotePath.nameOf(pathToOpen), pathToOpen, false, 0L, 0L))
+                                } else Modifier,
+                            )
                         }
                     }
                 },
@@ -565,7 +809,7 @@ fun SftpBrowserPane(
                 },
             )
             is SftpDialog.PasteConflict -> {
-                val clip = clipboard
+                val clip = localClipboard
                 AlertDialog(
                     onDismissRequest = { dialog = null },
                     title = { Text("目标已存在同名项目") },
@@ -576,24 +820,24 @@ fun SftpBrowserPane(
                                 dialog = null
                                 if (clip != null) applyPaste(
                                     clip, SftpPasteConflictMode.OVERWRITE, entries.map { it.name }.toSet(),
-                                    port, path, currentHandle(), onMessage, { busy = it }, { transfer = it },
-                                    { if (clip.mode == SftpClipboardMode.CUT) clipboard = null; refresh() }, scope,
+                                    port, path, currentHandle(), connectionId, onMessage, { busy = it }, { transfer = it },
+                                    { if (clip.mode == SftpClipboardMode.CUT) setClip(null); refresh() }, scope,
                                 )
                             }) { Text("覆盖") }
                             TextButton(onClick = {
                                 dialog = null
                                 if (clip != null) applyPaste(
                                     clip, SftpPasteConflictMode.SKIP, entries.map { it.name }.toSet(),
-                                    port, path, currentHandle(), onMessage, { busy = it }, { transfer = it },
-                                    { if (clip.mode == SftpClipboardMode.CUT) clipboard = null; refresh() }, scope,
+                                    port, path, currentHandle(), connectionId, onMessage, { busy = it }, { transfer = it },
+                                    { if (clip.mode == SftpClipboardMode.CUT) setClip(null); refresh() }, scope,
                                 )
                             }) { Text("跳过") }
                             TextButton(onClick = {
                                 dialog = null
                                 if (clip != null) applyPaste(
                                     clip, SftpPasteConflictMode.COMPATIBLE, entries.map { it.name }.toSet(),
-                                    port, path, currentHandle(), onMessage, { busy = it }, { transfer = it },
-                                    { if (clip.mode == SftpClipboardMode.CUT) clipboard = null; refresh() }, scope,
+                                    port, path, currentHandle(), connectionId, onMessage, { busy = it }, { transfer = it },
+                                    { if (clip.mode == SftpClipboardMode.CUT) setClip(null); refresh() }, scope,
                                 )
                             }) { Text("兼容") }
                         }
@@ -613,9 +857,11 @@ fun SftpBrowserPane(
                             runOp(onMessage, { busy = it }, { transfer = it }) {
                                 val bytes = currentFile.encoding.encode(currentFile.text)
                                 val receipt = port.write(currentHandle(), currentFile.path, bytes, null, null, force = true)
-                                editor = currentFile.copy(
-                                    baseline = RemoteFileRead(currentFile.path, bytes, receipt.mtimeMs, receipt.sha256),
-                                    dirty = false,
+                                upsertEditor(
+                                    currentFile.copy(
+                                        baseline = RemoteFileRead(currentFile.path, bytes, receipt.mtimeMs, receipt.sha256),
+                                        dirty = false,
+                                    ),
                                 )
                                 onMessage("已强制覆盖保存")
                             }
@@ -767,6 +1013,7 @@ private fun SftpActionBar(
     selectedCount: Int,
     canPaste: Boolean,
     onSelect: () -> Unit,
+    onOpen: () -> Unit,
     onCopy: () -> Unit,
     onCut: () -> Unit,
     onPaste: () -> Unit,
@@ -783,13 +1030,14 @@ private fun SftpActionBar(
     ) {
         MiniChip(if (selecting) "取消选择" else "选择", onSelect)
         if (selectedCount > 0) {
+            MiniChip("打开", onOpen)
             MiniChip("复制", onCopy)
             MiniChip("剪切", onCut)
             MiniChip("重命名", onRename, enabled = selectedCount == 1)
             MiniChip("删除", onDelete)
             MiniChip("压缩", onCompress)
             MiniChip("权限", onChmod, enabled = selectedCount == 1)
-            MiniChip("下载", onDownload, enabled = selectedCount == 1)
+            MiniChip("下载", onDownload, enabled = selectedCount >= 1)
             MiniChip("属性", onProperties)
         }
         MiniChip("粘贴", onPaste, enabled = canPaste)
@@ -850,11 +1098,27 @@ private fun SftpEntryRow(
 
 @Composable
 private fun SftpTextEditor(
-    file: BrowserFile,
-    onChange: (String, FileEncoding, String) -> Unit,
+    files: List<BrowserFile>,
+    activeIndex: Int,
+    onSelect: (Int) -> Unit,
+    onCloseTab: (Int) -> Unit,
+    onChange: (String, FileEncoding, String, Int, Boolean) -> Unit,
+    onUndo: () -> Unit,
+    onRedo: () -> Unit,
+    onFormat: () -> Unit,
     onBack: () -> Unit,
     onSave: () -> Unit,
+    onWorkspaceSearch: (String) -> Unit,
+    onOpenHit: (String) -> Unit,
 ) {
+    val file = files.getOrNull(activeIndex) ?: return
+    var findQuery by remember { mutableStateOf("") }
+    var findOpen by remember { mutableStateOf(false) }
+    var outlineOpen by remember { mutableStateOf(false) }
+    var workspaceQuery by remember { mutableStateOf("") }
+    var workspaceOpen by remember { mutableStateOf(false) }
+    val hits = remember(file.text, findQuery) { SftpEditorSupport.findInText(file.text, findQuery) }
+    val outline = remember(file.text, file.path) { SftpEditorSupport.outline(file.text, file.path) }
     Column(Modifier.fillMaxSize()) {
         Row(
             Modifier.fillMaxWidth().background(ZephyrTheme.palette.surfaces.content).padding(8.dp),
@@ -863,46 +1127,100 @@ private fun SftpTextEditor(
         ) {
             IconButton(onClick = onBack) { Icon(ZephyrIcons.Back, "返回文件列表") }
             Column(Modifier.weight(1f)) {
-                Text(file.path.substringAfterLast('/'), color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold)
-                Text(if (file.dirty) "未保存" else file.path, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 10.sp, maxLines = 1)
+                Text(file.title, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, maxLines = 1)
+                Text(
+                    (if (file.dirty) "未保存 · " else "") + SftpEditorSupport.languageOf(file.path) + " · " + file.path,
+                    color = ZephyrTheme.palette.onFloatingSubtle,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                )
             }
             PrimaryButton(onClick = onSave, enabled = file.dirty) { Text("保存") }
         }
         Row(
             Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp, vertical = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            files.forEachIndexed { index, tab ->
+                AssistChip(
+                    onClick = { onSelect(index) },
+                    label = { Text((if (tab.dirty) "● " else "") + tab.title, fontSize = 11.sp) },
+                )
+                if (index == activeIndex) {
+                    TextButton(onClick = { onCloseTab(index) }) { Text("×") }
+                }
+            }
+        }
+        Row(
+            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             FileEncoding.entries.forEach { encoding ->
                 FilterChip(
                     selected = file.encoding == encoding,
-                    onClick = { onChange(encoding.decode(file.baseline.bytes), encoding, file.lineEnding) },
+                    onClick = { onChange(encoding.decode(file.baseline.bytes), encoding, file.lineEnding, file.tabSize, file.wrap) },
                     enabled = encoding.isAvailable,
                     label = { Text(encoding.label, fontSize = 11.sp) },
                 )
             }
-            FilterChip(
-                selected = file.lineEnding == "lf",
-                onClick = { onChange(file.text, file.encoding, "lf") },
-                label = { Text("LF", fontSize = 11.sp) },
-            )
-            FilterChip(
-                selected = file.lineEnding == "crlf",
-                onClick = { onChange(file.text, file.encoding, "crlf") },
-                label = { Text("CRLF", fontSize = 11.sp) },
-            )
+            FilterChip(selected = file.lineEnding == "lf", onClick = { onChange(file.text, file.encoding, "lf", file.tabSize, file.wrap) }, label = { Text("LF", fontSize = 11.sp) })
+            FilterChip(selected = file.lineEnding == "crlf", onClick = { onChange(file.text, file.encoding, "crlf", file.tabSize, file.wrap) }, label = { Text("CRLF", fontSize = 11.sp) })
+            FilterChip(selected = file.tabSize == 2, onClick = { onChange(file.text, file.encoding, file.lineEnding, 2, file.wrap) }, label = { Text("Tab 2", fontSize = 11.sp) })
+            FilterChip(selected = file.tabSize == 4, onClick = { onChange(file.text, file.encoding, file.lineEnding, 4, file.wrap) }, label = { Text("Tab 4", fontSize = 11.sp) })
+            FilterChip(selected = file.wrap, onClick = { onChange(file.text, file.encoding, file.lineEnding, file.tabSize, !file.wrap) }, label = { Text("换行", fontSize = 11.sp) })
+            AssistChip(onClick = onUndo, label = { Text("撤回", fontSize = 11.sp) })
+            AssistChip(onClick = onRedo, label = { Text("前进", fontSize = 11.sp) })
+            AssistChip(onClick = onFormat, label = { Text("格式化", fontSize = 11.sp) })
+            AssistChip(onClick = { findOpen = !findOpen }, label = { Text("查找", fontSize = 11.sp) })
+            AssistChip(onClick = { outlineOpen = !outlineOpen }, label = { Text("大纲", fontSize = 11.sp) })
+            AssistChip(onClick = { workspaceOpen = !workspaceOpen }, label = { Text("搜目录", fontSize = 11.sp) })
         }
-        BasicTextField(
-            value = file.text,
-            onValueChange = { onChange(it, file.encoding, file.lineEnding) },
-            modifier = Modifier.fillMaxSize().background(ZephyrTheme.palette.surfaces.background).padding(14.dp),
-            textStyle = androidx.compose.ui.text.TextStyle(
-                color = ZephyrTheme.palette.onFloating,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
-                lineHeight = 19.sp,
-            ),
-        )
+        if (findOpen) {
+            Row(Modifier.fillMaxWidth().padding(horizontal = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+                OutlinedTextField(value = findQuery, onValueChange = { findQuery = it }, modifier = Modifier.weight(1f), singleLine = true, placeholder = { Text("在文件中查找") })
+                Text("${hits.size}", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp, modifier = Modifier.padding(start = 8.dp))
+            }
+            if (hits.isNotEmpty()) {
+                Column(Modifier.fillMaxWidth().heightIn(max = 120.dp).verticalScroll(rememberScrollState()).padding(horizontal = 12.dp)) {
+                    hits.take(40).forEach { hit ->
+                        Text("L${hit.line}:${hit.column}  ${hit.text}", color = ZephyrTheme.palette.onFloatingMuted, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                    }
+                }
+            }
+        }
+        if (workspaceOpen) {
+            Row(Modifier.fillMaxWidth().padding(horizontal = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+                OutlinedTextField(value = workspaceQuery, onValueChange = { workspaceQuery = it }, modifier = Modifier.weight(1f), singleLine = true, placeholder = { Text("在当前 SFTP 目录搜索文本…") })
+                TextButton(onClick = { if (workspaceQuery.isNotBlank()) onWorkspaceSearch(workspaceQuery) }) { Text("搜索") }
+            }
+        }
+        Row(Modifier.fillMaxSize()) {
+            BasicTextField(
+                value = file.text,
+                onValueChange = { onChange(it, file.encoding, file.lineEnding, file.tabSize, file.wrap) },
+                modifier = Modifier.weight(1f).fillMaxSize().background(ZephyrTheme.palette.surfaces.background).padding(14.dp),
+                textStyle = androidx.compose.ui.text.TextStyle(
+                    color = ZephyrTheme.palette.onFloating,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 13.sp,
+                    lineHeight = 19.sp,
+                ),
+            )
+            if (outlineOpen) {
+                Column(
+                    Modifier.width(160.dp).fillMaxSize().background(ZephyrTheme.palette.surfaces.content).verticalScroll(rememberScrollState()).padding(8.dp),
+                ) {
+                    Text("大纲", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp)
+                    if (outline.isEmpty()) Text("暂无符号", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp)
+                    outline.forEach { item ->
+                        Text("L${item.line}  ${item.name}", color = ZephyrTheme.palette.onFloating, fontSize = 11.sp, maxLines = 1, modifier = Modifier.padding(vertical = 3.dp))
+                    }
+                    @Suppress("UNUSED_VARIABLE")
+                    val keepOpen = onOpenHit
+                }
+            }
+        }
     }
 }
 
@@ -946,10 +1264,9 @@ private fun SftpPreviewPane(
                     }
                 }
                 SftpOpenKind.MEDIA -> {
-                    val mediaFile = remember(preview.path, preview.bytes) {
-                        val ext = SshFileKinds.extensionOf(preview.path).ifBlank { "bin" }
-                        File(cacheDir, "sftp-preview-${preview.path.hashCode()}.$ext").apply {
-                            writeBytes(preview.bytes)
+                    val mediaFile = remember(preview.path, preview.cacheFile) {
+                        preview.cacheFile ?: File(cacheDir, "sftp-preview-${preview.path.hashCode()}.${SshFileKinds.extensionOf(preview.path).ifBlank { "bin" }}").apply {
+                            if (preview.bytes.isNotEmpty()) writeBytes(preview.bytes)
                         }
                     }
                     DisposableEffect(mediaFile) { onDispose { mediaFile.delete() } }
@@ -1058,6 +1375,54 @@ private fun queryDisplayName(context: android.content.Context, uri: Uri): String
     }
 }
 
+private fun querySize(context: android.content.Context, uri: Uri): Long {
+    val cursor = context.contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.SIZE), null, null, null)
+    return cursor?.use {
+        if (it.moveToFirst()) it.getLong(0) else 0L
+    } ?: 0L
+}
+
+private suspend fun streamDownload(
+    port: SftpPort,
+    handle: SftpSessionHandle,
+    remotePath: String,
+    uri: Uri,
+    context: android.content.Context,
+    label: String,
+    push: (SftpTransferOps.Transfer) -> Unit,
+    knownSize: Long = 0L,
+) {
+    val id = "dl-$remotePath-${System.currentTimeMillis()}"
+    context.contentResolver.openOutputStream(uri)?.use { output ->
+        port.readStream(handle, remotePath, 0L) { offset, bytes, total ->
+            output.write(bytes)
+            push(
+                SftpTransferOps.Transfer(
+                    id = id,
+                    label = "下载 $label",
+                    direction = SftpTransferOps.Direction.DOWNLOAD,
+                    path = remotePath,
+                    loaded = offset + bytes.size,
+                    total = if (total > 0) total else knownSize,
+                    detail = SftpOpenPolicy.formatBytes(offset + bytes.size),
+                ),
+            )
+        }
+    } ?: error("无法写入本机文件")
+    push(
+        SftpTransferOps.Transfer(
+            id = id,
+            label = "下载 $label",
+            direction = SftpTransferOps.Direction.DOWNLOAD,
+            path = remotePath,
+            loaded = knownSize,
+            total = knownSize,
+            status = SftpTransferOps.Status.DONE,
+            detail = "完成",
+        ),
+    )
+}
+
 private suspend fun runOp(
     onMessage: (String) -> Unit,
     setBusy: (Boolean) -> Unit,
@@ -1082,6 +1447,7 @@ private fun applyPaste(
     port: SftpPort,
     directory: String,
     handle: SftpSessionHandle,
+    destinationConnectionId: String,
     onMessage: (String) -> Unit,
     setBusy: (Boolean) -> Unit,
     setTransfer: (TransferJob?) -> Unit,
@@ -1091,9 +1457,29 @@ private fun applyPaste(
     scope.launch {
         runOp(onMessage, setBusy, setTransfer) {
             val plan = SftpClipboardOps.planPaste(clip, directory, existing, mode)
-            val command = SftpClipboardOps.commandFor(plan, cut = clip.mode == SftpClipboardMode.CUT)
-                ?: error("没有可粘贴的项目")
-            port.exec(handle, command).requireOk("粘贴")
+            if (plan.copies.isEmpty()) error("没有可粘贴的项目")
+            if (clip.sameHostAs(destinationConnectionId)) {
+                val command = SftpClipboardOps.commandFor(plan, cut = clip.mode == SftpClipboardMode.CUT)
+                    ?: error("没有可粘贴的项目")
+                port.exec(handle, command).requireOk("粘贴")
+            } else {
+                val source = port.open(clip.sourceConnectionId)
+                try {
+                    for ((from, to) in plan.copies) {
+                        val chunks = ArrayList<ByteArray>()
+                        port.readStream(source, from, 0L) { _, bytes, _ -> chunks += bytes }
+                        var index = 0
+                        port.writeStream(handle, to) {
+                            if (index >= chunks.size) null else chunks[index++]
+                        }
+                        if (clip.mode == SftpClipboardMode.CUT) {
+                            runCatching { port.delete(source, from, recursive = true) }
+                        }
+                    }
+                } finally {
+                    runCatching { port.close(source) }
+                }
+            }
             onMessage("已粘贴 ${plan.copies.size} 项")
             onDone()
         }

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpCapabilities.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpCapabilities.kt
@@ -20,6 +20,12 @@ enum class SftpAction {
     EDIT,
     RENAME,
     DELETE,
+    CHMOD,
+    COMPRESS,
+    EXTRACT,
+    COPY,
+    PASTE,
+    PROPERTIES,
 }
 
 /**
@@ -33,12 +39,22 @@ enum class SftpAction {
 object SftpCapabilities {
 
     fun required(action: SftpAction): Capability = when (action) {
-        SftpAction.LIST, SftpAction.STAT, SftpAction.READ, SftpAction.DOWNLOAD -> Capability.FILE_READ
+        SftpAction.LIST,
+        SftpAction.STAT,
+        SftpAction.READ,
+        SftpAction.DOWNLOAD,
+        SftpAction.COPY,
+        SftpAction.PROPERTIES,
+        -> Capability.FILE_READ
         SftpAction.UPLOAD,
         SftpAction.CREATE,
         SftpAction.EDIT,
         SftpAction.RENAME,
         SftpAction.DELETE,
+        SftpAction.CHMOD,
+        SftpAction.COMPRESS,
+        SftpAction.EXTRACT,
+        SftpAction.PASTE,
         -> Capability.FILE_WRITE
     }
 

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpEditorSupport.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpEditorSupport.kt
@@ -1,0 +1,171 @@
+package one.zephyr.mobile.feature.notes
+
+import one.zephyr.mobile.protocol.ssh.SshRemoteOps
+
+/**
+ * Desktop editor extras that do not need Monaco: language label, outline, in-file find
+ * and a bounded workspace grep over the current SFTP directory.
+ */
+object SftpEditorSupport {
+
+    data class OutlineItem(val name: String, val line: Int, val kind: String)
+
+    data class FindHit(val line: Int, val column: Int, val text: String)
+
+    data class WorkspaceHit(val path: String, val line: Int, val text: String)
+
+    fun languageOf(path: String): String {
+        val ext = RemotePath.extensionOf(path)
+        return when (ext) {
+            "kt", "kts" -> "Kotlin"
+            "java" -> "Java"
+            "js", "mjs", "cjs" -> "JavaScript"
+            "ts", "tsx" -> "TypeScript"
+            "py" -> "Python"
+            "go" -> "Go"
+            "rs" -> "Rust"
+            "rb" -> "Ruby"
+            "php" -> "PHP"
+            "c", "h" -> "C"
+            "cc", "cpp", "hpp", "cxx" -> "C++"
+            "cs" -> "C#"
+            "swift" -> "Swift"
+            "sh", "bash", "zsh" -> "Shell"
+            "json", "jsonc" -> "JSON"
+            "yml", "yaml" -> "YAML"
+            "xml", "html", "htm" -> "Markup"
+            "css", "scss", "less" -> "CSS"
+            "md", "markdown" -> "Markdown"
+            "sql" -> "SQL"
+            "toml", "ini", "cfg", "conf", "properties" -> "Config"
+            else -> if (ext.isBlank()) "Text" else ext.uppercase()
+        }
+    }
+
+    fun outline(text: String, path: String): List<OutlineItem> {
+        val language = languageOf(path).lowercase()
+        val patterns = when {
+            language in setOf("kotlin", "java", "javascript", "typescript", "c#", "swift") ->
+                listOf(
+                    Regex("""^\s*(?:(?:public|private|protected|internal|open|override|suspend|fun|function|class|interface|object|enum|struct)\s+)+([A-Za-z_][\w.]*)"""),
+                    Regex("""^\s*(?:def|class|interface)\s+([A-Za-z_]\w*)"""),
+                )
+            language == "python" || language == "ruby" ->
+                listOf(Regex("""^\s*(?:def|class|async\s+def)\s+([A-Za-z_]\w*)"""))
+            language == "go" ->
+                listOf(Regex("""^\s*func\s+(?:\([^)]+\)\s+)?([A-Za-z_]\w*)"""))
+            language == "rust" ->
+                listOf(Regex("""^\s*(?:pub\s+)?(?:fn|struct|enum|trait|impl)\s+([A-Za-z_]\w*)"""))
+            else ->
+                listOf(
+                    Regex("""^\s*(?:function|def|class|fun|func|fn)\s+([A-Za-z_]\w*)"""),
+                    Regex("""^\s{0,3}#{1,3}\s+(.+?)\s*$"""),
+                )
+        }
+        val items = ArrayList<OutlineItem>()
+        text.lineSequence().forEachIndexed { index, line ->
+            for (pattern in patterns) {
+                val match = pattern.find(line) ?: continue
+                items += OutlineItem(match.groupValues[1].trim(), index + 1, "symbol")
+                break
+            }
+        }
+        return items.take(400)
+    }
+
+    fun findInText(text: String, query: String, ignoreCase: Boolean = true): List<FindHit> {
+        val needle = query.trim()
+        if (needle.isEmpty()) return emptyList()
+        val hits = ArrayList<FindHit>()
+        text.lineSequence().forEachIndexed { index, line ->
+            var from = 0
+            val hay = if (ignoreCase) line.lowercase() else line
+            val pin = if (ignoreCase) needle.lowercase() else needle
+            while (from <= hay.length) {
+                val at = hay.indexOf(pin, from)
+                if (at < 0) break
+                hits += FindHit(index + 1, at + 1, line.trim().take(200))
+                from = at + pin.length.coerceAtLeast(1)
+                if (hits.size >= 500) return hits
+            }
+        }
+        return hits
+    }
+
+    fun formatDocument(text: String, tabSize: Int, useTabs: Boolean = false): String {
+        val indent = if (useTabs) "\t" else " ".repeat(tabSize.coerceIn(2, 8))
+        val lines = text.replace("\r\n", "\n").replace('\r', '\n').split('\n')
+        var depth = 0
+        val out = ArrayList<String>(lines.size)
+        for (raw in lines) {
+            val trimmed = raw.trim()
+            val closes = trimmed.startsWith("}") || trimmed.startsWith("]") || trimmed.startsWith(")")
+            if (closes) depth = (depth - 1).coerceAtLeast(0)
+            out += if (trimmed.isEmpty()) "" else indent.repeat(depth) + trimmed
+            val opens = trimmed.endsWith("{") || trimmed.endsWith("[") || trimmed.endsWith("(")
+            if (opens && !trimmed.startsWith("}")) depth += 1
+        }
+        return out.joinToString("\n")
+    }
+
+    fun workspaceSearchCommand(directory: String, query: String, maxFiles: Int = 80): String {
+        val encoded = java.util.Base64.getEncoder().encodeToString(query.toByteArray(Charsets.UTF_8))
+        return """
+python3 - "$encoded" ${SshRemoteOps.shellQuote(directory)} $maxFiles <<'PY'
+import base64, json, os, sys
+query = base64.b64decode(sys.argv[1]).decode('utf-8', 'replace')
+root = sys.argv[2]
+limit = int(sys.argv[3])
+hits = []
+scanned = 0
+skip_ext = {'.png','.jpg','.jpeg','.gif','.webp','.mp4','.mkv','.mp3','.zip','.gz','.tar','.7z','.woff','.ttf','.so','.bin','.exe'}
+for dirpath, dirnames, filenames in os.walk(root):
+    dirnames[:] = [d for d in dirnames if d not in {'.git','node_modules','.cache'}][:40]
+    for name in filenames:
+        if scanned >= limit or len(hits) >= 200:
+            print(json.dumps({'hits': hits, 'filesScanned': scanned}))
+            raise SystemExit(0)
+        ext = os.path.splitext(name)[1].lower()
+        if ext in skip_ext:
+            continue
+        path = os.path.join(dirpath, name)
+        try:
+            size = os.lstat(path).st_size
+        except OSError:
+            continue
+        if size > 512 * 1024:
+            continue
+        scanned += 1
+        try:
+            with open(path, 'rb') as fh:
+                raw = fh.read()
+            if b'\x00' in raw:
+                continue
+            text = raw.decode('utf-8', 'replace')
+        except OSError:
+            continue
+        for index, line in enumerate(text.splitlines(), 1):
+            if query in line:
+                hits.append({'path': path, 'line': index, 'text': line.strip()[:200]})
+                if len(hits) >= 200:
+                    break
+print(json.dumps({'hits': hits, 'filesScanned': scanned}))
+PY
+        """.trimIndent()
+    }
+
+    fun parseWorkspaceHits(raw: String): Pair<List<WorkspaceHit>, Int> {
+        val line = raw.lineSequence().map(String::trim).lastOrNull { it.startsWith("{") } ?: return emptyList<WorkspaceHit>() to 0
+        val map = SshRemoteOps.parseFlatJsonObject(line)
+        val scanned = map["filesScanned"]?.toIntOrNull() ?: 0
+        val hitsRaw = line.substringAfter("\"hits\":", "[]")
+        val hits = ArrayList<WorkspaceHit>()
+        val objectPattern = Regex("""\{[^{}]+\}""")
+        for (blob in objectPattern.findAll(hitsRaw)) {
+            val item = SshRemoteOps.parseFlatJsonObject(blob.value)
+            val path = item["path"] ?: continue
+            hits += WorkspaceHit(path, item["line"]?.toIntOrNull() ?: 1, item["text"].orEmpty())
+        }
+        return hits to scanned
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpHostTabs.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpHostTabs.kt
@@ -1,0 +1,31 @@
+package one.zephyr.mobile.feature.notes
+
+/**
+ * Library SFTP tabs. Same shape as the terminal session rail: first pick opens one host,
+ * plus adds another, close drops that connection, last close returns to the picker.
+ */
+data class SftpHostTabs(
+    val openIds: List<String> = emptyList(),
+    val focusedId: String? = null,
+) {
+    val isEmpty: Boolean get() = openIds.isEmpty()
+
+    fun open(id: String): SftpHostTabs {
+        if (id.isBlank()) return this
+        val next = if (id in openIds) openIds else openIds + id
+        return copy(openIds = next, focusedId = id)
+    }
+
+    fun focus(id: String): SftpHostTabs =
+        if (id in openIds) copy(focusedId = id) else this
+
+    fun close(id: String): SftpHostTabs {
+        val next = openIds.filterNot { it == id }
+        val focused = when {
+            focusedId != id -> focusedId
+            next.isEmpty() -> null
+            else -> next.last()
+        }
+        return copy(openIds = next, focusedId = focused)
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicy.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicy.kt
@@ -7,9 +7,11 @@ enum class SftpOpenKind { DIRECTORY, IMAGE, MEDIA, TEXT, ARCHIVE, BINARY }
 
 object SftpOpenPolicy {
 
-    const val TEXT_EDIT_LIMIT = 2L * 1024 * 1024
-    const val IMAGE_PREVIEW_LIMIT = 8L * 1024 * 1024
-    const val MEDIA_PREVIEW_LIMIT = 32L * 1024 * 1024
+    const val TEXT_EDIT_LIMIT = 8L * 1024 * 1024
+    const val IMAGE_PREVIEW_LIMIT = 16L * 1024 * 1024
+    const val MEDIA_PREVIEW_LIMIT = 64L * 1024 * 1024
+    const val MEDIA_CACHE_LIMIT = 256L * 1024 * 1024
+
 
     fun kindOf(entry: RemoteEntry): SftpOpenKind = when {
         entry.isDirectory -> SftpOpenKind.DIRECTORY
@@ -32,8 +34,8 @@ object SftpOpenPolicy {
             "文件超过 ${formatBytes(TEXT_EDIT_LIMIT)}，拒绝作为文本打开"
         kind == SftpOpenKind.IMAGE && sizeBytes > IMAGE_PREVIEW_LIMIT ->
             "图片超过 ${formatBytes(IMAGE_PREVIEW_LIMIT)}，请下载后查看"
-        kind == SftpOpenKind.MEDIA && sizeBytes > MEDIA_PREVIEW_LIMIT ->
-            "媒体超过 ${formatBytes(MEDIA_PREVIEW_LIMIT)}，请下载后播放"
+        kind == SftpOpenKind.MEDIA && sizeBytes > MEDIA_CACHE_LIMIT ->
+            "媒体超过 ${formatBytes(MEDIA_CACHE_LIMIT)}，请下载后播放"
         else -> null
     }
 
@@ -70,9 +72,13 @@ data class SftpClipboard(
     val mode: SftpClipboardMode,
     val paths: List<String>,
     val sourceDirectory: String,
+    val sourceConnectionId: String = "",
 ) {
     val isEmpty: Boolean get() = paths.isEmpty()
     val count: Int get() = paths.size
+
+    fun sameHostAs(connectionId: String): Boolean =
+        sourceConnectionId.isBlank() || sourceConnectionId == connectionId
 }
 
 enum class SftpPasteConflictMode { OVERWRITE, SKIP, COMPATIBLE }

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicy.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicy.kt
@@ -1,0 +1,139 @@
+package one.zephyr.mobile.feature.notes
+
+import one.zephyr.mobile.protocol.ssh.SshFileKinds
+
+/** What tapping a remote file should do. Mirrors `public/terminal.js` open / preview routing. */
+enum class SftpOpenKind { DIRECTORY, IMAGE, MEDIA, TEXT, ARCHIVE, BINARY }
+
+object SftpOpenPolicy {
+
+    const val TEXT_EDIT_LIMIT = 2L * 1024 * 1024
+    const val IMAGE_PREVIEW_LIMIT = 8L * 1024 * 1024
+    const val MEDIA_PREVIEW_LIMIT = 32L * 1024 * 1024
+
+    fun kindOf(entry: RemoteEntry): SftpOpenKind = when {
+        entry.isDirectory -> SftpOpenKind.DIRECTORY
+        SshFileKinds.isImage(entry.name) -> SftpOpenKind.IMAGE
+        SshFileKinds.isMedia(entry.name) -> SftpOpenKind.MEDIA
+        SshFileKinds.isArchive(entry.name) -> SftpOpenKind.ARCHIVE
+        SshFileKinds.isText(entry.name) -> SftpOpenKind.TEXT
+        else -> SftpOpenKind.BINARY
+    }
+
+    fun previewLimit(kind: SftpOpenKind): Long = when (kind) {
+        SftpOpenKind.TEXT -> TEXT_EDIT_LIMIT
+        SftpOpenKind.IMAGE -> IMAGE_PREVIEW_LIMIT
+        SftpOpenKind.MEDIA -> MEDIA_PREVIEW_LIMIT
+        else -> TEXT_EDIT_LIMIT
+    }
+
+    fun rejectReason(kind: SftpOpenKind, sizeBytes: Long): String? = when {
+        kind == SftpOpenKind.TEXT && sizeBytes > TEXT_EDIT_LIMIT ->
+            "文件超过 ${formatBytes(TEXT_EDIT_LIMIT)}，拒绝作为文本打开"
+        kind == SftpOpenKind.IMAGE && sizeBytes > IMAGE_PREVIEW_LIMIT ->
+            "图片超过 ${formatBytes(IMAGE_PREVIEW_LIMIT)}，请下载后查看"
+        kind == SftpOpenKind.MEDIA && sizeBytes > MEDIA_PREVIEW_LIMIT ->
+            "媒体超过 ${formatBytes(MEDIA_PREVIEW_LIMIT)}，请下载后播放"
+        else -> null
+    }
+
+    fun formatBytes(bytes: Long): String {
+        if (bytes < 1024L) return "$bytes B"
+        val units = listOf("KiB", "MiB", "GiB", "TiB")
+        var value = bytes.toDouble() / 1024.0
+        var unit = 0
+        while (value >= 1024.0 && unit < units.lastIndex) {
+            value /= 1024.0
+            unit++
+        }
+        val rounded = (value * 10.0).toLong()
+        return "${rounded / 10L}.${rounded % 10L} ${units[unit]}"
+    }
+
+    fun formatTime(mtimeMs: Long): String {
+        if (mtimeMs <= 0L) return "—"
+        val seconds = mtimeMs / 1000L
+        val date = java.time.Instant.ofEpochSecond(seconds).atZone(java.time.ZoneId.systemDefault())
+        return "%04d-%02d-%02d %02d:%02d".format(
+            date.year,
+            date.monthValue,
+            date.dayOfMonth,
+            date.hour,
+            date.minute,
+        )
+    }
+}
+
+enum class SftpClipboardMode { COPY, CUT }
+
+data class SftpClipboard(
+    val mode: SftpClipboardMode,
+    val paths: List<String>,
+    val sourceDirectory: String,
+) {
+    val isEmpty: Boolean get() = paths.isEmpty()
+    val count: Int get() = paths.size
+}
+
+enum class SftpPasteConflictMode { OVERWRITE, SKIP, COMPATIBLE }
+
+data class SftpPastePlan(
+    val copies: List<Pair<String, String>>,
+    val skipped: List<String>,
+    val overwrites: List<String>,
+)
+
+object SftpClipboardOps {
+
+    fun planPaste(
+        clipboard: SftpClipboard,
+        destination: String,
+        existingNames: Set<String>,
+        conflict: SftpPasteConflictMode,
+    ): SftpPastePlan {
+        val copies = ArrayList<Pair<String, String>>()
+        val skipped = ArrayList<String>()
+        val overwrites = ArrayList<String>()
+        val reserved = existingNames.toMutableSet()
+        for (source in clipboard.paths) {
+            val name = RemotePath.nameOf(source)
+            val clash = name in reserved
+            when {
+                !clash -> {
+                    val target = RemotePath.join(destination, name)
+                    copies += source to target
+                    reserved += name
+                }
+                conflict == SftpPasteConflictMode.SKIP -> skipped += source
+                conflict == SftpPasteConflictMode.OVERWRITE -> {
+                    val target = RemotePath.join(destination, name)
+                    copies += source to target
+                    overwrites += target
+                }
+                else -> {
+                    val renamed = SshFileKinds.uniqueCopyName(reserved, name)
+                    copies += source to RemotePath.join(destination, renamed)
+                    reserved += renamed
+                }
+            }
+        }
+        return SftpPastePlan(copies = copies, skipped = skipped, overwrites = overwrites)
+    }
+
+    fun commandFor(plan: SftpPastePlan, cut: Boolean): String? {
+        if (plan.copies.isEmpty()) return null
+        val quote = one.zephyr.mobile.protocol.ssh.SshRemoteOps::shellQuote
+        val parts = ArrayList<String>()
+        if (cut) {
+            for (target in plan.overwrites) {
+                parts += SshFileKinds.recursiveDeleteCommand(target)
+            }
+        }
+        for ((from, to) in plan.copies) {
+            val destDir = RemotePath.parentOf(to)
+            val op = if (cut) "mv" else "cp -a"
+            parts += "mkdir -p ${quote(destDir)} && $op -- ${quote(from)} ${quote(to)}"
+        }
+        return parts.joinToString(" && ")
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpPort.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpPort.kt
@@ -175,6 +175,40 @@ interface SftpPort {
 
     /** Runs a shell command on the same SSH session. Used for compress / extract / copy / properties. */
     suspend fun exec(handle: SftpSessionHandle, command: String): RemoteExecResult
+
+    /** Streaming remote command. Cancel the collector to stop `docker logs -f` / a long pull. */
+    fun execStream(handle: SftpSessionHandle, command: String): kotlinx.coroutines.flow.Flow<RemoteExecChunk> =
+        kotlinx.coroutines.flow.flow {
+            val result = exec(handle, command)
+            if (result.stdout.isNotEmpty()) emit(RemoteExecChunk.Output(result.stdout, stderr = false))
+            if (result.stderr.isNotEmpty()) emit(RemoteExecChunk.Output(result.stderr, stderr = true))
+            emit(RemoteExecChunk.Closed(result.exitCode))
+        }
+
+    /**
+     * Stream-read [path] from [resumeFromBytes]. [onChunk] receives each payload.
+     * Implementations must not buffer the whole file.
+     */
+    suspend fun readStream(
+        handle: SftpSessionHandle,
+        path: String,
+        resumeFromBytes: Long,
+        onChunk: suspend (offset: Long, bytes: ByteArray, total: Long) -> Unit,
+    ): RemoteWriteReceipt
+
+    /**
+     * Stream-write [path] from [next] chunks. Used for uploads larger than memory.
+     */
+    suspend fun writeStream(
+        handle: SftpSessionHandle,
+        path: String,
+        next: suspend () -> ByteArray?,
+    ): RemoteWriteReceipt
+}
+
+sealed interface RemoteExecChunk {
+    data class Output(val text: String, val stderr: Boolean) : RemoteExecChunk
+    data class Closed(val exitCode: Int) : RemoteExecChunk
 }
 
 /**
@@ -245,4 +279,17 @@ object UnavailableSftpPort : SftpPort {
     ): Long = fail()
 
     override suspend fun exec(handle: SftpSessionHandle, command: String): RemoteExecResult = fail()
+
+    override suspend fun readStream(
+        handle: SftpSessionHandle,
+        path: String,
+        resumeFromBytes: Long,
+        onChunk: suspend (offset: Long, bytes: ByteArray, total: Long) -> Unit,
+    ): RemoteWriteReceipt = fail()
+
+    override suspend fun writeStream(
+        handle: SftpSessionHandle,
+        path: String,
+        next: suspend () -> ByteArray?,
+    ): RemoteWriteReceipt = fail()
 }

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpPort.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpPort.kt
@@ -79,6 +79,16 @@ value class SftpSessionHandle(val token: String)
  */
 data class DownloadProgress(val transferredBytes: Long, val totalBytes: Long?)
 
+/** One remote shell command run on the same SSH session the SFTP handle owns. */
+data class RemoteExecResult(val exitCode: Int, val stdout: String, val stderr: String) {
+    fun requireOk(label: String = "远程命令"): String {
+        if (exitCode != 0) {
+            error(stderr.ifBlank { stdout }.ifBlank { "$label 失败（exit $exitCode）" })
+        }
+        return stdout
+    }
+}
+
 /**
  * The narrow SFTP surface S31 is written against.
  *
@@ -136,6 +146,15 @@ interface SftpPort {
 
     suspend fun delete(handle: SftpSessionHandle, path: String, recursive: Boolean)
 
+    suspend fun chmod(handle: SftpSessionHandle, path: String, mode: Int)
+
+    suspend fun readRange(
+        handle: SftpSessionHandle,
+        path: String,
+        offset: Long,
+        maxBytes: Int,
+    ): RemoteFileRead
+
     suspend fun upload(handle: SftpSessionHandle, path: String, bytes: ByteArray): RemoteWriteReceipt
 
     /**
@@ -153,6 +172,9 @@ interface SftpPort {
         resumeFromBytes: Long,
         onProgress: (DownloadProgress) -> Unit,
     ): Long
+
+    /** Runs a shell command on the same SSH session. Used for compress / extract / copy / properties. */
+    suspend fun exec(handle: SftpSessionHandle, command: String): RemoteExecResult
 }
 
 /**
@@ -203,6 +225,15 @@ object UnavailableSftpPort : SftpPort {
 
     override suspend fun delete(handle: SftpSessionHandle, path: String, recursive: Boolean) = fail()
 
+    override suspend fun chmod(handle: SftpSessionHandle, path: String, mode: Int) = fail()
+
+    override suspend fun readRange(
+        handle: SftpSessionHandle,
+        path: String,
+        offset: Long,
+        maxBytes: Int,
+    ): RemoteFileRead = fail()
+
     override suspend fun upload(handle: SftpSessionHandle, path: String, bytes: ByteArray): RemoteWriteReceipt = fail()
 
     override suspend fun download(
@@ -212,4 +243,6 @@ object UnavailableSftpPort : SftpPort {
         resumeFromBytes: Long,
         onProgress: (DownloadProgress) -> Unit,
     ): Long = fail()
+
+    override suspend fun exec(handle: SftpSessionHandle, command: String): RemoteExecResult = fail()
 }

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpTransferOps.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpTransferOps.kt
@@ -1,0 +1,42 @@
+package one.zephyr.mobile.feature.notes
+
+import one.zephyr.mobile.protocol.ssh.SshFileKinds
+import one.zephyr.mobile.protocol.ssh.SshRemoteOps
+
+object SftpTransferOps {
+
+    const val STREAM_CHUNK = 256 * 1024
+
+    fun bundleName(): String {
+        val stamp = java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmm"))
+        return "zephyr-download-$stamp.tar.gz"
+    }
+
+    fun bundleCommand(sources: List<String>, target: String): String {
+        require(sources.isNotEmpty()) { "没有可打包的项目" }
+        val quoted = sources.joinToString(" ") { SshRemoteOps.shellQuote(it) }
+        return "tar -czf ${SshRemoteOps.shellQuote(target)} $quoted"
+    }
+
+    fun remoteTempPath(name: String): String = "/tmp/${name.trimStart('/')}"
+
+    fun cleanupCommand(path: String): String = SshFileKinds.recursiveDeleteCommand(path)
+
+    data class Transfer(
+        val id: String,
+        val label: String,
+        val direction: Direction,
+        val path: String,
+        val loaded: Long = 0L,
+        val total: Long = 0L,
+        val status: Status = Status.RUNNING,
+        val detail: String = "",
+    ) {
+        val fraction: Float
+            get() = if (total <= 0L) 0f else (loaded.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+    }
+
+    enum class Direction { UPLOAD, DOWNLOAD, ARCHIVE }
+
+    enum class Status { RUNNING, DONE, ERROR, CANCELLED }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt
@@ -2,33 +2,42 @@ package one.zephyr.mobile.feature.notes
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.CircleShape
+import one.zephyr.mobile.ui.component.ActionSheet
+import one.zephyr.mobile.ui.component.ActionSheetGroup
+import one.zephyr.mobile.ui.component.ActionSheetItem
 import one.zephyr.mobile.ui.component.AlertDialog
 import one.zephyr.mobile.ui.component.GroupCard
+import one.zephyr.mobile.ui.component.Icon
 import one.zephyr.mobile.ui.component.OutlinedTextField
 import one.zephyr.mobile.ui.component.PrimaryButton
 import one.zephyr.mobile.ui.component.SettingsRow
 import one.zephyr.mobile.ui.component.Switch
 import one.zephyr.mobile.ui.component.Text
 import one.zephyr.mobile.ui.component.TextButton
+import one.zephyr.mobile.ui.icon.ZephyrIcons
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -36,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -369,35 +379,188 @@ fun SftpBrowserRoute(
     onMessage: (String) -> Unit = {},
 ) {
     val available = connections.filter { it.protocol.supportsFiles && it.capabilities.canReadFiles }
-    var selectedId by remember(available) { mutableStateOf(available.firstOrNull()?.id) }
-    val selected = available.firstOrNull { it.id == selectedId }
+    val ids = available.joinToString("\u0000") { it.id }
+    var tabs by remember { mutableStateOf(SftpHostTabs()) }
+    var addOpen by remember { mutableStateOf(false) }
+    var clipboard by remember { mutableStateOf<SftpClipboard?>(null) }
+    LaunchedEffect(ids) {
+        val gone = tabs.openIds.filter { id -> available.none { it.id == id } }
+        gone.forEach { tabs = tabs.close(it) }
+    }
+    val focused = available.firstOrNull { it.id == tabs.focusedId }
+    val openHosts = tabs.openIds.mapNotNull { id -> available.firstOrNull { it.id == id } }
+    val addable = available.filter { it.id !in tabs.openIds }
     Column(Modifier.fillMaxSize()) {
-        PushedPageHeader(title = "SFTP · ${selected?.name ?: "未选择连接"}", onBack = onBack)
-        if (available.size > 1) {
-            LazyRow(
-                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(available, key = { it.id }) { connection ->
-                    one.zephyr.mobile.ui.component.FilterChip(
-                        selected = selectedId == connection.id,
-                        onClick = { selectedId = connection.id },
-                        label = { Text(connection.name, maxLines = 1) },
-                    )
-                }
-            }
-        }
-        if (selected == null) {
+        PushedPageHeader(title = "SFTP · ${focused?.name ?: "选择主机"}", onBack = onBack)
+        if (available.isEmpty()) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text("没有可读取文件的 SSH 连接", color = ZephyrTheme.palette.onFloatingSubtle)
             }
-        } else {
-            SftpBrowserPane(
-                port = port,
-                connectionId = selected.id,
-                modifier = Modifier.fillMaxSize(),
-                onMessage = onMessage,
+            return
+        }
+        if (tabs.isEmpty) {
+            SftpHostPicker(
+                hosts = available,
+                onPick = { tabs = tabs.open(it.id) },
             )
+        } else {
+            SftpHostRail(
+                hosts = openHosts,
+                focusedId = tabs.focusedId,
+                canAdd = addable.isNotEmpty(),
+                onFocus = { tabs = tabs.focus(it) },
+                onClose = { tabs = tabs.close(it) },
+                onAdd = { addOpen = true },
+            )
+            Box(Modifier.fillMaxSize()) {
+                openHosts.sortedBy { if (it.id == tabs.focusedId) 1 else 0 }.forEach { host ->
+                    key(host.id) {
+                        SftpBrowserPane(
+                            port = port,
+                            connectionId = host.id,
+                            connectionName = host.name,
+                            clipboard = clipboard,
+                            onClipboard = { clipboard = it },
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .graphicsLayer { alpha = if (host.id == tabs.focusedId) 1f else 0f },
+                            onMessage = onMessage,
+                        )
+                    }
+                }
+            }
+        }
+    }
+    ActionSheet(
+        visible = addOpen,
+        onDismiss = { addOpen = false },
+        groups = listOf(
+            ActionSheetGroup(
+                title = "再开一台主机",
+                items = addable.map { host ->
+                    ActionSheetItem(
+                        label = host.name,
+                        subtitle = host.displayAddress,
+                        onClick = {
+                            addOpen = false
+                            tabs = tabs.open(host.id)
+                        },
+                    )
+                },
+            ),
+            ActionSheetGroup(
+                items = listOf(
+                    ActionSheetItem(
+                        label = "取消",
+                        cancel = true,
+                        onClick = { addOpen = false },
+                    ),
+                ),
+            ),
+        ),
+    )
+}
+
+@Composable
+private fun SftpHostPicker(
+    hosts: List<one.zephyr.mobile.model.Connection>,
+    onPick: (one.zephyr.mobile.model.Connection) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 140.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                "先选一台主机。打开后会自动连接，不必先去首页连上。点加号可以再开一台，从 A 复制到 B。",
+                color = ZephyrTheme.palette.onFloatingSubtle,
+                fontSize = 13.sp,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
+        items(hosts, key = { it.id }) { host ->
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(ZephyrTheme.palette.surfaces.content)
+                    .clickable { onPick(host) }
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+            ) {
+                Text(host.name, fontWeight = FontWeight.SemiBold)
+                Text(host.displayAddress, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 12.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SftpHostRail(
+    hosts: List<one.zephyr.mobile.model.Connection>,
+    focusedId: String?,
+    canAdd: Boolean,
+    onFocus: (String) -> Unit,
+    onClose: (String) -> Unit,
+    onAdd: () -> Unit,
+) {
+    val palette = ZephyrTheme.palette
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(palette.surfaces.content)
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        hosts.forEach { host ->
+            val on = host.id == focusedId
+            Row(
+                modifier = Modifier
+                    .height(34.dp)
+                    .padding(end = 8.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(if (on) palette.brand.accent.copy(alpha = 0.22f) else palette.surfaces.elevated)
+                    .clickable { onFocus(host.id) }
+                    .padding(start = 10.dp, end = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    Modifier
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(if (on) palette.status.success else palette.onFloatingSubtle),
+                )
+                Spacer(Modifier.width(7.dp))
+                Text(
+                    host.name,
+                    color = if (on) palette.onFloating else palette.onFloatingMuted,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 12.sp,
+                    fontWeight = if (on) FontWeight.SemiBold else FontWeight.Medium,
+                    maxLines = 1,
+                )
+                Text(
+                    "×",
+                    color = palette.onFloatingSubtle,
+                    fontSize = 14.sp,
+                    modifier = Modifier
+                        .padding(start = 6.dp)
+                        .clickable { onClose(host.id) },
+                )
+            }
+        }
+        if (canAdd) {
+            Box(
+                modifier = Modifier
+                    .size(34.dp)
+                    .clip(CircleShape)
+                    .background(palette.surfaces.elevated)
+                    .clickable(onClick = onAdd),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(ZephyrIcons.Plus, "再开一台", tint = palette.onFloatingMuted, modifier = Modifier.size(14.dp))
+            }
         }
     }
 }

--- a/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpCapabilitiesParityTest.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpCapabilitiesParityTest.kt
@@ -1,0 +1,37 @@
+package one.zephyr.mobile.feature.notes
+
+import one.zephyr.mobile.contracts.Capability
+import one.zephyr.mobile.model.CapabilitySet
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SftpCapabilitiesParityTest {
+
+    @Test
+    fun desktopWriteActionsStayBehindFileWrite() {
+        val write = setOf(
+            SftpAction.UPLOAD, SftpAction.CREATE, SftpAction.EDIT, SftpAction.RENAME,
+            SftpAction.DELETE, SftpAction.CHMOD, SftpAction.COMPRESS, SftpAction.EXTRACT, SftpAction.PASTE,
+        )
+        write.forEach { action ->
+            assertEquals(action.name, Capability.FILE_WRITE, SftpCapabilities.required(action))
+        }
+        val read = setOf(
+            SftpAction.LIST, SftpAction.STAT, SftpAction.READ, SftpAction.DOWNLOAD,
+            SftpAction.COPY, SftpAction.PROPERTIES,
+        )
+        read.forEach { action ->
+            assertEquals(action.name, Capability.FILE_READ, SftpCapabilities.required(action))
+        }
+        assertEquals(write.size + read.size, SftpAction.entries.size)
+    }
+
+    @Test
+    fun writeActionsStayVisibleWhenTheGrantIsReadOnly() {
+        val readOnly = CapabilitySet(setOf(Capability.FILE_READ))
+        assertTrue(SftpCapabilities.gate(readOnly, SftpAction.DELETE).isVisible)
+        assertTrue(!SftpCapabilities.gate(readOnly, SftpAction.DELETE).isAllowed)
+        assertTrue(SftpCapabilities.gate(readOnly, SftpAction.LIST).isAllowed)
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpEditorSupportTest.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpEditorSupportTest.kt
@@ -1,0 +1,59 @@
+package one.zephyr.mobile.feature.notes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SftpEditorSupportTest {
+
+    @Test
+    fun languageAndOutlineComeFromThePathAndText() {
+        assertEquals("Kotlin", SftpEditorSupport.languageOf("/src/Main.kt"))
+        val items = SftpEditorSupport.outline(
+            """
+            class Host {
+              fun start() {}
+              private fun stop() {}
+            }
+            """.trimIndent(),
+            "Host.kt",
+        )
+        assertTrue(items.any { it.name == "Host" })
+        assertTrue(items.any { it.name == "start" })
+    }
+
+    @Test
+    fun findIsCaseInsensitiveAndBounded() {
+        val hits = SftpEditorSupport.findInText("Alpha\nalpha\nBETA", "alp")
+        assertEquals(2, hits.size)
+        assertEquals(1, hits.first().line)
+    }
+
+    @Test
+    fun formatIndentsBracesWithoutInventingCode() {
+        val formatted = SftpEditorSupport.formatDocument("fun x(){\nval a=1\n}", tabSize = 4)
+        assertEquals("fun x(){\n    val a=1\n}", formatted)
+    }
+
+    @Test
+    fun workspaceHitsParseJsonObjects() {
+        val raw = """{"hits":[{"path":"/var/a.conf","line":12,"text":"worker_processes auto;"},{"path":"/var/b.conf","line":3,"text":"listen 80;"}],"filesScanned":4}"""
+        val (hits, scanned) = SftpEditorSupport.parseWorkspaceHits(raw)
+        assertEquals(4, scanned)
+        assertEquals(2, hits.size)
+        assertEquals("/var/a.conf", hits[0].path)
+        assertEquals(12, hits[0].line)
+    }
+
+    @Test
+    fun bundleCommandRefusesEmptyAndQuotesPaths() {
+        val command = SftpTransferOps.bundleCommand(listOf("/var/log", "/etc/nginx"), "/tmp/a.tar.gz")
+        assertTrue(command.startsWith("tar -czf '/tmp/a.tar.gz'"))
+        assertTrue(command.contains("'/var/log'"))
+        try {
+            SftpTransferOps.bundleCommand(emptyList(), "/tmp/a.tar.gz")
+            throw AssertionError("empty bundle accepted")
+        } catch (_: IllegalArgumentException) {
+        }
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpHostTabsTest.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpHostTabsTest.kt
@@ -1,0 +1,38 @@
+package one.zephyr.mobile.feature.notes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SftpHostTabsTest {
+
+    @Test
+    fun firstPickOpensAndFocuses() {
+        val tabs = SftpHostTabs().open("a")
+        assertEquals(listOf("a"), tabs.openIds)
+        assertEquals("a", tabs.focusedId)
+    }
+
+    @Test
+    fun plusAddsAnotherWithoutDroppingTheFirst() {
+        val tabs = SftpHostTabs().open("a").open("b")
+        assertEquals(listOf("a", "b"), tabs.openIds)
+        assertEquals("b", tabs.focusedId)
+        assertEquals(listOf("a", "b"), tabs.focus("a").openIds)
+        assertEquals("a", tabs.focus("a").focusedId)
+    }
+
+    @Test
+    fun openingTheSameHostJustFocuses() {
+        val tabs = SftpHostTabs().open("a").open("b").open("a")
+        assertEquals(listOf("a", "b"), tabs.openIds)
+        assertEquals("a", tabs.focusedId)
+    }
+
+    @Test
+    fun closeLastReturnsToThePicker() {
+        val closed = SftpHostTabs().open("a").open("b").close("b").close("a")
+        assertTrue(closed.isEmpty)
+        assertEquals(null, closed.focusedId)
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicyTest.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicyTest.kt
@@ -33,6 +33,8 @@ class SftpOpenPolicyTest {
         assertTrue(text!!.contains("拒绝作为文本打开"))
         val image = SftpOpenPolicy.rejectReason(SftpOpenKind.IMAGE, SftpOpenPolicy.IMAGE_PREVIEW_LIMIT + 1)
         assertTrue(image!!.contains("请下载后查看"))
+        assertEquals(null, SftpOpenPolicy.rejectReason(SftpOpenKind.MEDIA, SftpOpenPolicy.MEDIA_PREVIEW_LIMIT))
+        assertTrue(SftpOpenPolicy.rejectReason(SftpOpenKind.MEDIA, SftpOpenPolicy.MEDIA_CACHE_LIMIT + 1)!!.contains("请下载后播放"))
     }
 
     @Test
@@ -41,6 +43,7 @@ class SftpOpenPolicyTest {
             mode = SftpClipboardMode.COPY,
             paths = listOf("/src/notes.txt", "/src/only.txt"),
             sourceDirectory = "/src",
+            sourceConnectionId = "host-a",
         )
         val existing = setOf("notes.txt")
         val overwrite = SftpClipboardOps.planPaste(clip, "/dst", existing, SftpPasteConflictMode.OVERWRITE)
@@ -54,6 +57,14 @@ class SftpOpenPolicyTest {
         val command = SftpClipboardOps.commandFor(compatible, cut = false)!!
         assertTrue(command.contains("cp -a -- '/src/notes.txt' '/dst/notes-复制.txt'"))
         assertTrue(command.startsWith("mkdir -p '/dst'"))
+    }
+
+    @Test
+    fun clipboardKnowsWhetherPasteIsSameHost() {
+        val clip = SftpClipboard(SftpClipboardMode.COPY, listOf("/a"), "/src", sourceConnectionId = "alpha")
+        assertTrue(clip.sameHostAs("alpha"))
+        assertTrue(!clip.sameHostAs("beta"))
+        assertTrue(SftpClipboard(SftpClipboardMode.COPY, listOf("/a"), "/src").sameHostAs("beta"))
     }
 
     @Test

--- a/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicyTest.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicyTest.kt
@@ -1,0 +1,67 @@
+package one.zephyr.mobile.feature.notes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SftpOpenPolicyTest {
+
+    private fun entry(name: String, directory: Boolean = false, size: Long = 10L) = RemoteEntry(
+        name = name,
+        path = "/var/$name",
+        isDirectory = directory,
+        sizeBytes = size,
+        mtimeMs = 1_700_000_000_000,
+    )
+
+    @Test
+    fun tapRoutesMatchDesktopPreviewTables() {
+        assertEquals(SftpOpenKind.DIRECTORY, SftpOpenPolicy.kindOf(entry("etc", directory = true)))
+        assertEquals(SftpOpenKind.IMAGE, SftpOpenPolicy.kindOf(entry("logo.PNG")))
+        assertEquals(SftpOpenKind.MEDIA, SftpOpenPolicy.kindOf(entry("clip.mkv")))
+        assertEquals(SftpOpenKind.MEDIA, SftpOpenPolicy.kindOf(entry("song.flac")))
+        assertEquals(SftpOpenKind.ARCHIVE, SftpOpenPolicy.kindOf(entry("backup.tar.gz")))
+        assertEquals(SftpOpenKind.TEXT, SftpOpenPolicy.kindOf(entry("nginx.conf")))
+        assertEquals(SftpOpenKind.BINARY, SftpOpenPolicy.kindOf(entry("payload.bin")))
+    }
+
+    @Test
+    fun oversizedPreviewIsRejectedWithAReadableLimit() {
+        assertNull(SftpOpenPolicy.rejectReason(SftpOpenKind.TEXT, 1024))
+        val text = SftpOpenPolicy.rejectReason(SftpOpenKind.TEXT, SftpOpenPolicy.TEXT_EDIT_LIMIT + 1)
+        assertTrue(text!!.contains("拒绝作为文本打开"))
+        val image = SftpOpenPolicy.rejectReason(SftpOpenKind.IMAGE, SftpOpenPolicy.IMAGE_PREVIEW_LIMIT + 1)
+        assertTrue(image!!.contains("请下载后查看"))
+    }
+
+    @Test
+    fun pastePlansCoverOverwriteSkipAndCompatible() {
+        val clip = SftpClipboard(
+            mode = SftpClipboardMode.COPY,
+            paths = listOf("/src/notes.txt", "/src/only.txt"),
+            sourceDirectory = "/src",
+        )
+        val existing = setOf("notes.txt")
+        val overwrite = SftpClipboardOps.planPaste(clip, "/dst", existing, SftpPasteConflictMode.OVERWRITE)
+        assertEquals(listOf("/dst/notes.txt"), overwrite.overwrites)
+        assertEquals(2, overwrite.copies.size)
+        val skip = SftpClipboardOps.planPaste(clip, "/dst", existing, SftpPasteConflictMode.SKIP)
+        assertEquals(listOf("/src/notes.txt"), skip.skipped)
+        assertEquals(listOf("/src/only.txt" to "/dst/only.txt"), skip.copies)
+        val compatible = SftpClipboardOps.planPaste(clip, "/dst", existing, SftpPasteConflictMode.COMPATIBLE)
+        assertTrue(compatible.copies.any { it.second.endsWith("notes-复制.txt") })
+        val command = SftpClipboardOps.commandFor(compatible, cut = false)!!
+        assertTrue(command.contains("cp -a -- '/src/notes.txt' '/dst/notes-复制.txt'"))
+        assertTrue(command.startsWith("mkdir -p '/dst'"))
+    }
+
+    @Test
+    fun cutOverwriteDeletesTheTargetFirst() {
+        val clip = SftpClipboard(SftpClipboardMode.CUT, listOf("/src/a"), "/src")
+        val plan = SftpClipboardOps.planPaste(clip, "/dst", setOf("a"), SftpPasteConflictMode.OVERWRITE)
+        val command = SftpClipboardOps.commandFor(plan, cut = true)!!
+        assertTrue(command.contains("rm -rf -- '/dst/a'"))
+        assertTrue(command.contains("mv -- '/src/a' '/dst/a'"))
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/build.gradle.kts
+++ b/zephyr_one/mobile/android/feature-sessions/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(project(":protocol-ssh"))
     implementation(project(":protocol-telnet"))
     implementation(project(":feature-notes"))
+    implementation(project(":feature-tools"))
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -89,6 +89,8 @@ class SshTerminalHost(
 
     override suspend fun exec(sessionId: String, command: String) = engine.exec(sessionId, command)
 
+    override fun execStream(sessionId: String, command: String) = engine.execStream(sessionId, command)
+
     override suspend fun trustHostKey(sessionId: String) {
         val remembered = lastRequest[sessionId] ?: return
         engine.acceptHostKey(sessionId, remembered.host, remembered.port)

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt
@@ -429,6 +429,7 @@ internal fun toolIcon(kind: TerminalToolKind): ImageVector = when (kind) {
     TerminalToolKind.SNIPPET -> ZephyrIcons.Bolt
     TerminalToolKind.NOTES -> ZephyrIcons.Notes
     TerminalToolKind.STATS -> ZephyrIcons.Stats
+    TerminalToolKind.DOCKER -> ZephyrIcons.Docker
     TerminalToolKind.THEME -> ZephyrIcons.Theme
 }
 
@@ -438,6 +439,7 @@ internal fun toolTitle(kind: TerminalToolKind, hostName: String): String = when 
     TerminalToolKind.SNIPPET -> "代码片段"
     TerminalToolKind.NOTES -> "笔记 · 关联 $hostName"
     TerminalToolKind.STATS -> "监控 · $hostName"
+    TerminalToolKind.DOCKER -> "Docker · $hostName"
     TerminalToolKind.THEME -> stringResource(R.string.terminal_theme_title)
 }
 

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalHost.kt
@@ -193,6 +193,11 @@ interface TerminalHost {
     suspend fun exec(sessionId: String, command: String): Result<one.zephyr.mobile.protocol.ssh.SshExecResult> =
         Result.failure(IllegalStateException("SSH exec unavailable"))
 
+    fun execStream(
+        sessionId: String,
+        command: String,
+    ): Flow<one.zephyr.mobile.protocol.ssh.SshExecEvent> = emptyFlow()
+
     /** Accepts and remembers a presented host key after the user confirmed it. */
     suspend fun trustHostKey(sessionId: String) = Unit
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
@@ -68,7 +68,8 @@ internal fun TerminalToolBody(
         TerminalToolKind.FILES -> FilesToolBody(colors, viewModel, onMessage)
         TerminalToolKind.SNIPPET -> SnippetToolBody(colors, snippets, onInsert)
         TerminalToolKind.NOTES -> NotesToolBody(colors, notes, onOpenNote)
-        TerminalToolKind.STATS -> StatsToolBody(colors, viewModel, onOpenDocker)
+        TerminalToolKind.STATS -> StatsToolBody(viewModel, onOpenDocker, onMessage)
+        TerminalToolKind.DOCKER -> DockerToolBody(viewModel, onMessage)
         TerminalToolKind.THEME -> ThemeToolBody(colors, workspace, onWorkspace, onMessage)
     }
 }
@@ -179,53 +180,39 @@ private fun NotesToolBody(
 
 @Composable
 private fun StatsToolBody(
-    colors: TerminalChromeColors,
     viewModel: TerminalViewModel?,
     onOpenDocker: () -> Unit,
+    onMessage: (String) -> Unit,
 ) {
-    val dockerLabel = stringResource(R.string.terminal_open_docker)
-    var loading by remember { mutableStateOf(true) }
-    var metrics by remember { mutableStateOf<RemoteMetrics?>(null) }
-    var error by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(viewModel) {
-        if (viewModel == null) {
-            loading = false
-            error = "当前没有已连接的 SSH 会话"
-            return@LaunchedEffect
-        }
-        viewModel.remoteMetrics().fold(
-            onSuccess = { metrics = it; error = null },
-            onFailure = { error = it.message ?: "读取远端监控失败" },
-        )
-        loading = false
-    }
-    Column {
-        when {
-            loading -> EmptyToolBody(colors, "正在读取远端监控…")
-            error != null -> EmptyToolBody(colors, error ?: "监控失败")
-            metrics != null -> {
-                val value = metrics ?: return@Column
-                Meter(colors, "CPU", "${value.cpuPercent}%", value.cpuPercent / 100f)
-                Meter(colors, "内存", "${value.memoryPercent}%", value.memoryPercent / 100f)
-                Meter(colors, "磁盘 /", "${value.diskPercent}%", value.diskPercent / 100f, warn = value.diskPercent >= 80)
-            }
-        }
-        Text(
-            text = "DOCKER · $dockerLabel",
-            color = colors.accent,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 0.8.sp,
-            modifier = Modifier
-                .padding(horizontal = 8.dp, vertical = 8.dp)
-                .then(Modifier),
-        )
-        TermPressable(onClick = onOpenDocker, modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp), scale = 0.99f) {
-            Text(dockerLabel, color = colors.accent, fontSize = 12.sp)
-        }
-        Spacer(Modifier.height(6.dp))
-    }
+    one.zephyr.mobile.feature.tools.HostMonitorPanel(
+        shell = viewModel?.asRemoteShell(),
+        modifier = Modifier.fillMaxSize(),
+        onOpenDocker = onOpenDocker,
+        onMessage = onMessage,
+    )
 }
+
+@Composable
+private fun DockerToolBody(
+    viewModel: TerminalViewModel?,
+    onMessage: (String) -> Unit,
+) {
+    one.zephyr.mobile.feature.tools.HostDockerPanel(
+        shell = viewModel?.asRemoteShell(),
+        modifier = Modifier.fillMaxSize(),
+        onMessage = onMessage,
+    )
+}
+
+private fun TerminalViewModel.asRemoteShell(): one.zephyr.mobile.feature.tools.RemoteShell =
+    one.zephyr.mobile.feature.tools.RemoteShell { command ->
+        val result = executeRemote(command).getOrThrow()
+        one.zephyr.mobile.feature.tools.RemoteShellResult(
+            exitCode = result.exitCode,
+            stdout = result.stdout.toString(Charsets.UTF_8),
+            stderr = result.stderr.toString(Charsets.UTF_8),
+        )
+    }
 
 @Composable
 private fun ThemeToolBody(
@@ -418,6 +405,7 @@ internal fun SideToolDock(
     onOpenDocker: () -> Unit,
     onMessage: (String) -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: TerminalViewModel? = null,
 ) {
     Column(
         modifier
@@ -463,7 +451,10 @@ internal fun SideToolDock(
             }
         }
         Box(Modifier.fillMaxWidth().height(1.dp).background(colors.line))
-        Box(Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(6.dp)) {
+        Box(Modifier.weight(1f).then(
+            if (workspace.dockCurrent == TerminalToolKind.STATS || workspace.dockCurrent == TerminalToolKind.DOCKER) Modifier
+            else Modifier.verticalScroll(rememberScrollState()),
+        ).padding(6.dp)) {
             val current = workspace.dockCurrent
             if (current == null) {
                 Text(
@@ -482,8 +473,11 @@ internal fun SideToolDock(
                     onWorkspace = onWorkspace,
                     onInsert = onInsert,
                     onOpenNote = onOpenNote,
-                    onOpenDocker = onOpenDocker,
+                    onOpenDocker = {
+                        onWorkspace(TerminalWorkspace.openTool(workspace, TerminalToolKind.DOCKER, phone = false))
+                    },
                     onMessage = onMessage,
+                    viewModel = viewModel,
                 )
             }
         }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
@@ -205,13 +205,28 @@ private fun DockerToolBody(
 }
 
 private fun TerminalViewModel.asRemoteShell(): one.zephyr.mobile.feature.tools.RemoteShell =
-    one.zephyr.mobile.feature.tools.RemoteShell { command ->
-        val result = executeRemote(command).getOrThrow()
-        one.zephyr.mobile.feature.tools.RemoteShellResult(
-            exitCode = result.exitCode,
-            stdout = result.stdout.toString(Charsets.UTF_8),
-            stderr = result.stderr.toString(Charsets.UTF_8),
-        )
+    object : one.zephyr.mobile.feature.tools.RemoteShell {
+        override suspend fun run(command: String): one.zephyr.mobile.feature.tools.RemoteShellResult {
+            val result = executeRemote(command).getOrThrow()
+            return one.zephyr.mobile.feature.tools.RemoteShellResult(
+                exitCode = result.exitCode,
+                stdout = result.stdout.toString(Charsets.UTF_8),
+                stderr = result.stderr.toString(Charsets.UTF_8),
+            )
+        }
+
+        override fun stream(command: String) = kotlinx.coroutines.flow.flow {
+            executeRemoteStream(command).collect { event ->
+                when (event) {
+                    is one.zephyr.mobile.protocol.ssh.SshExecEvent.Stdout ->
+                        emit(one.zephyr.mobile.feature.tools.RemoteShellChunk.Output(event.bytes.toString(Charsets.UTF_8)))
+                    is one.zephyr.mobile.protocol.ssh.SshExecEvent.Stderr ->
+                        emit(one.zephyr.mobile.feature.tools.RemoteShellChunk.Output(event.bytes.toString(Charsets.UTF_8)))
+                    is one.zephyr.mobile.protocol.ssh.SshExecEvent.Closed ->
+                        emit(one.zephyr.mobile.feature.tools.RemoteShellChunk.Closed(event.exitCode))
+                }
+            }
+        }
     }
 
 @Composable

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -342,8 +342,8 @@ private fun DemoTerminalSurface(
                         },
                     )
                 }
-                if (!pad && ws.sheetFraction > 0f && ws.sheetCurrent != null &&
-                    (!imeOpen || ws.sheetCurrent?.keepsIme == true)
+                if (!pad && ws.sheetCurrent != null &&
+                    (!imeOpen || ws.sheetCurrent?.keepsIme == true || ws.sheetFraction == 0f)
                 ) {
                     TerminalToolSheet(
                         workspace = ws,

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -307,7 +307,9 @@ private fun DemoTerminalSurface(
                         onIntent = onIntent,
                         onInsert = { text -> onIntent(TerminalIntent.Commit(text)); onMessage(insertToastMsg) },
                         onOpenNote = onOpenNote,
-                        onOpenDocker = onOpenDocker,
+                        onOpenDocker = {
+                            onWorkspace(TerminalWorkspace.openTool(ws, TerminalToolKind.DOCKER, phone = !pad))
+                        },
                         onMessage = onMessage,
                         onFocusPane = { pane -> onWorkspace(ws.withFocus(pane)) },
                     )
@@ -341,7 +343,7 @@ private fun DemoTerminalSurface(
                     )
                 }
                 if (!pad && ws.sheetFraction > 0f && ws.sheetCurrent != null &&
-                    (!imeOpen || ws.sheetCurrent == TerminalToolKind.FILES)
+                    (!imeOpen || ws.sheetCurrent?.keepsIme == true)
                 ) {
                     TerminalToolSheet(
                         workspace = ws,
@@ -355,7 +357,9 @@ private fun DemoTerminalSurface(
                         onWorkspace = onWorkspace,
                         onInsert = { text -> onIntent(TerminalIntent.Commit(text)); onMessage(insertToastMsg) },
                         onOpenNote = onOpenNote,
-                        onOpenDocker = onOpenDocker,
+                        onOpenDocker = {
+                            onWorkspace(TerminalWorkspace.openTool(ws, TerminalToolKind.DOCKER, phone = true))
+                        },
                         onMessage = onMessage,
                     )
                 }
@@ -481,6 +485,7 @@ private fun TerminalSplitArea(
                 onOpenNote = onOpenNote,
                 onOpenDocker = onOpenDocker,
                 onMessage = onMessage,
+                viewModel = focusedVm,
                 modifier = Modifier
                     .fillMaxHeight()
                     .fillMaxWidth(workspace.dockWidthFraction),
@@ -547,6 +552,7 @@ private fun TerminalSplitArea(
                 onOpenNote = onOpenNote,
                 onOpenDocker = onOpenDocker,
                 onMessage = onMessage,
+                viewModel = focusedVm,
                 modifier = Modifier
                     .fillMaxHeight()
                     .fillMaxWidth(workspace.dockWidthFraction),

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
@@ -1,6 +1,7 @@
 package one.zephyr.mobile.feature.sessions
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -66,15 +67,28 @@ internal fun TerminalToolSheet(
     var liveFraction by remember { mutableFloatStateOf(workspace.sheetFraction) }
     var velocityPxPerMs by remember { mutableFloatStateOf(0f) }
     var lastMoveAtNanos by remember { mutableStateOf(0L) }
+    // First frame targets 0 so open animates 0 → detent instead of appearing at height.
+    var ready by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { ready = true }
 
     LaunchedEffect(workspace.sheetFraction, dragging) {
         if (!dragging) liveFraction = workspace.sheetFraction
     }
+    val desiredFraction = if (dragging) liveFraction else workspace.sheetFraction
     val animatedFraction by animateFloatAsState(
-        targetValue = if (dragging) liveFraction else workspace.sheetFraction,
-        animationSpec = tween(260, easing = ZephyrMotionTokens.easeDrawer),
+        targetValue = if (ready || dragging) desiredFraction else 0f,
+        animationSpec = if (dragging) {
+            snap()
+        } else {
+            tween(ZephyrMotionTokens.SHEET_MS, easing = ZephyrMotionTokens.easeDrawer)
+        },
         label = "terminalToolSheetHeight",
     )
+    LaunchedEffect(animatedFraction, dragging, workspace.sheetFraction, workspace.sheetCurrent) {
+        if (!dragging && workspace.sheetFraction == 0f && animatedFraction == 0f && workspace.sheetCurrent != null) {
+            onWorkspace(TerminalWorkspace.finishClose(workspace))
+        }
+    }
 
     BoxWithConstraints(Modifier.fillMaxWidth()) {
         val hostHeightPx = with(density) { maxHeight.toPx() }.coerceAtLeast(1f)
@@ -82,8 +96,9 @@ internal fun TerminalToolSheet(
             Modifier
                 .fillMaxWidth()
                 .height(maxHeight * animatedFraction)
+                .clip(RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp))
                 .background(colors.chrome)
-                .border(width = 1.dp, color = colors.line),
+                .border(width = 1.dp, color = colors.line, shape = RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)),
         ) {
             Box(
                 Modifier

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
@@ -182,6 +182,24 @@ internal fun TerminalToolSheet(
                     modifier = Modifier.weight(1f).fillMaxWidth(),
                     onMessage = onMessage,
                 )
+            } else if (current == TerminalToolKind.STATS || current == TerminalToolKind.DOCKER) {
+                Box(Modifier.weight(1f).fillMaxWidth()) {
+                    TerminalToolBody(
+                        kind = current,
+                        colors = colors,
+                        notes = notes,
+                        snippets = snippets,
+                        workspace = workspace,
+                        onWorkspace = onWorkspace,
+                        onInsert = onInsert,
+                        onOpenNote = onOpenNote,
+                        onOpenDocker = {
+                            onWorkspace(TerminalWorkspace.openTool(workspace, TerminalToolKind.DOCKER, phone = true))
+                        },
+                        onMessage = onMessage,
+                        viewModel = viewModel,
+                    )
+                }
             } else {
                 Box(
                     Modifier

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -532,6 +532,8 @@ class TerminalViewModel(
 
     suspend fun executeRemote(command: String) = host.exec(sessionId, command)
 
+    fun executeRemoteStream(command: String) = host.execStream(sessionId, command)
+
     suspend fun remoteMetrics(): Result<RemoteMetrics> = host.exec(
         sessionId,
         one.zephyr.mobile.protocol.ssh.SshRemoteOps.statsCommand,

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -534,12 +534,15 @@ class TerminalViewModel(
 
     suspend fun remoteMetrics(): Result<RemoteMetrics> = host.exec(
         sessionId,
-        "LC_ALL=C head -n 1 /proc/stat; " +
-            "LC_ALL=C awk '/MemTotal:/{t=\$2}/MemAvailable:/{a=\$2}END{print t,a}' /proc/meminfo; " +
-            "LC_ALL=C df -Pk / | awk 'NR==2{gsub(/%/,\"\",\$5);print \$5}'",
+        one.zephyr.mobile.protocol.ssh.SshRemoteOps.statsCommand,
     ).mapCatching { result ->
-        if (result.exitCode != 0) error(result.stderr.toString(Charsets.UTF_8).ifBlank { "读取远端指标失败" })
-        parseRemoteMetrics(result.stdout.toString(Charsets.UTF_8))
+        if (result.exitCode != 0 && result.stdout.isEmpty()) {
+            error(result.stderr.toString(Charsets.UTF_8).ifBlank { "读取远端指标失败" })
+        }
+        val snapshot = one.zephyr.mobile.protocol.ssh.SshRemoteOps.parseRemoteStats(
+            result.stdout.toString(Charsets.UTF_8),
+        )
+        parseRemoteMetrics(snapshot)
     }
 
     fun onDock(item: TerminalDockItem) {
@@ -625,19 +628,14 @@ class TerminalViewModel(
 
 data class RemoteMetrics(val cpuPercent: Int, val memoryPercent: Int, val diskPercent: Int)
 
-internal fun parseRemoteMetrics(text: String): RemoteMetrics {
-    val lines = text.lineSequence().map(String::trim).filter(String::isNotBlank).toList()
-    require(lines.size >= 3) { "远端指标响应不完整" }
-    val cpu = lines[0].split(Regex("\\s+")).mapNotNull(String::toLongOrNull)
-    require(cpu.size >= 4) { "远端 CPU 数据无效" }
-    val total = cpu.sum().coerceAtLeast(1L)
-    val idle = cpu.getOrElse(3) { 0L } + cpu.getOrElse(4) { 0L }
-    val memory = lines[1].split(Regex("\\s+")).mapNotNull(String::toLongOrNull)
-    require(memory.size >= 2 && memory[0] > 0) { "远端内存数据无效" }
-    val disk = lines[2].toIntOrNull() ?: error("远端磁盘数据无效")
+internal fun parseRemoteMetrics(text: String): RemoteMetrics =
+    parseRemoteMetrics(one.zephyr.mobile.protocol.ssh.SshRemoteOps.parseRemoteStats(text))
+
+internal fun parseRemoteMetrics(snapshot: one.zephyr.mobile.protocol.ssh.HostStatsSnapshot): RemoteMetrics {
+    val disk = snapshot.disks.maxByOrNull { it.percent }?.percent ?: 0
     return RemoteMetrics(
-        cpuPercent = (((total - idle) * 100L) / total).toInt().coerceIn(0, 100),
-        memoryPercent = (((memory[0] - memory[1]) * 100L) / memory[0]).toInt().coerceIn(0, 100),
+        cpuPercent = snapshot.cpu.usagePercent.toInt().coerceIn(0, 100),
+        memoryPercent = snapshot.memory.memPercent.toInt().coerceIn(0, 100),
         diskPercent = disk.coerceIn(0, 100),
     )
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
@@ -22,8 +22,14 @@ enum class TerminalToolKind {
     SNIPPET,
     NOTES,
     STATS,
+    DOCKER,
     THEME,
     ;
+
+    /** Drawers that embed a text field must stay composed while the system IME is open. */
+    val keepsIme: Boolean
+        get() = this == FILES || this == STATS || this == DOCKER
+}
 
     companion object {
         fun fromDock(item: TerminalDockItem): TerminalToolKind? = when (item) {

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
@@ -29,7 +29,6 @@ enum class TerminalToolKind {
     /** Drawers that embed a text field must stay composed while the system IME is open. */
     val keepsIme: Boolean
         get() = this == FILES || this == STATS || this == DOCKER
-}
 
     companion object {
         fun fromDock(item: TerminalDockItem): TerminalToolKind? = when (item) {
@@ -219,7 +218,16 @@ object TerminalWorkspace {
     }
 
     fun closeSheet(state: TerminalWorkspaceState): TerminalWorkspaceState =
-        state.copy(sheetTools = emptyList(), sheetCurrent = null, sheetFraction = 0f)
+        state.copy(sheetFraction = 0f)
+
+    /**
+     * Drops the last tab after the close height animation has reached 0.
+     * Called only from the sheet, never from a dock tap — otherwise the node
+     * disappears before [animateFloatAsState] can run.
+     */
+    fun finishClose(state: TerminalWorkspaceState): TerminalWorkspaceState =
+        if (state.sheetFraction > 0f) state
+        else state.copy(sheetTools = emptyList(), sheetCurrent = null, sheetFraction = 0f)
 
     fun setSheetFraction(state: TerminalWorkspaceState, fraction: Float): TerminalWorkspaceState =
         state.copy(sheetFraction = fraction.coerceIn(0f, SHEET_MAX_FRACTION))

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/RemoteMetricsTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/RemoteMetricsTest.kt
@@ -8,64 +8,44 @@ import org.junit.Test
 class RemoteMetricsTest {
     @Test
     fun parsesDesktopStatsSnapshot() {
-        val raw = listOf(
-            "cpu  100 20 30 850 0 0 0 0 0 0",
-            SshRemoteOps.MARKER_CPU,
-            "MemTotal:        1000000 kB",
-            "MemAvailable:     420000 kB",
-            "SwapTotal: 0 kB",
-            "SwapFree: 0 kB",
-            SshRemoteOps.MARKER_MEM,
-            "Filesystem     1024-blocks     Used Available Capacity Mounted on",
-            "/dev/sda1        1048576 860032 188544      82% /",
-            SshRemoteOps.MARKER_DISK,
-            "",
-            SshRemoteOps.MARKER_DISKSTATS,
-            "",
-            SshRemoteOps.MARKER_NET,
-            "",
-            SshRemoteOps.MARKER_IP4,
-            "",
-            SshRemoteOps.MARKER_IP6,
-            "processor : 0",
-            SshRemoteOps.MARKER_CPUINFO,
-            "Linux",
-            SshRemoteOps.MARKER_UNAME,
-            "",
-            SshRemoteOps.MARKER_PROC,
-            "host",
-        ).joinToString("\n")
-        val value = parseRemoteMetrics(raw)
+        val snapshot = SshRemoteOps.parseRemoteStats(
+            buildStatsRaw(
+                cpu = "cpu  100 20 30 850 0 0 0 0 0 0",
+                mem = "MemTotal:        1000000 kB\nMemAvailable:     420000 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB",
+                disk = "Filesystem     1024-blocks     Used Available Capacity Mounted on\n/dev/sda1        1048576 860032 188544      82% /",
+                diskstats = "",
+                net = "",
+                ip4 = "",
+                ip6 = "",
+                cpuinfo = "processor : 0",
+                uname = "Linux",
+                processes = "",
+                hostname = "host",
+            ),
+        )
+        val value = parseRemoteMetrics(snapshot)
         assertEquals(0, value.cpuPercent)
-        assertEquals(58, value.memoryPercent)
+        assertEquals(snapshot.memory.memPercent.toInt(), value.memoryPercent)
         assertEquals(82, value.diskPercent)
+        assertTrue(snapshot.memory.memTotalMb > 900.0)
+        assertTrue(value.memoryPercent in 50..70)
     }
 
     @Test
     fun secondSampleProducesCpuUsage() {
-        fun raw(cpu: String) = listOf(
-            cpu,
-            SshRemoteOps.MARKER_CPU,
-            "MemTotal: 1000 kB\nMemAvailable: 400 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB",
-            SshRemoteOps.MARKER_MEM,
-            "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1024 512 512 50% /",
-            SshRemoteOps.MARKER_DISK,
-            "",
-            SshRemoteOps.MARKER_DISKSTATS,
-            "",
-            SshRemoteOps.MARKER_NET,
-            "",
-            SshRemoteOps.MARKER_IP4,
-            "",
-            SshRemoteOps.MARKER_IP6,
-            "processor : 0",
-            SshRemoteOps.MARKER_CPUINFO,
-            "Linux",
-            SshRemoteOps.MARKER_UNAME,
-            "",
-            SshRemoteOps.MARKER_PROC,
-            "host",
-        ).joinToString("\n")
+        fun raw(cpu: String) = buildStatsRaw(
+            cpu = cpu,
+            mem = "MemTotal: 1000 kB\nMemAvailable: 400 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB",
+            disk = "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1024 512 512 50% /",
+            diskstats = "",
+            net = "",
+            ip4 = "",
+            ip6 = "",
+            cpuinfo = "processor : 0",
+            uname = "Linux",
+            processes = "",
+            hostname = "host",
+        )
         val first = SshRemoteOps.parseRemoteStats(raw("cpu  100 0 0 100 0 0 0 0 0 0"), previous = null, nowMs = 1_000L)
         val second = SshRemoteOps.parseRemoteStats(raw("cpu  180 0 0 120 0 0 0 0 0 0"), previous = first.sample, nowMs = 2_000L)
         val metrics = parseRemoteMetrics(second)
@@ -80,4 +60,30 @@ class RemoteMetricsTest {
         assertEquals(0, value.memoryPercent)
         assertEquals(0, value.diskPercent)
     }
+
+    private fun buildStatsRaw(
+        cpu: String,
+        mem: String,
+        disk: String,
+        diskstats: String,
+        net: String,
+        ip4: String,
+        ip6: String,
+        cpuinfo: String,
+        uname: String,
+        processes: String,
+        hostname: String,
+    ): String = listOf(
+        cpu, SshRemoteOps.MARKER_CPU,
+        mem, SshRemoteOps.MARKER_MEM,
+        disk, SshRemoteOps.MARKER_DISK,
+        diskstats, SshRemoteOps.MARKER_DISKSTATS,
+        net, SshRemoteOps.MARKER_NET,
+        ip4, SshRemoteOps.MARKER_IP4,
+        ip6, SshRemoteOps.MARKER_IP6,
+        cpuinfo, SshRemoteOps.MARKER_CPUINFO,
+        uname, SshRemoteOps.MARKER_UNAME,
+        processes, SshRemoteOps.MARKER_PROC,
+        hostname,
+    ).joinToString("\n")
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/RemoteMetricsTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/RemoteMetricsTest.kt
@@ -1,25 +1,83 @@
 package one.zephyr.mobile.feature.sessions
 
+import one.zephyr.mobile.protocol.ssh.SshRemoteOps
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RemoteMetricsTest {
     @Test
-    fun parsesProcAndDfOutput() {
-        val value = parseRemoteMetrics(
-            """
-            cpu  100 20 30 850 0 0 0 0 0 0
-            1000000 420000
-            82
-            """.trimIndent(),
-        )
-        assertEquals(15, value.cpuPercent)
+    fun parsesDesktopStatsSnapshot() {
+        val raw = listOf(
+            "cpu  100 20 30 850 0 0 0 0 0 0",
+            SshRemoteOps.MARKER_CPU,
+            "MemTotal:        1000000 kB",
+            "MemAvailable:     420000 kB",
+            "SwapTotal: 0 kB",
+            "SwapFree: 0 kB",
+            SshRemoteOps.MARKER_MEM,
+            "Filesystem     1024-blocks     Used Available Capacity Mounted on",
+            "/dev/sda1        1048576 860032 188544      82% /",
+            SshRemoteOps.MARKER_DISK,
+            "",
+            SshRemoteOps.MARKER_DISKSTATS,
+            "",
+            SshRemoteOps.MARKER_NET,
+            "",
+            SshRemoteOps.MARKER_IP4,
+            "",
+            SshRemoteOps.MARKER_IP6,
+            "processor : 0",
+            SshRemoteOps.MARKER_CPUINFO,
+            "Linux",
+            SshRemoteOps.MARKER_UNAME,
+            "",
+            SshRemoteOps.MARKER_PROC,
+            "host",
+        ).joinToString("\n")
+        val value = parseRemoteMetrics(raw)
+        assertEquals(0, value.cpuPercent)
         assertEquals(58, value.memoryPercent)
         assertEquals(82, value.diskPercent)
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun rejectsIncompleteMetricsInsteadOfShowingZeros() {
-        parseRemoteMetrics("cpu 1 2")
+    @Test
+    fun secondSampleProducesCpuUsage() {
+        fun raw(cpu: String) = listOf(
+            cpu,
+            SshRemoteOps.MARKER_CPU,
+            "MemTotal: 1000 kB\nMemAvailable: 400 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB",
+            SshRemoteOps.MARKER_MEM,
+            "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1024 512 512 50% /",
+            SshRemoteOps.MARKER_DISK,
+            "",
+            SshRemoteOps.MARKER_DISKSTATS,
+            "",
+            SshRemoteOps.MARKER_NET,
+            "",
+            SshRemoteOps.MARKER_IP4,
+            "",
+            SshRemoteOps.MARKER_IP6,
+            "processor : 0",
+            SshRemoteOps.MARKER_CPUINFO,
+            "Linux",
+            SshRemoteOps.MARKER_UNAME,
+            "",
+            SshRemoteOps.MARKER_PROC,
+            "host",
+        ).joinToString("\n")
+        val first = SshRemoteOps.parseRemoteStats(raw("cpu  100 0 0 100 0 0 0 0 0 0"), previous = null, nowMs = 1_000L)
+        val second = SshRemoteOps.parseRemoteStats(raw("cpu  180 0 0 120 0 0 0 0 0 0"), previous = first.sample, nowMs = 2_000L)
+        val metrics = parseRemoteMetrics(second)
+        assertTrue(metrics.cpuPercent > 0)
+        assertEquals(50, metrics.diskPercent)
+    }
+
+    @Test
+    fun garbageDoesNotInventABusyHost() {
+        val value = parseRemoteMetrics("not a stats dump")
+        assertEquals(0, value.cpuPercent)
+        assertEquals(0, value.memoryPercent)
+        assertEquals(0, value.diskPercent)
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
@@ -85,6 +85,13 @@ class SshTerminalHostTest {
             bytes: ByteArray,
             expected: SshRemoteFileVersion?,
         ) = Result.failure<SshRemoteFileVersion>(IllegalStateException("unused"))
+        override suspend fun readFileRange(
+            sessionId: String,
+            path: String,
+            offset: Long,
+            maxBytes: Int,
+        ) = Result.failure<SshRemoteFile>(IllegalStateException("unused"))
+        override suspend fun chmod(sessionId: String, path: String, mode: Int) = Result.success(Unit)
         override suspend fun exec(sessionId: String, command: String): Result<SshExecResult> =
             Result.failure(IllegalStateException("unused"))
     }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
@@ -18,9 +18,21 @@ class TerminalToolSheetTest {
     @Test
     fun tappingCurrentToolAgainClosesTheSheet() {
         val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.FILES, phone = true)
-        val closed = TerminalWorkspace.openTool(opened, TerminalToolKind.FILES, phone = true)
-        assertEquals(0f, closed.sheetFraction, 0.001f)
-        assertTrue(closed.sheetTools.isEmpty())
+        val closing = TerminalWorkspace.openTool(opened, TerminalToolKind.FILES, phone = true)
+        assertEquals(0f, closing.sheetFraction, 0.001f)
+        assertEquals(TerminalToolKind.FILES, closing.sheetCurrent)
+        assertEquals(listOf(TerminalToolKind.FILES), closing.sheetTools)
+        val gone = TerminalWorkspace.finishClose(closing)
+        assertTrue(gone.sheetTools.isEmpty())
+        assertEquals(null, gone.sheetCurrent)
+    }
+
+    @Test
+    fun finishCloseDoesNotDropAnOpenSheet() {
+        val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.FILES, phone = true)
+        val same = TerminalWorkspace.finishClose(opened)
+        assertEquals(TerminalToolKind.FILES, same.sheetCurrent)
+        assertEquals(TerminalWorkspace.SHEET_MID_FRACTION, same.sheetFraction, 0.001f)
     }
 
     @Test

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
@@ -48,6 +48,16 @@ class TerminalToolSheetTest {
     }
 
     @Test
+    fun dockerAndMonitorDrawersKeepTheIme() {
+        assertTrue(TerminalToolKind.FILES.keepsIme)
+        assertTrue(TerminalToolKind.STATS.keepsIme)
+        assertTrue(TerminalToolKind.DOCKER.keepsIme)
+        assertTrue(!TerminalToolKind.THEME.keepsIme)
+        val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.DOCKER, phone = true)
+        assertEquals(TerminalToolKind.DOCKER, opened.sheetCurrent)
+    }
+
+    @Test
     fun tabletToolUsesInPageSideDock() {
         val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.NOTES, phone = false)
         assertEquals(TerminalSplitMode.RIGHT, opened.split)

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/BatchExecutionScreen.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/BatchExecutionScreen.kt
@@ -91,7 +91,7 @@ fun BatchExecutionScreen(
                     bottom = 190.dp,
                 ),
             ) {
-                item("targets-label") { DemoSectionLabel("目标（需 execute 能力）", compact = true) }
+                item("targets-label") { DemoSectionLabel("目标（需 execute · 未连接会自动拨号）", compact = true) }
                 item("targets") {
                     GroupCard {
                         content.targets.forEachIndexed { index, target ->

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/BatchRun.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/BatchRun.kt
@@ -134,17 +134,19 @@ class BatchRun(
      * when the port itself failed to honour the deadline.
      */
     private suspend fun attempt(target: BatchTarget, plan: BatchPlan): ExecOutcome {
-        val budgetMs = (plan.timeoutSeconds + WATCHDOG_GRACE_SECONDS) * 1_000L
+        val budgetMs = (plan.timeoutSeconds + CONNECT_BUDGET_SECONDS + WATCHDOG_GRACE_SECONDS) * 1_000L
         return withTimeoutOrNull(budgetMs) {
             exec.exec(
                 connectionId = target.connectionId,
                 command = plan.command,
-                timeoutSeconds = plan.timeoutSeconds,
+                timeoutSeconds = plan.timeoutSeconds + CONNECT_BUDGET_SECONDS,
             )
         } ?: ExecOutcome.TimedOut
     }
 
     private companion object {
         const val WATCHDOG_GRACE_SECONDS = 5
+        /** Extra time so a host that is not already connected can be dialled first. */
+        const val CONNECT_BUDGET_SECONDS = 20
     }
 }

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt
@@ -1,0 +1,807 @@
+package one.zephyr.mobile.feature.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import one.zephyr.mobile.protocol.ssh.DockerContainerAction
+import one.zephyr.mobile.protocol.ssh.DockerContainerInfo
+import one.zephyr.mobile.protocol.ssh.DockerEngineStatus
+import one.zephyr.mobile.protocol.ssh.DockerImageInfo
+import one.zephyr.mobile.protocol.ssh.HostProcessInfo
+import one.zephyr.mobile.protocol.ssh.HostStatsSample
+import one.zephyr.mobile.protocol.ssh.HostStatsSnapshot
+import one.zephyr.mobile.protocol.ssh.ProcessSignal
+import one.zephyr.mobile.protocol.ssh.SshRemoteOps
+import one.zephyr.mobile.ui.component.AlertDialog
+import one.zephyr.mobile.ui.component.AssistChip
+import one.zephyr.mobile.ui.component.FilterChip
+import one.zephyr.mobile.ui.component.LinearProgress
+import one.zephyr.mobile.ui.component.OutlinedTextField
+import one.zephyr.mobile.ui.component.PrimaryButton
+import one.zephyr.mobile.ui.component.Text
+import one.zephyr.mobile.ui.component.TextButton
+import one.zephyr.mobile.ui.theme.ZephyrTheme
+
+fun interface RemoteShell {
+    suspend fun run(command: String): RemoteShellResult
+}
+
+data class RemoteShellResult(val exitCode: Int, val stdout: String, val stderr: String) {
+    fun text(): String = stdout.ifBlank { stderr }
+}
+
+private enum class DockerTab { CONTAINERS, IMAGES, MIRRORS }
+private enum class ProcessSort { CPU, MEM, PID }
+
+@Composable
+fun HostMonitorPanel(
+    shell: RemoteShell?,
+    modifier: Modifier = Modifier,
+    onOpenDocker: (() -> Unit)? = null,
+    onMessage: (String) -> Unit = {},
+) {
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
+    var tab by remember { mutableIntStateOf(0) }
+    var loading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var snapshot by remember { mutableStateOf<HostStatsSnapshot?>(null) }
+    var sample by remember { mutableStateOf<HostStatsSample?>(null) }
+    var query by remember { mutableStateOf("") }
+    var sort by remember { mutableStateOf(ProcessSort.CPU) }
+    var pendingKill by remember { mutableStateOf<HostProcessInfo?>(null) }
+    var tick by remember { mutableIntStateOf(0) }
+
+    suspend fun refresh() {
+        val client = shell
+        if (client == null) {
+            loading = false
+            error = "当前没有已连接的 SSH 会话"
+            return
+        }
+        if (snapshot == null) loading = true
+        runCatching {
+            val result = client.run(SshRemoteOps.statsCommand)
+            if (result.exitCode != 0 && result.stdout.isBlank()) {
+                error(result.stderr.ifBlank { "读取远端监控失败" })
+            }
+            SshRemoteOps.parseRemoteStats(result.stdout, sample)
+        }.onSuccess {
+            snapshot = it
+            sample = it.sample
+            error = null
+        }.onFailure {
+            if (snapshot == null) error = it.message ?: "读取远端监控失败"
+            else onMessage(it.message ?: "刷新监控失败")
+        }
+        loading = false
+    }
+
+    LaunchedEffect(shell, tick) { refresh() }
+    LaunchedEffect(shell) {
+        if (shell == null) return@LaunchedEffect
+        while (isActive) {
+            delay(5_000)
+            tick++
+        }
+    }
+
+    Column(modifier.fillMaxSize()) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilterChip(selected = tab == 0, onClick = { tab = 0 }, label = { Text("概览") })
+            FilterChip(selected = tab == 1, onClick = { tab = 1 }, label = { Text("进程") })
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = { tick++ }, enabled = shell != null && !loading) { Text("刷新") }
+        }
+        when {
+            loading && snapshot == null -> HostOpsEmpty(error ?: "正在读取远端监控…")
+            error != null && snapshot == null -> HostOpsEmpty(error ?: "监控失败")
+            snapshot != null && tab == 0 -> MonitorOverview(
+                snapshot = snapshot!!,
+                onCopy = { value ->
+                    clipboard.setText(AnnotatedString(value))
+                    onMessage("已复制")
+                },
+                onOpenDocker = onOpenDocker,
+            )
+            snapshot != null -> ProcessList(
+                processes = snapshot!!.processes,
+                query = query,
+                sort = sort,
+                onQuery = { query = it },
+                onSort = { sort = it },
+                onSignal = { process, signal ->
+                    if (signal == ProcessSignal.KILL) pendingKill = process
+                    else scope.launch { sendSignal(shell, process, signal, onMessage) { tick++ } }
+                },
+            )
+        }
+    }
+
+    pendingKill?.let { process ->
+        AlertDialog(
+            onDismissRequest = { pendingKill = null },
+            title = { Text("强制结束进程 ${process.pid}？") },
+            text = { Text(process.command + " " + process.args) },
+            confirmButton = {
+                TextButton(onClick = {
+                    val target = process
+                    pendingKill = null
+                    scope.launch { sendSignal(shell, target, ProcessSignal.KILL, onMessage) { tick++ } }
+                }) { Text("强制结束") }
+            },
+            dismissButton = { TextButton(onClick = { pendingKill = null }) { Text("取消") } },
+        )
+    }
+}
+
+@Composable
+fun HostDockerPanel(
+    shell: RemoteShell?,
+    modifier: Modifier = Modifier,
+    onMessage: (String) -> Unit = {},
+) {
+    val scope = rememberCoroutineScope()
+    var tab by remember { mutableStateOf(DockerTab.CONTAINERS) }
+    var loading by remember { mutableStateOf(true) }
+    var status by remember { mutableStateOf<DockerEngineStatus?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var containers by remember { mutableStateOf<List<DockerContainerInfo>>(emptyList()) }
+    var images by remember { mutableStateOf<List<DockerImageInfo>>(emptyList()) }
+    var mirrors by remember { mutableStateOf<List<String>>(emptyList()) }
+    var pullImage by remember { mutableStateOf("") }
+    var pullLog by remember { mutableStateOf("") }
+    var pulling by remember { mutableStateOf(false) }
+    var mirrorDraft by remember { mutableStateOf("") }
+    var logTarget by remember { mutableStateOf<DockerContainerInfo?>(null) }
+    var logText by remember { mutableStateOf("") }
+    var pendingRemove by remember { mutableStateOf<DockerContainerInfo?>(null) }
+    var pendingImage by remember { mutableStateOf<Pair<DockerImageInfo, String?>?>(null) }
+    var confirmRestart by remember { mutableStateOf(false) }
+
+    suspend fun loadAll(forceCheck: Boolean = false) {
+        val client = shell
+        if (client == null) {
+            loading = false
+            error = "当前没有已连接的 SSH 会话"
+            return
+        }
+        if (status == null) loading = true
+        runCatching {
+            if (forceCheck || status == null) {
+                val checked = client.run(SshRemoteOps.dockerCheckCommand)
+                status = SshRemoteOps.parseDockerStatus(checked.text())
+            }
+            val current = status
+            if (current?.installed != true) return@runCatching
+            val listed = client.run(SshRemoteOps.dockerListContainersCommand)
+            containers = SshRemoteOps.parseDockerContainers(listed.stdout)
+            val imageRaw = client.run(SshRemoteOps.dockerListImagesCommand)
+            images = SshRemoteOps.parseDockerImages(imageRaw.stdout)
+            val mirrorRaw = client.run(SshRemoteOps.dockerMirrorsGetCommand)
+            mirrors = SshRemoteOps.parseDockerMirrors(mirrorRaw.stdout)
+        }.onFailure {
+            error = it.message ?: "Docker 操作失败"
+        }
+        loading = false
+    }
+
+    LaunchedEffect(shell) { loadAll(forceCheck = true) }
+
+    fun run(label: String, command: String, after: (RemoteShellResult) -> Unit = {}) {
+        val client = shell ?: return
+        scope.launch {
+            runCatching {
+                val result = client.run(command)
+                if (result.exitCode != 0 && result.stdout.isBlank()) {
+                    error(result.stderr.ifBlank { "$label 失败" })
+                }
+                after(result)
+                onMessage(label)
+                loadAll()
+            }.onFailure { onMessage(it.message ?: "$label 失败") }
+        }
+    }
+
+    Column(modifier.fillMaxSize()) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                status?.version?.ifBlank { if (status?.installed == true) "Docker 已安装" else "未检测到 Docker" } ?: "检测中",
+                color = ZephyrTheme.palette.onFloatingMuted,
+                fontSize = 11.sp,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+            )
+            TextButton(onClick = { confirmRestart = true }, enabled = status?.installed == true) { Text("重启 Docker") }
+            TextButton(onClick = { scope.launch { loadAll(forceCheck = true) } }, enabled = shell != null) { Text("刷新") }
+        }
+        when {
+            loading && status == null -> HostOpsEmpty(error ?: "正在检测 Docker…")
+            status?.installed != true -> HostOpsEmpty(
+                (error ?: "未检测到 Docker，请先安装 Docker") + "\ncurl -fsSL https://get.docker.com | bash",
+            )
+            logTarget != null -> DockerLogPane(
+                title = "容器日志 · ${logTarget!!.name}",
+                text = logText,
+                onRefresh = {
+                    val target = logTarget ?: return@DockerLogPane
+                    run("已刷新日志", SshRemoteOps.dockerLogsCommand(target.target, tail = 400)) { logText = it.text() }
+                },
+                onClose = { logTarget = null; logText = "" },
+            )
+            else -> {
+                Row(
+                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    FilterChip(selected = tab == DockerTab.CONTAINERS, onClick = { tab = DockerTab.CONTAINERS }, label = { Text("容器") })
+                    FilterChip(selected = tab == DockerTab.IMAGES, onClick = { tab = DockerTab.IMAGES }, label = { Text("镜像") })
+                    FilterChip(selected = tab == DockerTab.MIRRORS, onClick = { tab = DockerTab.MIRRORS }, label = { Text("镜像加速器") })
+                }
+                when (tab) {
+                    DockerTab.CONTAINERS -> DockerContainerList(
+                        containers = containers,
+                        onStart = { run("已启动 ${it.name}", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.START, it.target)) },
+                        onStop = { run("已停止 ${it.name}", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.STOP, it.target)) },
+                        onRestart = { run("已重启 ${it.name}", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.RESTART, it.target)) },
+                        onLogs = { container ->
+                            logTarget = container
+                            run("已打开日志", SshRemoteOps.dockerLogsCommand(container.target, tail = 400)) { logText = it.text() }
+                        },
+                        onRemove = { pendingRemove = it },
+                    )
+                    DockerTab.IMAGES -> DockerImageList(
+                        images = images,
+                        pullImage = pullImage,
+                        pullLog = pullLog,
+                        pulling = pulling,
+                        onPullChange = { pullImage = it },
+                        onPull = {
+                            val image = pullImage.trim()
+                            if (image.isEmpty()) {
+                                onMessage("请输入镜像名，例如 nginx:alpine")
+                                return@DockerImageList
+                            }
+                            pulling = true
+                            pullLog = "开始拉取 $image…\n"
+                            scope.launch {
+                                val client = shell
+                                if (client == null) {
+                                    pulling = false
+                                    return@launch
+                                }
+                                runCatching {
+                                    val result = client.run(SshRemoteOps.dockerPullCommand(image))
+                                    pullLog += result.text().ifBlank { result.stderr }
+                                    if (result.exitCode != 0) error(result.stderr.ifBlank { "镜像拉取失败" })
+                                    onMessage("镜像拉取完成")
+                                    loadAll()
+                                }.onFailure { failure ->
+                                    pullLog += "\n${failure.message ?: "镜像拉取失败"}"
+                                    onMessage(failure.message ?: "镜像拉取失败")
+                                }
+                                pulling = false
+                            }
+                        },
+                        onDelete = { image ->
+                            scope.launch {
+                                val client = shell ?: return@launch
+                                val used = runCatching { client.run(SshRemoteOps.dockerUsedByCommand(image.reference)).stdout.trim() }.getOrDefault("")
+                                pendingImage = image to used.ifBlank { null }
+                            }
+                        },
+                    )
+                    DockerTab.MIRRORS -> DockerMirrorList(
+                        mirrors = mirrors,
+                        draft = mirrorDraft,
+                        onDraft = { mirrorDraft = it },
+                        onChange = { index, value ->
+                            mirrors = mirrors.toMutableList().also { it[index] = value }
+                        },
+                        onRemove = { index -> mirrors = mirrors.toMutableList().also { it.removeAt(index) } },
+                        onAdd = {
+                            if (!SshRemoteOps.isValidMirror(mirrorDraft)) {
+                                onMessage("镜像地址必须以 http:// 或 https:// 开头")
+                                return@DockerMirrorList
+                            }
+                            mirrors = (mirrors + SshRemoteOps.sanitizeMirror(mirrorDraft)).distinct()
+                            mirrorDraft = ""
+                        },
+                        onSave = {
+                            run("镜像加速器已保存，请重启 Docker 服务", SshRemoteOps.dockerMirrorsSetCommand(mirrors.filter(SshRemoteOps::isValidMirror)))
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    pendingRemove?.let { container ->
+        AlertDialog(
+            onDismissRequest = { pendingRemove = null },
+            title = { Text("确认删除容器 ${container.name}?") },
+            text = { Text(container.image) },
+            confirmButton = {
+                TextButton(onClick = {
+                    val target = container
+                    pendingRemove = null
+                    run("已删除 ${target.name}", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.REMOVE, target.target))
+                }) { Text("删除") }
+            },
+            dismissButton = { TextButton(onClick = { pendingRemove = null }) { Text("取消") } },
+        )
+    }
+    pendingImage?.let { (image, usedBy) ->
+        AlertDialog(
+            onDismissRequest = { pendingImage = null },
+            title = { Text(if (usedBy == null) "确认删除镜像 ${image.reference}?" else "该镜像正在被容器使用") },
+            text = { Text(usedBy ?: image.id) },
+            confirmButton = {
+                TextButton(onClick = {
+                    val target = image
+                    val force = usedBy != null
+                    pendingImage = null
+                    run("已删除镜像", SshRemoteOps.dockerDeleteImageCommand(target.reference, force))
+                }) { Text(if (usedBy == null) "删除" else "强制删除") }
+            },
+            dismissButton = { TextButton(onClick = { pendingImage = null }) { Text("取消") } },
+        )
+    }
+    if (confirmRestart) {
+        AlertDialog(
+            onDismissRequest = { confirmRestart = false },
+            title = { Text("重启目标主机 Docker 服务？") },
+            text = { Text("会短暂中断该主机上的全部容器。") },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmRestart = false
+                    run("Docker 服务已重启", SshRemoteOps.dockerRestartServiceCommand)
+                }) { Text("重启") }
+            },
+            dismissButton = { TextButton(onClick = { confirmRestart = false }) { Text("取消") } },
+        )
+    }
+}
+
+@Composable
+private fun MonitorOverview(
+    snapshot: HostStatsSnapshot,
+    onCopy: (String) -> Unit,
+    onOpenDocker: (() -> Unit)?,
+) {
+    val palette = ZephyrTheme.palette
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp, 4.dp, 8.dp, 24.dp)) {
+        item("host") {
+            OverviewCard("主机", snapshot.hostName, snapshot.os)
+        }
+        item("cpu") {
+            OverviewCard(
+                "CPU",
+                snapshot.cpu.model,
+                "${snapshot.cpu.freq} · ${snapshot.cpu.cores} 核心",
+                snapshot.cpu.usagePercent.toFloat() / 100f,
+                "${"%.1f".format(snapshot.cpu.usagePercent)}%",
+            )
+        }
+        item("mem") {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) {
+                    OverviewCard(
+                        "内存",
+                        "${gb(snapshot.memory.memUsedMb)} / ${gb(snapshot.memory.memTotalMb)} GB",
+                        null,
+                        snapshot.memory.memPercent.toFloat() / 100f,
+                    )
+                }
+                Box(Modifier.weight(1f)) {
+                    OverviewCard(
+                        "Swap",
+                        "${gb(snapshot.memory.swapUsedMb)} / ${gb(snapshot.memory.swapTotalMb)} GB",
+                        null,
+                        snapshot.memory.swapPercent.toFloat() / 100f,
+                    )
+                }
+            }
+        }
+        items(snapshot.disks, key = { it.id }) { disk ->
+            OverviewCard(
+                disk.mountpoint,
+                "${"%.1f".format(disk.usedGb)} / ${"%.1f".format(disk.totalGb)} GB",
+                "已用 ${disk.percent}% · 读 ${"%.1f".format(disk.readKBps)} KB/s · 写 ${"%.1f".format(disk.writeKBps)} KB/s",
+                disk.percent / 100f,
+                warn = disk.percent >= 80,
+            )
+        }
+        item("net") {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { OverviewCard("下载", "${"%.1f".format(snapshot.network.rxMbps)} Mbps") }
+                Box(Modifier.weight(1f)) { OverviewCard("上传", "${"%.1f".format(snapshot.network.txMbps)} Mbps") }
+            }
+        }
+        item("ip") {
+            Column(Modifier.fillMaxWidth().padding(top = 8.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                IpRow("IPv4", snapshot.ipv4, onCopy)
+                IpRow("IPv6", snapshot.ipv6, onCopy)
+            }
+        }
+        if (onOpenDocker != null) {
+            item("docker") {
+                PrimaryButton(onClick = onOpenDocker, modifier = Modifier.fillMaxWidth().padding(top = 12.dp)) {
+                    Text("打开 Docker 管理")
+                }
+            }
+        }
+        item("note") {
+            Text(
+                "每 5 秒刷新一次 · 速率需要至少两帧采样",
+                color = palette.onFloatingSubtle,
+                fontSize = 11.sp,
+                modifier = Modifier.padding(top = 14.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProcessList(
+    processes: List<HostProcessInfo>,
+    query: String,
+    sort: ProcessSort,
+    onQuery: (String) -> Unit,
+    onSort: (ProcessSort) -> Unit,
+    onSignal: (HostProcessInfo, ProcessSignal) -> Unit,
+) {
+    val filtered = remember(processes, query, sort) {
+        val needle = query.trim().lowercase()
+        processes.filter { process ->
+            needle.isEmpty() ||
+                process.pid.toString().contains(needle) ||
+                process.user.lowercase().contains(needle) ||
+                process.command.lowercase().contains(needle) ||
+                process.args.lowercase().contains(needle)
+        }.sortedWith(
+            when (sort) {
+                ProcessSort.CPU -> compareByDescending { it.cpuPercent }
+                ProcessSort.MEM -> compareByDescending { it.memPercent }
+                ProcessSort.PID -> compareBy { it.pid }
+            },
+        ).take(60)
+    }
+    Column(Modifier.fillMaxSize()) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQuery,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+            singleLine = true,
+            placeholder = { Text("搜索 PID / 用户 / 命令") },
+        )
+        Row(
+            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilterChip(selected = sort == ProcessSort.CPU, onClick = { onSort(ProcessSort.CPU) }, label = { Text("CPU") })
+            FilterChip(selected = sort == ProcessSort.MEM, onClick = { onSort(ProcessSort.MEM) }, label = { Text("内存优先") })
+            FilterChip(selected = sort == ProcessSort.PID, onClick = { onSort(ProcessSort.PID) }, label = { Text("PID") })
+            Text("${processes.size} 个进程", color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp)
+        }
+        if (filtered.isEmpty()) {
+            HostOpsEmpty("暂无进程数据")
+        } else {
+            LazyColumn(Modifier.fillMaxSize(), contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp)) {
+                items(filtered, key = { it.pid }) { process ->
+                    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(process.command, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f), maxLines = 1)
+                            Text("PID ${process.pid}", color = ZephyrTheme.palette.onFloatingSubtle, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                        }
+                        Text(process.args, color = ZephyrTheme.palette.onFloatingSubtle, fontSize = 11.sp, maxLines = 2)
+                        Text(
+                            "${process.user} · ${process.stat} · CPU ${"%.1f".format(process.cpuPercent)}% · MEM ${"%.1f".format(process.memPercent)}%",
+                            color = ZephyrTheme.palette.onFloatingMuted,
+                            fontSize = 11.sp,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(top = 4.dp)) {
+                            AssistChip(onClick = { onSignal(process, ProcessSignal.TERM) }, label = { Text("结束") })
+                            AssistChip(onClick = { onSignal(process, ProcessSignal.KILL) }, label = { Text("强制") })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DockerContainerList(
+    containers: List<DockerContainerInfo>,
+    onStart: (DockerContainerInfo) -> Unit,
+    onStop: (DockerContainerInfo) -> Unit,
+    onRestart: (DockerContainerInfo) -> Unit,
+    onLogs: (DockerContainerInfo) -> Unit,
+    onRemove: (DockerContainerInfo) -> Unit,
+) {
+    if (containers.isEmpty()) {
+        HostOpsEmpty("暂无容器")
+        return
+    }
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp)) {
+        items(containers, key = { it.id.ifBlank { it.name } }) { container ->
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(ZephyrTheme.palette.surfaces.content)
+                    .padding(10.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(container.name, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f), maxLines = 1)
+                    Text(
+                        container.status,
+                        color = if (container.running) ZephyrTheme.palette.status.success else ZephyrTheme.palette.onFloatingSubtle,
+                        fontSize = 11.sp,
+                    )
+                }
+                Text(container.image, color = ZephyrTheme.palette.onFloatingMuted, fontSize = 11.sp, maxLines = 1)
+                Text(
+                    "${SshRemoteOps.shortId(container.id)} · ${container.ports} · ${container.createdAt}",
+                    color = ZephyrTheme.palette.onFloatingSubtle,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                )
+                Row(
+                    Modifier.horizontalScroll(rememberScrollState()).padding(top = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    AssistChip(onClick = { onStart(container) }, enabled = !container.running, label = { Text("启动") })
+                    AssistChip(onClick = { onStop(container) }, enabled = container.running, label = { Text("停止") })
+                    AssistChip(onClick = { onRestart(container) }, label = { Text("重启") })
+                    AssistChip(onClick = { onLogs(container) }, label = { Text("日志") })
+                    AssistChip(onClick = { onRemove(container) }, label = { Text("删除") })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DockerImageList(
+    images: List<DockerImageInfo>,
+    pullImage: String,
+    pullLog: String,
+    pulling: Boolean,
+    onPullChange: (String) -> Unit,
+    onPull: () -> Unit,
+    onDelete: (DockerImageInfo) -> Unit,
+) {
+    Column(Modifier.fillMaxSize()) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedTextField(
+                value = pullImage,
+                onValueChange = onPullChange,
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                placeholder = { Text("镜像名，例如 nginx:alpine") },
+            )
+            PrimaryButton(onClick = onPull, enabled = !pulling) { Text("拉取") }
+        }
+        if (pullLog.isNotBlank()) {
+            Text(
+                pullLog.takeLast(2000),
+                color = ZephyrTheme.palette.onFloatingMuted,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 10.sp,
+                modifier = Modifier.fillMaxWidth().height(88.dp).padding(horizontal = 10.dp).verticalScroll(rememberScrollState()),
+            )
+        }
+        if (images.isEmpty()) {
+            HostOpsEmpty("暂无镜像")
+        } else {
+            LazyColumn(Modifier.fillMaxSize(), contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp)) {
+                items(images, key = { it.id + it.tag }) { image ->
+                    Row(
+                        Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(image.repository, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, maxLines = 1)
+                            Text(
+                                "${image.tag} · ${image.size} · ${image.createdAt} · ${SshRemoteOps.shortId(image.id)}",
+                                color = ZephyrTheme.palette.onFloatingSubtle,
+                                fontSize = 11.sp,
+                                maxLines = 1,
+                            )
+                        }
+                        AssistChip(onClick = { onDelete(image) }, label = { Text("删除") })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DockerMirrorList(
+    mirrors: List<String>,
+    draft: String,
+    onDraft: (String) -> Unit,
+    onChange: (Int, String) -> Unit,
+    onRemove: (Int) -> Unit,
+    onAdd: () -> Unit,
+    onSave: () -> Unit,
+) {
+    Column(Modifier.fillMaxSize().padding(horizontal = 8.dp)) {
+        Text(
+            "配置 Docker registry-mirrors 后，请重启 Docker 服务使配置生效。",
+            color = ZephyrTheme.palette.onFloatingSubtle,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+        if (mirrors.isEmpty()) {
+            Text("尚未配置镜像加速器", color = ZephyrTheme.palette.onFloatingMuted, modifier = Modifier.padding(vertical = 8.dp))
+        }
+        mirrors.forEachIndexed { index, mirror ->
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(bottom = 6.dp)) {
+                OutlinedTextField(value = mirror, onValueChange = { onChange(index, it) }, modifier = Modifier.weight(1f), singleLine = true)
+                TextButton(onClick = { onRemove(index) }) { Text("删除") }
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = draft,
+                onValueChange = onDraft,
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                placeholder = { Text("https://mirror.ccs.tencentyun.com") },
+            )
+            AssistChip(onClick = onAdd, label = { Text("添加") })
+            PrimaryButton(onClick = onSave) { Text("保存配置") }
+        }
+    }
+}
+
+@Composable
+private fun DockerLogPane(title: String, text: String, onRefresh: () -> Unit, onClose: () -> Unit) {
+    Column(Modifier.fillMaxSize()) {
+        Row(
+            Modifier.fillMaxWidth().padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(title, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f), maxLines = 1)
+            TextButton(onClick = onRefresh) { Text("刷新") }
+            TextButton(onClick = onClose) { Text("关闭") }
+        }
+        Text(
+            text.ifBlank { "暂无日志" },
+            color = ZephyrTheme.palette.onFloating,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+            modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp).verticalScroll(rememberScrollState()),
+        )
+    }
+}
+
+@Composable
+private fun OverviewCard(
+    title: String,
+    value: String,
+    subtitle: String? = null,
+    progress: Float? = null,
+    badge: String? = null,
+    warn: Boolean = false,
+) {
+    val palette = ZephyrTheme.palette
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(vertical = 5.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(palette.surfaces.content)
+            .border(1.dp, palette.surfaces.outlineSoft, RoundedCornerShape(10.dp))
+            .padding(12.dp),
+    ) {
+        Row {
+            Text(title, color = palette.onFloatingMuted, fontSize = 11.sp, modifier = Modifier.weight(1f))
+            if (badge != null) Text(badge, color = if (warn) palette.status.warning else palette.onFloatingMuted, fontSize = 11.sp)
+        }
+        Text(value, color = if (warn) palette.status.warning else palette.onFloating, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(top = 4.dp))
+        if (subtitle != null) Text(subtitle, color = palette.onFloatingSubtle, fontSize = 11.sp, modifier = Modifier.padding(top = 2.dp))
+        if (progress != null) {
+            LinearProgress(
+                progress = progress,
+                color = if (warn) palette.status.warning else palette.brand.accent,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun IpRow(label: String, value: String, onCopy: (String) -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(ZephyrTheme.palette.surfaces.content)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, color = ZephyrTheme.palette.onFloatingMuted, fontSize = 11.sp, modifier = Modifier.width(40.dp))
+        Text(value, color = ZephyrTheme.palette.onFloating, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1f), maxLines = 1)
+        TextButton(onClick = { onCopy(value) }, enabled = value != "N/A") { Text("复制") }
+    }
+}
+
+@Composable
+private fun HostOpsEmpty(message: String) {
+    Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+        Text(message, color = ZephyrTheme.palette.onFloatingSubtle)
+    }
+}
+
+private fun gb(mb: Double): String = "%.1f".format(mb / 1024.0)
+
+private suspend fun sendSignal(
+    shell: RemoteShell?,
+    process: HostProcessInfo,
+    signal: ProcessSignal,
+    onMessage: (String) -> Unit,
+    onDone: () -> Unit,
+) {
+    val client = shell ?: return
+    runCatching {
+        val result = client.run(SshRemoteOps.processSignalCommand(process.pid, signal))
+        if (result.exitCode != 0) error(result.stderr.ifBlank { "信号发送失败" })
+        onMessage("${if (signal == ProcessSignal.KILL) "强制结束" else "结束"}进程 ${process.pid} 的信号已发送")
+        onDone()
+    }.onFailure { onMessage(it.message ?: "进程操作失败") }
+}

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt
@@ -57,12 +57,29 @@ import one.zephyr.mobile.ui.component.Text
 import one.zephyr.mobile.ui.component.TextButton
 import one.zephyr.mobile.ui.theme.ZephyrTheme
 
-fun interface RemoteShell {
+interface RemoteShell {
     suspend fun run(command: String): RemoteShellResult
+
+    fun stream(command: String): kotlinx.coroutines.flow.Flow<RemoteShellChunk> =
+        kotlinx.coroutines.flow.flow {
+            val result = run(command)
+            if (result.stdout.isNotEmpty()) emit(RemoteShellChunk.Output(result.stdout))
+            if (result.stderr.isNotEmpty()) emit(RemoteShellChunk.Output(result.stderr))
+            emit(RemoteShellChunk.Closed(result.exitCode))
+        }
+}
+
+fun RemoteShell(block: suspend (String) -> RemoteShellResult): RemoteShell = object : RemoteShell {
+    override suspend fun run(command: String): RemoteShellResult = block(command)
 }
 
 data class RemoteShellResult(val exitCode: Int, val stdout: String, val stderr: String) {
     fun text(): String = stdout.ifBlank { stderr }
+}
+
+sealed interface RemoteShellChunk {
+    data class Output(val text: String) : RemoteShellChunk
+    data class Closed(val exitCode: Int) : RemoteShellChunk
 }
 
 private enum class DockerTab { CONTAINERS, IMAGES, MIRRORS }
@@ -194,6 +211,8 @@ fun HostDockerPanel(
     var mirrorDraft by remember { mutableStateOf("") }
     var logTarget by remember { mutableStateOf<DockerContainerInfo?>(null) }
     var logText by remember { mutableStateOf("") }
+    var logFollow by remember { mutableStateOf(true) }
+    var logPaused by remember { mutableStateOf(false) }
     var pendingRemove by remember { mutableStateOf<DockerContainerInfo?>(null) }
     var pendingImage by remember { mutableStateOf<Pair<DockerImageInfo, String?>?>(null) }
     var confirmRestart by remember { mutableStateOf(false) }
@@ -226,6 +245,28 @@ fun HostDockerPanel(
     }
 
     LaunchedEffect(shell) { loadAll(forceCheck = true) }
+
+    LaunchedEffect(shell, logTarget, logFollow) {
+        val client = shell
+        val container = logTarget
+        if (client == null || container == null || !logFollow) return@LaunchedEffect
+        runCatching {
+            client.stream(SshRemoteOps.dockerLogsCommand(container.target, tail = 200, follow = true)).collect { chunk ->
+                when (chunk) {
+                    is RemoteShellChunk.Output -> {
+                        logText = (logText + chunk.text).takeLast(80_000)
+                    }
+                    is RemoteShellChunk.Closed -> {
+                        logFollow = false
+                        if (chunk.exitCode != 0) onMessage("日志流结束（exit ${chunk.exitCode}）")
+                    }
+                }
+            }
+        }.onFailure { failure ->
+            logFollow = false
+            onMessage(failure.message ?: "日志流中断")
+        }
+    }
 
     fun run(label: String, command: String, after: (RemoteShellResult) -> Unit = {}) {
         val client = shell ?: return
@@ -266,11 +307,10 @@ fun HostDockerPanel(
             logTarget != null -> DockerLogPane(
                 title = "容器日志 · ${logTarget!!.name}",
                 text = logText,
-                onRefresh = {
-                    val target = logTarget ?: return@DockerLogPane
-                    run("已刷新日志", SshRemoteOps.dockerLogsCommand(target.target, tail = 400)) { logText = it.text() }
-                },
-                onClose = { logTarget = null; logText = "" },
+                following = logFollow,
+                paused = logPaused,
+                onTogglePause = { logPaused = !logPaused },
+                onClose = { logTarget = null; logText = ""; logFollow = false },
             )
             else -> {
                 Row(
@@ -289,7 +329,9 @@ fun HostDockerPanel(
                         onRestart = { run("已重启 ${it.name}", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.RESTART, it.target)) },
                         onLogs = { container ->
                             logTarget = container
-                            run("已打开日志", SshRemoteOps.dockerLogsCommand(container.target, tail = 400)) { logText = it.text() }
+                            logText = ""
+                            logFollow = true
+                            logPaused = false
                         },
                         onRemove = { pendingRemove = it },
                     )
@@ -314,9 +356,14 @@ fun HostDockerPanel(
                                     return@launch
                                 }
                                 runCatching {
-                                    val result = client.run(SshRemoteOps.dockerPullCommand(image))
-                                    pullLog += result.text().ifBlank { result.stderr }
-                                    if (result.exitCode != 0) error(result.stderr.ifBlank { "镜像拉取失败" })
+                                    var code = 0
+                                    client.stream(SshRemoteOps.dockerPullCommand(image)).collect { chunk ->
+                                        when (chunk) {
+                                            is RemoteShellChunk.Output -> pullLog = (pullLog + chunk.text).takeLast(20_000)
+                                            is RemoteShellChunk.Closed -> code = chunk.exitCode
+                                        }
+                                    }
+                                    if (code != 0) error("镜像拉取失败（exit $code）")
                                     onMessage("镜像拉取完成")
                                     loadAll()
                                 }.onFailure { failure ->
@@ -710,22 +757,39 @@ private fun DockerMirrorList(
 }
 
 @Composable
-private fun DockerLogPane(title: String, text: String, onRefresh: () -> Unit, onClose: () -> Unit) {
+private fun DockerLogPane(
+    title: String,
+    text: String,
+    following: Boolean,
+    paused: Boolean,
+    onTogglePause: () -> Unit,
+    onClose: () -> Unit,
+) {
+    val scroll = rememberScrollState()
+    LaunchedEffect(text, paused) {
+        if (!paused) scroll.animateScrollTo(scroll.maxValue)
+    }
     Column(Modifier.fillMaxSize()) {
         Row(
             Modifier.fillMaxWidth().padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(title, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f), maxLines = 1)
-            TextButton(onClick = onRefresh) { Text("刷新") }
+            TextButton(onClick = onTogglePause) { Text(if (paused) "继续滚动" else "暂停滚动") }
             TextButton(onClick = onClose) { Text("关闭") }
         }
+        Text(
+            if (following) "跟随中 · docker logs --timestamps -f" else "日志流已结束",
+            color = ZephyrTheme.palette.onFloatingSubtle,
+            fontSize = 10.sp,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
+        )
         Text(
             text.ifBlank { "暂无日志" },
             color = ZephyrTheme.palette.onFloating,
             fontFamily = FontFamily.Monospace,
             fontSize = 11.sp,
-            modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp).verticalScroll(rememberScrollState()),
+            modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp).verticalScroll(scroll),
         )
     }
 }

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -699,14 +700,23 @@ fun DockerMonitorScreen(
     connections: List<Connection>,
     section: OpsSection,
     onBack: () -> Unit,
+    shellFor: (String) -> RemoteShell? = { null },
+    onMessage: (String) -> Unit = {},
 ) {
     val palette = ZephyrTheme.palette
-    val connection = connections.firstOrNull { it.protocol == Protocol.SSH && it.capabilities.canObserve }
-    val unavailable = UnavailableOpsPort()
+    val ssh = connections.filter { it.protocol == Protocol.SSH && it.capabilities.canObserve }
+    val sshIds = ssh.joinToString(separator = "\u0000") { it.id }
+    var selectedId by remember(sshIds) { mutableStateOf(ssh.firstOrNull()?.id) }
+    val selected = ssh.firstOrNull { it.id == selectedId } ?: ssh.firstOrNull()
+    val title = when (section) {
+        OpsSection.DOCKER -> "Docker"
+        OpsSection.METRICS -> "监控"
+        OpsSection.LOGS -> "日志"
+    }
     Column(Modifier.fillMaxSize()) {
-        PushedPageHeader(title = "Docker / 监控", onBack = onBack) {
+        PushedPageHeader(title = title, onBack = onBack) {
             Text(
-                connection?.name ?: "未选择",
+                selected?.name ?: "未选择",
                 color = palette.protocol.ssh,
                 fontSize = 11.sp,
                 fontWeight = FontWeight.SemiBold,
@@ -716,88 +726,32 @@ fun DockerMonitorScreen(
                     .padding(horizontal = 8.dp, vertical = 3.dp),
             )
         }
-        Column(
-            Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = ZephyrSpacing.lg)
-                .padding(bottom = 140.dp),
-        ) {
-            Text(
-                "资源 · snapshot --".uppercase(),
-                style = ZephyrTheme.typography.section,
-                color = palette.onFloatingSubtle,
-                modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 10.dp),
-            )
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                DockerStatCard("--", "CPU", 0f, Modifier.weight(1f))
-                DockerStatCard("--", "内存", 0f, Modifier.weight(1f))
-            }
+        if (ssh.size > 1) {
             Row(
-                Modifier.fillMaxWidth().padding(top = 10.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                DockerStatCard("--", "磁盘 /", 0f, Modifier.weight(1f), warning = true)
-                DockerStatCard("--", "网络", 0f, Modifier.weight(1f))
+                ssh.forEach { connection ->
+                    FilterChip(
+                        selected = selectedId == connection.id,
+                        onClick = { selectedId = connection.id },
+                        label = { Text(connection.name, maxLines = 1) },
+                    )
+                }
             }
-
-            SectionLabel("容器 · control 能力可启停")
-            GroupCard {
-                SettingsRow(
-                    title = if (connection == null) "暂无可观察 SSH 连接" else "暂无容器快照",
-                    subtitle = unavailable.let { "SSH 引擎尚未接入，当前无法读取容器状态" },
-                    showDivider = false,
-                )
-            }
-
-            SectionLabel("服务日志")
-            GroupCard {
-                SettingsRow(
-                    title = if (connection == null) "暂无服务日志" else connection.name,
-                    subtitle = "tail · 搜索 · 导出",
-                    showChevron = connection != null && unavailable.isAvailable,
-                    showDivider = false,
-                )
-            }
-
-            Text(
-                "离线时显示最后 snapshot 时间，不把旧值说成实时",
-                color = palette.onFloatingSubtle,
-                fontSize = 13.sp,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth().padding(top = 26.dp, bottom = 8.dp),
+        }
+        val activeShell = selected?.id?.let(shellFor)
+        when (section) {
+            OpsSection.DOCKER -> HostDockerPanel(shell = activeShell, modifier = Modifier.fillMaxSize(), onMessage = onMessage)
+            OpsSection.METRICS, OpsSection.LOGS -> HostMonitorPanel(
+                shell = activeShell,
+                modifier = Modifier.fillMaxSize(),
+                onMessage = onMessage,
             )
         }
-    }
-}
-
-@Composable
-private fun DockerStatCard(
-    value: String,
-    label: String,
-    progress: Float,
-    modifier: Modifier = Modifier,
-    warning: Boolean = false,
-) {
-    val palette = ZephyrTheme.palette
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(8.dp))
-            .background(palette.surfaces.content)
-            .border(1.dp, palette.surfaces.outlineSoft, RoundedCornerShape(8.dp))
-            .padding(horizontal = 12.dp, vertical = 11.dp),
-    ) {
-        Text(
-            value,
-            color = if (warning) palette.status.warning else palette.onFloating,
-            fontSize = 17.sp,
-            fontWeight = FontWeight.SemiBold,
-        )
-        LinearProgress(
-            progress = progress,
-            color = if (warning) palette.status.warning else palette.brand.accent,
-            modifier = Modifier.padding(top = 8.dp),
-        )
-        Text(label, color = palette.onFloatingMuted, fontSize = 11.sp, modifier = Modifier.padding(top = 7.dp))
     }
 }
 

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsPorts.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsPorts.kt
@@ -32,6 +32,9 @@ interface SshExecPort {
      * (ZEPHYR_PARITY.md 4.2).
      */
     suspend fun exec(connectionId: String, command: String, timeoutSeconds: Int): ExecOutcome
+
+    fun execStream(connectionId: String, command: String): kotlinx.coroutines.flow.Flow<RemoteShellChunk> =
+        kotlinx.coroutines.flow.emptyFlow()
 }
 
 /**

--- a/zephyr_one/mobile/android/feature-tools/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-tools/src/main/res/values-en/strings.xml
@@ -67,7 +67,7 @@
     <string name="tools_batch_output_hide">Hide %1$s</string>
     <string name="tools_batch_output_show">Show %1$s (%2$d chars)</string>
     <string name="tools_batch_status_pending">Waiting</string>
-    <string name="tools_batch_status_running">Running</string>
+    <string name="tools_batch_status_running">Connecting and running</string>
     <string name="tools_batch_status_succeeded">Succeeded</string>
     <string name="tools_batch_status_failed">Failed</string>
     <string name="tools_batch_status_timed_out">Timed out</string>

--- a/zephyr_one/mobile/android/feature-tools/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-tools/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="tools_batch_output_hide">收起 %1$s</string>
     <string name="tools_batch_output_show">查看 %1$s（%2$d 字符）</string>
     <string name="tools_batch_status_pending">等待中</string>
-    <string name="tools_batch_status_running">执行中</string>
+    <string name="tools_batch_status_running">连接并执行中</string>
     <string name="tools_batch_status_succeeded">成功</string>
     <string name="tools_batch_status_failed">失败</string>
     <string name="tools_batch_status_timed_out">超时</string>

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
@@ -67,6 +67,66 @@ interface SshEngine {
     suspend fun chmod(sessionId: String, path: String, mode: Int): Result<Unit>
 
     suspend fun exec(sessionId: String, command: String): Result<SshExecResult>
+
+    /**
+     * Streaming exec for `docker logs -f` / `docker pull`.
+     * Completes after [SshExecEvent.Closed]. Cancel the collector to kill the remote process.
+     */
+    fun execStream(sessionId: String, command: String): Flow<SshExecEvent> =
+        kotlinx.coroutines.flow.flow {
+            val result = exec(sessionId, command).getOrElse { throw it }
+            if (result.stdout.isNotEmpty()) emit(SshExecEvent.Stdout(result.stdout))
+            if (result.stderr.isNotEmpty()) emit(SshExecEvent.Stderr(result.stderr))
+            emit(SshExecEvent.Closed(result.exitCode))
+        }
+
+    /**
+     * Stream a remote file in chunks so a 2 GiB download never sits in a ByteArray.
+     * [onChunk] is invoked on the IO dispatcher.
+     */
+    suspend fun readFileStream(
+        sessionId: String,
+        path: String,
+        offset: Long = 0L,
+        onChunk: suspend (offset: Long, bytes: ByteArray, total: Long) -> Unit,
+    ): Result<SshRemoteFileVersion> = readFileRange(sessionId, path, offset, Int.MAX_VALUE / 4).mapCatching { file ->
+        if (file.bytes.isNotEmpty()) onChunk(offset, file.bytes, file.size)
+        SshRemoteFileVersion(file.path, file.size, file.modifiedAt)
+    }
+
+    /**
+     * Stream-write [next] chunks to [path]. [next] returns the next payload or null at EOF.
+     */
+    suspend fun writeFileStream(
+        sessionId: String,
+        path: String,
+        expected: SshRemoteFileVersion? = null,
+        next: suspend () -> ByteArray?,
+    ): Result<SshRemoteFileVersion> {
+        val chunks = ArrayList<ByteArray>()
+        var total = 0
+        while (true) {
+            val chunk = next() ?: break
+            chunks += chunk
+            total += chunk.size
+            if (total > 8 * 1024 * 1024) {
+                return Result.failure(IllegalStateException("写入内容过大，当前引擎回退上限 8 MiB"))
+            }
+        }
+        val bytes = ByteArray(total)
+        var cursor = 0
+        for (chunk in chunks) {
+            System.arraycopy(chunk, 0, bytes, cursor, chunk.size)
+            cursor += chunk.size
+        }
+        return writeFile(sessionId, path, bytes, expected)
+    }
+}
+
+sealed interface SshExecEvent {
+    data class Stdout(val bytes: ByteArray) : SshExecEvent
+    data class Stderr(val bytes: ByteArray) : SshExecEvent
+    data class Closed(val exitCode: Int) : SshExecEvent
 }
 
 data class SshConnectRequest(

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
@@ -52,12 +52,19 @@ interface SshEngine {
     suspend fun rename(sessionId: String, from: String, to: String): Result<Unit>
     suspend fun delete(sessionId: String, path: String, recursive: Boolean): Result<Unit>
     suspend fun readFile(sessionId: String, path: String, maxBytes: Int): Result<SshRemoteFile>
+    suspend fun readFileRange(
+        sessionId: String,
+        path: String,
+        offset: Long,
+        maxBytes: Int,
+    ): Result<SshRemoteFile>
     suspend fun writeFile(
         sessionId: String,
         path: String,
         bytes: ByteArray,
         expected: SshRemoteFileVersion? = null,
     ): Result<SshRemoteFileVersion>
+    suspend fun chmod(sessionId: String, path: String, mode: Int): Result<Unit>
 
     suspend fun exec(sessionId: String, command: String): Result<SshExecResult>
 }
@@ -161,12 +168,22 @@ class UnavailableSshEngine : SshEngine {
     override suspend fun readFile(sessionId: String, path: String, maxBytes: Int): Result<SshRemoteFile> =
         Result.failure(MobileApiException(BLOCKED))
 
+    override suspend fun readFileRange(
+        sessionId: String,
+        path: String,
+        offset: Long,
+        maxBytes: Int,
+    ): Result<SshRemoteFile> = Result.failure(MobileApiException(BLOCKED))
+
     override suspend fun writeFile(
         sessionId: String,
         path: String,
         bytes: ByteArray,
         expected: SshRemoteFileVersion?,
     ): Result<SshRemoteFileVersion> = Result.failure(MobileApiException(BLOCKED))
+
+    override suspend fun chmod(sessionId: String, path: String, mode: Int): Result<Unit> =
+        Result.failure(MobileApiException(BLOCKED))
 
     override suspend fun exec(sessionId: String, command: String): Result<SshExecResult> =
         Result.failure(one.zephyr.mobile.model.MobileApiException(BLOCKED))

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshFileKinds.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshFileKinds.kt
@@ -1,0 +1,200 @@
+package one.zephyr.mobile.protocol.ssh
+
+/**
+ * Desktop `public/terminal.js` file-kind tables, used so Mobile opens the same preview / editor
+ * path the main end would for a given extension.
+ */
+object SshFileKinds {
+
+    val IMAGE = setOf(
+        "jpg", "jpeg", "png", "webp", "gif", "svg", "avif",
+        "tif", "tiff", "heic", "heif", "jxl", "jp2", "j2k", "bmp", "dib", "ico", "cur", "icns",
+        "psd", "psb", "xcf", "dds", "tga", "hdr", "exr", "pnm", "pbm", "pgm", "ppm", "pam",
+        "pcx", "sgi", "ras", "sun", "fits", "fit", "dng", "cr2", "cr3", "nef", "arw", "orf",
+        "rw2", "raf", "pef", "srw", "x3f", "mrw", "erf", "kdc", "dcr", "mos",
+    )
+
+    val VIDEO = setOf(
+        "mp4", "m4v", "mov", "mkv", "webm", "avi", "wmv", "flv", "f4v", "mpeg", "mpg", "mpe",
+        "ts", "mts", "m2ts", "vob", "ogv", "3gp", "3g2", "asf", "rm", "rmvb", "divx", "mxf",
+    )
+
+    val AUDIO = setOf(
+        "mp3", "m4a", "aac", "wav", "flac", "ogg", "oga", "opus", "weba", "wma", "alac",
+        "aiff", "aif", "ape", "amr", "mid", "midi", "mka", "caf", "ac3", "dts", "m4b",
+    )
+
+    val ARCHIVE = setOf(
+        "zip", "rar", "7z", "tar", "gz", "tgz", "bz2", "tbz", "tbz2", "xz", "txz", "zst",
+        "lz", "lzma", "br", "jar", "war", "ear", "apk", "ipa", "deb", "rpm", "pkg", "dmg", "iso",
+    )
+
+    val TEXT = setOf(
+        "txt", "md", "markdown", "json", "jsonc", "yml", "yaml", "toml", "ini", "cfg", "conf",
+        "xml", "html", "htm", "css", "scss", "less", "js", "jsx", "ts", "tsx", "mjs", "cjs",
+        "kt", "kts", "java", "go", "rs", "py", "rb", "php", "c", "h", "cc", "cpp", "hpp",
+        "cs", "swift", "sh", "bash", "zsh", "fish", "ps1", "bat", "cmd", "sql", "graphql",
+        "gradle", "properties", "env", "gitignore", "dockerignore", "editorconfig", "log",
+        "csv", "tsv", "svg", "vue", "svelte", "lua", "r", "pl", "pm", "ex", "exs", "erl",
+        "hs", "clj", "scala", "groovy", "dart", "proto", "tf", "hcl", "nginx", "service",
+    )
+
+    val ARCHIVE_EXTRACTABLE = listOf(
+        ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz", ".tar", ".zip", ".gz", ".bz2", ".xz", ".7z",
+    )
+
+    fun extensionOf(path: String): String {
+        val name = path.substringAfterLast('/').substringAfterLast('\\')
+        val dot = name.lastIndexOf('.')
+        if (dot <= 0 || dot == name.length - 1) return ""
+        return name.substring(dot + 1).lowercase()
+    }
+
+    fun archiveExtensionOf(name: String): String {
+        val lower = name.lowercase()
+        return ARCHIVE_EXTRACTABLE.firstOrNull { lower.endsWith(it) }.orEmpty()
+    }
+
+    fun isImage(path: String): Boolean = extensionOf(path) in IMAGE
+
+    fun isVideo(path: String): Boolean = extensionOf(path) in VIDEO
+
+    fun isAudio(path: String): Boolean = extensionOf(path) in AUDIO
+
+    fun isMedia(path: String): Boolean = isVideo(path) || isAudio(path)
+
+    fun isArchive(path: String): Boolean =
+        archiveExtensionOf(path).isNotEmpty() || extensionOf(path) in ARCHIVE
+
+    fun isText(path: String): Boolean {
+        val ext = extensionOf(path)
+        if (ext.isEmpty()) return true
+        return ext in TEXT
+    }
+
+    fun decodeOctalMode(text: String): Int {
+        val trimmed = text.trim()
+        require(trimmed.matches(Regex("^[0-7]{3,4}$"))) { "mode 必须是 3–4 位八进制，例如 644 或 0755" }
+        return trimmed.toInt(8)
+    }
+
+    fun formatOctalMode(mode: Int): String = (mode and 0x1FF).toString(8).padStart(3, '0')
+
+    fun uniqueCopyName(existing: Set<String>, original: String): String {
+        if (original !in existing) return original
+        val archive = archiveExtensionOf(original)
+        val stem = if (archive.isNotEmpty()) original.dropLast(archive.length) else {
+            val dot = original.lastIndexOf('.')
+            if (dot <= 0) original else original.substring(0, dot)
+        }
+        val suffix = if (archive.isNotEmpty()) archive else {
+            val dot = original.lastIndexOf('.')
+            if (dot <= 0) "" else original.substring(dot)
+        }
+        var index = 1
+        while (true) {
+            val candidate = if (index == 1) "$stem-复制$suffix" else "$stem-复制$index$suffix"
+            if (candidate !in existing) return candidate
+            index++
+        }
+    }
+
+    fun compressCommand(sources: List<String>, target: String): String {
+        require(sources.isNotEmpty()) { "缺少压缩项目" }
+        val quotedSources = sources.joinToString(" ") { SshRemoteOps.shellQuote(it) }
+        val quotedTarget = SshRemoteOps.shellQuote(target)
+        val lower = target.lowercase()
+        return when {
+            lower.endsWith(".zip") -> "zip -r -- $quotedTarget $quotedSources"
+            lower.endsWith(".tar.bz2") || lower.endsWith(".tbz2") -> "tar -cjf $quotedTarget $quotedSources"
+            lower.endsWith(".tar.xz") || lower.endsWith(".txz") -> "tar -cJf $quotedTarget $quotedSources"
+            else -> "tar -czf $quotedTarget $quotedSources"
+        }
+    }
+
+    fun extractCommand(archive: String, targetDir: String): String {
+        val quotedArchive = SshRemoteOps.shellQuote(archive)
+        val quotedDir = SshRemoteOps.shellQuote(targetDir)
+        val lower = archive.lowercase()
+        return when {
+            lower.endsWith(".zip") -> "mkdir -p $quotedDir && unzip -o $quotedArchive -d $quotedDir"
+            lower.endsWith(".tar.bz2") || lower.endsWith(".tbz2") || lower.endsWith(".bz2") ->
+                "mkdir -p $quotedDir && tar -xjf $quotedArchive -C $quotedDir"
+            lower.endsWith(".tar.xz") || lower.endsWith(".txz") || lower.endsWith(".xz") ->
+                "mkdir -p $quotedDir && tar -xJf $quotedArchive -C $quotedDir"
+            else -> "mkdir -p $quotedDir && tar -xzf $quotedArchive -C $quotedDir"
+        }
+    }
+
+    fun copyCommand(sources: List<String>, directory: String, cut: Boolean): String {
+        require(sources.isNotEmpty()) { "没有可粘贴的项目" }
+        val dest = SshRemoteOps.shellQuote(directory)
+        val quoted = sources.joinToString(" ") { SshRemoteOps.shellQuote(it) }
+        return if (cut) {
+            "mkdir -p $dest && mv -- $quoted $dest"
+        } else {
+            "mkdir -p $dest && cp -a -- $quoted $dest"
+        }
+    }
+
+    fun recursiveDeleteCommand(path: String): String {
+        require(path.isNotBlank() && path != "/") { "拒绝删除空路径或根目录" }
+        return "rm -rf -- ${SshRemoteOps.shellQuote(path)}"
+    }
+
+    fun treePropertiesCommand(path: String): String =
+        "python3 - <<'PY'\n" +
+            "import os, json\n" +
+            "root = ${jsonString(path)}\n" +
+            "size = 0\n" +
+            "files = 0\n" +
+            "dirs = 0\n" +
+            "mtime = 0\n" +
+            "try:\n" +
+            "    st = os.lstat(root)\n" +
+            "    mtime = int(st.st_mtime)\n" +
+            "    if os.path.isdir(root) and not os.path.islink(root):\n" +
+            "        for dirpath, dirnames, filenames in os.walk(root):\n" +
+            "            dirs += len(dirnames)\n" +
+            "            files += len(filenames)\n" +
+            "            for name in filenames:\n" +
+            "                fp = os.path.join(dirpath, name)\n" +
+            "                try:\n" +
+            "                    size += os.lstat(fp).st_size\n" +
+            "                except OSError:\n" +
+            "                    pass\n" +
+            "        dirs += 1\n" +
+            "    else:\n" +
+            "        files = 1\n" +
+            "        size = st.st_size\n" +
+            "except OSError as err:\n" +
+            "    print(json.dumps({'error': str(err)}))\n" +
+            "    raise SystemExit(1)\n" +
+            "print(json.dumps({'path': root, 'size': size, 'fileCount': files, 'dirCount': dirs, 'mtime': mtime}))\n" +
+            "PY"
+
+    fun parseTreeProperties(raw: String): RemoteTreeProperties {
+        val line = raw.lineSequence().map(String::trim).lastOrNull { it.startsWith("{") }
+            ?: error("属性响应无效")
+        val map = SshRemoteOps.parseFlatJsonObject(line)
+        if (map["error"]?.isNotBlank() == true) error(map.getValue("error"))
+        return RemoteTreeProperties(
+            path = map["path"].orEmpty(),
+            sizeBytes = map["size"]?.toLongOrNull() ?: 0L,
+            fileCount = map["fileCount"]?.toIntOrNull() ?: 0,
+            dirCount = map["dirCount"]?.toIntOrNull() ?: 0,
+            mtimeSec = map["mtime"]?.toLongOrNull() ?: 0L,
+        )
+    }
+
+    private fun jsonString(value: String): String =
+        "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+}
+
+data class RemoteTreeProperties(
+    val path: String,
+    val sizeBytes: Long,
+    val fileCount: Int,
+    val dirCount: Int,
+    val mtimeSec: Long,
+)

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
@@ -92,10 +92,11 @@ object SshRemoteOps {
         }
     }
 
-    fun dockerLogsCommand(container: String, tail: Int = 400, follow: Boolean = false): String {
+    fun dockerLogsCommand(container: String, tail: Int = 200, follow: Boolean = true): String {
         val flags = buildString {
             append("--tail ")
             append(tail.coerceIn(1, 2000))
+            append(" --timestamps")
             if (follow) append(" -f")
         }
         return "docker logs $flags ${shellQuote(container)}"

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
@@ -488,7 +488,7 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
      * Only string values are produced by that format; numbers and nested objects are stored as
      * their raw token text. That is enough for ID / Names / Status / Ports / Size.
      */
-    internal fun parseFlatJsonObject(raw: String): Map<String, String> {
+    fun parseFlatJsonObject(raw: String): Map<String, String> {
         val out = linkedMapOf<String, String>()
         val body = raw.trim().removePrefix("{").removeSuffix("}")
         var index = 0

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
@@ -284,10 +284,13 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
     }
 
     internal fun parseCpuStat(raw: String): CpuStat? {
-        val line = raw.lineSequence().firstOrNull { it.startsWith("cpu ") } ?: return null
-        val parts = line.trim().split(Regex("\\s+")).drop(1).mapNotNull(String::toLongOrNull)
-        if (parts.isEmpty()) return null
-        val idle = parts.getOrElse(3) { 0L } + parts.getOrElse(4) { 0L }
+        val line = raw.lineSequence()
+            .map(String::trim)
+            .firstOrNull { it.startsWith("cpu") && (it.length == 3 || it[3].isWhitespace()) }
+            ?: return null
+        val parts = line.split(Regex("\\s+")).drop(1).mapNotNull(String::toLongOrNull)
+        if (parts.size < 4) return null
+        val idle = parts[3] + parts.getOrElse(4) { 0L }
         return CpuStat(idle = idle, total = parts.sum())
     }
 

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt
@@ -1,0 +1,682 @@
+package one.zephyr.mobile.protocol.ssh
+
+/**
+ * Desktop-parity Docker / host-monitor command builders and parsers.
+ *
+ * The desktop terminal talks to `server.js` over WebSocket; Mobile already has a live SSH
+ * exec channel, so the same remote shell snippets run here and the JSON / marker output is
+ * parsed locally. Keeping the command text and the parsers in one file is what stops the
+ * drawer UI from inventing a second, thinner protocol.
+ */
+object SshRemoteOps {
+
+    const val MARKER_INSTALLED = "__DOCKER_INSTALLED__="
+    const val MARKER_SOCKET = "__DOCKER_SOCKET__="
+    const val MARKER_CPU = "__END_CPU__"
+    const val MARKER_MEM = "__END_MEM__"
+    const val MARKER_DISK = "__END_DISK__"
+    const val MARKER_DISKSTATS = "__END_DISKSTATS__"
+    const val MARKER_NET = "__END_NET__"
+    const val MARKER_IP4 = "__END_IP4__"
+    const val MARKER_IP6 = "__END_IP6__"
+    const val MARKER_CPUINFO = "__END_CPUINFO__"
+    const val MARKER_UNAME = "__END_UNAME__"
+    const val MARKER_PROC = "__END_PROC__"
+
+    val dockerCheckCommand: String = listOf(
+        "if command -v docker >/dev/null 2>&1; then",
+        "  echo ${MARKER_INSTALLED}1; docker --version 2>/dev/null || true;",
+        "  if [ -S /var/run/docker.sock ]; then echo ${MARKER_SOCKET}1; else echo ${MARKER_SOCKET}0; fi;",
+        "else echo ${MARKER_INSTALLED}0; fi",
+    ).joinToString(" ")
+
+    val dockerListContainersCommand: String =
+        "docker ps -a --no-trunc --format '{{json .}}'"
+
+    val dockerListImagesCommand: String =
+        "docker image ls --no-trunc --format '{{json .}}'"
+
+    val dockerMirrorsGetCommand: String =
+        "if [ -f /etc/docker/daemon.json ]; then cat /etc/docker/daemon.json; else printf '{}'; fi"
+
+    val dockerRestartServiceCommand: String = listOf(
+        "set -e",
+        "if [ \"\$(id -u)\" = \"0\" ]; then SUDO=\"\"; else SUDO=\"sudo -n\"; fi",
+        "if command -v systemctl >/dev/null 2>&1; then",
+        "  \$SUDO systemctl restart docker",
+        "elif command -v service >/dev/null 2>&1; then",
+        "  \$SUDO service docker restart",
+        "else",
+        "  echo \"未找到 systemctl/service，无法自动重启 Docker\" >&2",
+        "  exit 1",
+        "fi",
+        "echo \"Docker 服务已重启\"",
+    ).joinToString("\n")
+
+    val statsCommand: String = listOf(
+        "cat /proc/stat || true",
+        "printf '\\n$MARKER_CPU\\n'",
+        "cat /proc/meminfo || true",
+        "printf '\\n$MARKER_MEM\\n'",
+        "df -kP -x tmpfs -x devtmpfs -x squashfs -x overlay || true",
+        "printf '\\n$MARKER_DISK\\n'",
+        "cat /proc/diskstats || true",
+        "printf '\\n$MARKER_DISKSTATS\\n'",
+        "cat /proc/net/dev || true",
+        "printf '\\n$MARKER_NET\\n'",
+        "if command -v curl >/dev/null 2>&1; then curl -4 -fsS --connect-timeout 3 --max-time 5 https://api.ipify.org || curl -4 -fsS --connect-timeout 3 --max-time 5 https://ifconfig.me/ip || true; else true; fi",
+        "printf '\\n$MARKER_IP4\\n'",
+        "if command -v curl >/dev/null 2>&1; then curl -6 -fsS --connect-timeout 3 --max-time 5 https://api64.ipify.org || curl -6 -fsS --connect-timeout 3 --max-time 5 https://ifconfig.co/ip || true; else true; fi",
+        "printf '\\n$MARKER_IP6\\n'",
+        "cat /proc/cpuinfo || true",
+        "printf '\\n$MARKER_CPUINFO\\n'",
+        "uname -srmo 2>/dev/null || true",
+        "printf '\\n$MARKER_UNAME\\n'",
+        "ps -eo pid=,user=,pcpu=,pmem=,stat=,comm=,args= --sort=-pcpu 2>/dev/null | head -n 61 || true",
+        "printf '\\n$MARKER_PROC\\n'",
+        "hostname 2>/dev/null || true",
+    ).joinToString(" && ")
+
+    fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\\''") + "'"
+
+    fun dockerContainerActionCommand(action: DockerContainerAction, target: String): String {
+        val quoted = shellQuote(target)
+        return when (action) {
+            DockerContainerAction.START -> "docker start $quoted"
+            DockerContainerAction.STOP -> "docker stop $quoted"
+            DockerContainerAction.RESTART -> "docker restart $quoted"
+            DockerContainerAction.REMOVE -> "docker rm -f $quoted"
+            DockerContainerAction.PAUSE -> "docker pause $quoted"
+            DockerContainerAction.UNPAUSE -> "docker unpause $quoted"
+        }
+    }
+
+    fun dockerLogsCommand(container: String, tail: Int = 400, follow: Boolean = false): String {
+        val flags = buildString {
+            append("--tail ")
+            append(tail.coerceIn(1, 2000))
+            if (follow) append(" -f")
+        }
+        return "docker logs $flags ${shellQuote(container)}"
+    }
+
+    fun dockerUsedByCommand(image: String): String =
+        "docker ps -a --filter ${shellQuote("ancestor=$image")} --format '{{.ID}} {{.Names}}' || true"
+
+    fun dockerDeleteImageCommand(image: String, force: Boolean): String =
+        if (force) "docker rmi -f ${shellQuote(image)}" else "docker rmi ${shellQuote(image)}"
+
+    fun dockerPullCommand(image: String): String = "docker pull ${shellQuote(image)}"
+
+    fun dockerMirrorsSetCommand(mirrors: List<String>): String {
+        val encoded = java.util.Base64.getEncoder()
+            .encodeToString(jsonArray(mirrors.map(::sanitizeMirror)).toByteArray(Charsets.UTF_8))
+        return """
+set -e
+PY=$(command -v python3 || command -v python || true)
+[ -n "${'$'}PY" ] || { echo "目标主机需要 python3/python 才能安全更新 daemon.json" >&2; exit 1; }
+TMP=$(mktemp)
+OUT=$(mktemp)
+if [ -f /etc/docker/daemon.json ]; then cat /etc/docker/daemon.json > "${'$'}TMP"; else printf '{}' > "${'$'}TMP"; fi
+"${'$'}PY" - "${'$'}TMP" "${'$'}OUT" ${shellQuote(encoded)} <<'PY'
+import base64, json, sys
+src, out, encoded = sys.argv[1:4]
+try:
+    with open(src, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+except Exception:
+    data = {}
+if not isinstance(data, dict):
+    data = {}
+data['registry-mirrors'] = json.loads(base64.b64decode(encoded).decode('utf-8'))
+with open(out, 'w', encoding='utf-8') as fh:
+    json.dump(data, fh, ensure_ascii=False, indent=2)
+    fh.write('\n')
+PY
+if [ "${'$'}(id -u)" = "0" ]; then
+  mkdir -p /etc/docker && cp "${'$'}OUT" /etc/docker/daemon.json
+else
+  sudo -n mkdir -p /etc/docker && sudo -n cp "${'$'}OUT" /etc/docker/daemon.json
+fi
+rm -f "${'$'}TMP" "${'$'}OUT"
+echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效。"
+""".trimIndent()
+    }
+
+    fun processSignalCommand(pid: Int, signal: ProcessSignal): String {
+        require(pid > 1) { "PID 无效或不允许操作系统关键进程" }
+        val name = if (signal == ProcessSignal.KILL) "KILL" else "TERM"
+        return "kill -s $name $pid"
+    }
+
+    fun parseDockerStatus(raw: String): DockerEngineStatus {
+        val installed = raw.contains("${MARKER_INSTALLED}1")
+        val socket = raw.contains("${MARKER_SOCKET}1")
+        val version = raw.lineSequence()
+            .map(String::trim)
+            .firstOrNull { it.lowercase().startsWith("docker version") }
+            .orEmpty()
+        return DockerEngineStatus(installed = installed, socket = socket, version = version, raw = raw)
+    }
+
+    fun parseJsonLines(raw: String): List<Map<String, String>> =
+        raw.lineSequence()
+            .map(String::trim)
+            .filter { it.startsWith("{") && it.endsWith("}") }
+            .mapNotNull { line -> runCatching { parseFlatJsonObject(line) }.getOrNull() }
+            .toList()
+
+    fun parseDockerContainers(raw: String): List<DockerContainerInfo> =
+        parseJsonLines(raw).map { row ->
+            val id = first(row, "ID", "Id", "id")
+            val name = first(row, "Names", "Name", "names").trimStart('/')
+            val image = first(row, "Image", "image")
+            val status = first(row, "Status", "status")
+            val state = first(row, "State", "state").ifBlank {
+                if (status.contains("up", ignoreCase = true) || status.contains("running", ignoreCase = true)) {
+                    "running"
+                } else {
+                    "exited"
+                }
+            }
+            DockerContainerInfo(
+                id = id,
+                name = name.ifBlank { shortId(id) },
+                image = image,
+                status = status.ifBlank { state },
+                state = state,
+                ports = first(row, "Ports", "ports").ifBlank { "—" },
+                createdAt = first(row, "CreatedAt", "Created", "createdAt"),
+            )
+        }
+
+    fun parseDockerImages(raw: String): List<DockerImageInfo> =
+        parseJsonLines(raw).map { row ->
+            DockerImageInfo(
+                id = first(row, "ID", "Id", "ImageID", "id"),
+                repository = first(row, "Repository", "repository").ifBlank { "<none>" },
+                tag = first(row, "Tag", "tag").ifBlank { "<none>" },
+                size = first(row, "Size", "size"),
+                createdAt = first(row, "CreatedAt", "CreatedSince", "Created", "createdAt"),
+            )
+        }
+
+    fun parseDockerMirrors(raw: String): List<String> {
+        val text = raw.trim()
+        if (text.isEmpty()) return emptyList()
+        val key = "\"registry-mirrors\""
+        val keyIndex = text.indexOf(key)
+        if (keyIndex < 0) return emptyList()
+        val bracket = text.indexOf('[', keyIndex)
+        if (bracket < 0) return emptyList()
+        val end = text.indexOf(']', bracket)
+        if (end < 0) return emptyList()
+        val body = text.substring(bracket + 1, end)
+        return body.split(',')
+            .map { it.trim().trim('"').trim() }
+            .filter { it.startsWith("http://") || it.startsWith("https://") }
+            .distinct()
+    }
+
+    fun parseRemoteStats(raw: String, previous: HostStatsSample? = null, nowMs: Long = System.currentTimeMillis()): HostStatsSnapshot {
+        val sections = splitStatsSections(raw)
+        val cpuStat = parseCpuStat(sections.cpu)
+        val mem = parseMemory(sections.mem)
+        val disk = parseDisk(sections.disk)
+        val diskStats = parseDiskStats(sections.diskstats)
+        val netValues = parseNet(sections.net)
+        val elapsedSec = previous?.timestampMs?.let { (nowMs - it) / 1000.0 } ?: 0.0
+        val cpuUsage = computeCpuUsage(cpuStat, previous?.cpu)
+        val netRates = computeNetRates(netValues, previous?.net, elapsedSec)
+        val disks = computeDiskRates(disk, diskStats, previous?.diskStats, elapsedSec)
+        return HostStatsSnapshot(
+            hostName = sections.hostname.trim().ifBlank { "N/A" },
+            os = sections.uname.trim().ifBlank { "N/A" },
+            cpu = HostCpuInfo(
+                usagePercent = cpuUsage,
+                model = parseCpuModel(sections.cpuinfo),
+                freq = parseCpuFreq(sections.cpuinfo),
+                cores = parseCpuCores(sections.cpuinfo),
+            ),
+            memory = mem,
+            disks = disks,
+            network = netRates,
+            ipv4 = parseIp(sections.ip4),
+            ipv6 = parseIp(sections.ip6),
+            processes = parseProcesses(sections.processes),
+            sample = HostStatsSample(
+                cpu = cpuStat,
+                net = netValues,
+                diskStats = diskStats,
+                timestampMs = nowMs,
+            ),
+        )
+    }
+
+    fun shortId(id: String): String = id.removePrefix("sha256:").take(12)
+
+    fun sanitizeMirror(value: String): String = value.trim().trimEnd('/')
+
+    fun isValidMirror(value: String): Boolean {
+        val trimmed = sanitizeMirror(value)
+        return trimmed.startsWith("http://") || trimmed.startsWith("https://")
+    }
+
+    internal fun splitStatsSections(raw: String): StatsSections {
+        fun cut(source: String, marker: String): Pair<String, String> {
+            val idx = source.indexOf("\n$marker\n")
+            if (idx < 0) return source to ""
+            return source.substring(0, idx) to source.substring(idx + marker.length + 2)
+        }
+        val (cpu, rest1) = cut(raw, MARKER_CPU)
+        val (mem, rest2) = cut(rest1, MARKER_MEM)
+        val (disk, rest3) = cut(rest2, MARKER_DISK)
+        val (diskstats, rest4) = cut(rest3, MARKER_DISKSTATS)
+        val (net, rest5) = cut(rest4, MARKER_NET)
+        val (ip4, rest6) = cut(rest5, MARKER_IP4)
+        val (ip6, rest7) = cut(rest6, MARKER_IP6)
+        val (cpuinfo, rest8) = cut(rest7, MARKER_CPUINFO)
+        val (uname, rest9) = cut(rest8, MARKER_UNAME)
+        val (processes, hostname) = cut(rest9, MARKER_PROC)
+        return StatsSections(cpu, mem, disk, diskstats, net, ip4, ip6, cpuinfo, uname, processes, hostname)
+    }
+
+    internal fun parseCpuStat(raw: String): CpuStat? {
+        val line = raw.lineSequence().firstOrNull { it.startsWith("cpu ") } ?: return null
+        val parts = line.trim().split(Regex("\\s+")).drop(1).mapNotNull(String::toLongOrNull)
+        if (parts.isEmpty()) return null
+        val idle = parts.getOrElse(3) { 0L } + parts.getOrElse(4) { 0L }
+        return CpuStat(idle = idle, total = parts.sum())
+    }
+
+    internal fun parseMemory(raw: String): HostMemoryInfo {
+        var memTotal = 0.0
+        var memAvail = 0.0
+        var swapTotal = 0.0
+        var swapFree = 0.0
+        raw.lineSequence().forEach { line ->
+            when {
+                line.startsWith("MemTotal") -> memTotal = kibToMb(line)
+                line.startsWith("MemAvailable") -> memAvail = kibToMb(line)
+                line.startsWith("SwapTotal") -> swapTotal = kibToMb(line)
+                line.startsWith("SwapFree") -> swapFree = kibToMb(line)
+            }
+        }
+        return HostMemoryInfo(
+            memUsedMb = (memTotal - memAvail).coerceAtLeast(0.0),
+            memTotalMb = memTotal,
+            swapUsedMb = (swapTotal - swapFree).coerceAtLeast(0.0),
+            swapTotalMb = swapTotal,
+        )
+    }
+
+    internal fun parseDisk(raw: String): List<HostDiskDevice> {
+        return raw.trim().lineSequence().drop(1).mapNotNull { line ->
+            val parts = line.trim().split(Regex("\\s+"))
+            if (parts.size < 6) return@mapNotNull null
+            val filesystem = parts[0]
+            val blocks = parts[1].toDoubleOrNull() ?: return@mapNotNull null
+            val used = parts[2].toDoubleOrNull() ?: 0.0
+            val percent = parts[4].trimEnd('%').toIntOrNull() ?: 0
+            val mount = parts[5]
+            HostDiskDevice(
+                id = "disk-${filesystem.replace(Regex("[^A-Za-z0-9_-]"), "")}-${mount.replace(Regex("[^A-Za-z0-9_-]"), "")}",
+                filesystem = filesystem,
+                mountpoint = mount,
+                diskName = diskBaseName(filesystem),
+                usedGb = used / 1024.0 / 1024.0,
+                totalGb = blocks / 1024.0 / 1024.0,
+                percent = percent,
+                readKBps = 0.0,
+                writeKBps = 0.0,
+            )
+        }.toList()
+    }
+
+    internal fun parseDiskStats(raw: String): Map<String, DiskCounters> {
+        val stats = linkedMapOf<String, DiskCounters>()
+        raw.lineSequence().forEach { line ->
+            val parts = line.trim().split(Regex("\\s+"))
+            if (parts.size < 14) return@forEach
+            stats[parts[2]] = DiskCounters(
+                reads = parts[5].toLongOrNull() ?: 0L,
+                writes = parts[9].toLongOrNull() ?: 0L,
+            )
+        }
+        return stats
+    }
+
+    internal fun parseNet(raw: String): NetCounters {
+        var rx = 0L
+        var tx = 0L
+        raw.lineSequence().forEach { line ->
+            val cleaned = line.replace(":", " ")
+            val parts = cleaned.trim().split(Regex("\\s+"))
+            if (parts.size < 17) return@forEach
+            val iface = parts[0]
+            if (iface == "lo" || iface.startsWith("docker") || iface.startsWith("veth") || iface.startsWith("br-")) {
+                return@forEach
+            }
+            rx += parts[1].toLongOrNull() ?: 0L
+            tx += parts[9].toLongOrNull() ?: 0L
+        }
+        return NetCounters(rx = rx, tx = tx)
+    }
+
+    internal fun parseProcesses(raw: String): List<HostProcessInfo> =
+        raw.lineSequence().mapNotNull { line ->
+            val match = PROCESS_LINE.matchEntire(line.trim()) ?: return@mapNotNull null
+            HostProcessInfo(
+                pid = match.groupValues[1].toIntOrNull() ?: return@mapNotNull null,
+                user = match.groupValues[2],
+                cpuPercent = match.groupValues[3].toDoubleOrNull() ?: 0.0,
+                memPercent = match.groupValues[4].toDoubleOrNull() ?: 0.0,
+                stat = match.groupValues[5],
+                command = match.groupValues[6],
+                args = match.groupValues[7].ifBlank { match.groupValues[6] }.take(500),
+            )
+        }.filter { it.pid > 0 }.toList()
+
+    internal fun parseIp(raw: String): String {
+        raw.lineSequence().forEach { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) return@forEach
+            if (IPV4.matches(trimmed)) return trimmed
+            if (trimmed.contains(':') && HEX_ADDR.matches(trimmed.lowercase()) &&
+                !trimmed.startsWith("fe80", ignoreCase = true) && trimmed != "::1"
+            ) {
+                return trimmed
+            }
+        }
+        return "N/A"
+    }
+
+    internal fun parseCpuModel(raw: String): String =
+        raw.lineSequence().firstOrNull { it.startsWith("model name") }
+            ?.substringAfter(':')
+            ?.trim()
+            .orEmpty()
+            .ifBlank { "N/A" }
+
+    internal fun parseCpuFreq(raw: String): String {
+        val mhz = raw.lineSequence().firstOrNull { it.startsWith("cpu MHz") }
+            ?.substringAfter(':')
+            ?.trim()
+            ?.toDoubleOrNull()
+        return if (mhz == null) "N/A" else "${mhz.toInt()} MHz"
+    }
+
+    internal fun parseCpuCores(raw: String): Int {
+        val count = raw.lineSequence().count { it.startsWith("processor") }
+        return if (count == 0) 1 else count
+    }
+
+    internal fun computeCpuUsage(current: CpuStat?, previous: CpuStat?): Double {
+        if (current == null || previous == null) return 0.0
+        val totalDiff = current.total - previous.total
+        val idleDiff = current.idle - previous.idle
+        if (totalDiff <= 0L) return 0.0
+        return ((1.0 - idleDiff.toDouble() / totalDiff.toDouble()) * 100.0).coerceIn(0.0, 100.0)
+    }
+
+    internal fun computeNetRates(current: NetCounters, previous: NetCounters?, elapsedSec: Double): HostNetworkRates {
+        if (previous == null || elapsedSec <= 0.0) return HostNetworkRates(0.0, 0.0)
+        val rx = ((current.rx - previous.rx).coerceAtLeast(0L) * 8.0) / elapsedSec / 1024.0 / 1024.0
+        val tx = ((current.tx - previous.tx).coerceAtLeast(0L) * 8.0) / elapsedSec / 1024.0 / 1024.0
+        return HostNetworkRates(rxMbps = rx, txMbps = tx)
+    }
+
+    internal fun computeDiskRates(
+        devices: List<HostDiskDevice>,
+        current: Map<String, DiskCounters>,
+        previous: Map<String, DiskCounters>?,
+        elapsedSec: Double,
+    ): List<HostDiskDevice> = devices.map { device ->
+        val now = device.diskName?.let { current[it] }
+        val before = device.diskName?.let { previous?.get(it) }
+        if (now == null || before == null || elapsedSec <= 0.0) return@map device
+        val read = (now.reads - before.reads).coerceAtLeast(0L) / 2.0 / elapsedSec
+        val write = (now.writes - before.writes).coerceAtLeast(0L) / 2.0 / elapsedSec
+        device.copy(readKBps = read, writeKBps = write)
+    }
+
+    internal data class StatsSections(
+        val cpu: String,
+        val mem: String,
+        val disk: String,
+        val diskstats: String,
+        val net: String,
+        val ip4: String,
+        val ip6: String,
+        val cpuinfo: String,
+        val uname: String,
+        val processes: String,
+        val hostname: String,
+    )
+
+    private fun kibToMb(line: String): Double =
+        (line.split(Regex("\\s+")).getOrNull(1)?.toDoubleOrNull() ?: 0.0) / 1024.0
+
+    private fun diskBaseName(filesystem: String): String? {
+        if (filesystem.isBlank()) return null
+        val name = filesystem.removePrefix("/dev/").removePrefix("mapper/")
+        return when {
+            Regex("""^nvme\d+n\d+p\d+$""").matches(name) -> name.replace(Regex("p\\d+$"), "")
+            Regex("""^mmcblk\d+p\d+$""").matches(name) -> name.replace(Regex("p\\d+$"), "")
+            else -> name.replace(Regex("\\d+$"), "")
+        }
+    }
+
+    private fun first(row: Map<String, String>, vararg keys: String): String {
+        for (key in keys) {
+            val value = row[key]
+            if (!value.isNullOrBlank()) return value
+        }
+        return ""
+    }
+
+    private fun jsonArray(values: List<String>): String =
+        values.joinToString(prefix = "[", postfix = "]") { value ->
+            "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        }
+
+    /**
+     * Tiny object parser for `docker --format '{{json .}}'` lines.
+     *
+     * Only string values are produced by that format; numbers and nested objects are stored as
+     * their raw token text. That is enough for ID / Names / Status / Ports / Size.
+     */
+    internal fun parseFlatJsonObject(raw: String): Map<String, String> {
+        val out = linkedMapOf<String, String>()
+        val body = raw.trim().removePrefix("{").removeSuffix("}")
+        var index = 0
+        fun skipWs() {
+            while (index < body.length && body[index].isWhitespace()) index++
+        }
+        fun readString(): String {
+            require(body[index] == '"') { "expected string" }
+            index++
+            val built = StringBuilder()
+            while (index < body.length) {
+                val ch = body[index++]
+                when (ch) {
+                    '\\' -> {
+                        if (index >= body.length) break
+                        val next = body[index++]
+                        built.append(
+                            when (next) {
+                                'n' -> '\n'
+                                't' -> '\t'
+                                'r' -> '\r'
+                                '"' -> '"'
+                                '\\' -> '\\'
+                                'u' -> {
+                                    val hex = body.substring(index, (index + 4).coerceAtMost(body.length))
+                                    index += hex.length
+                                    hex.toIntOrNull(16)?.toChar() ?: '?'
+                                }
+                                else -> next
+                            },
+                        )
+                    }
+                    '"' -> return built.toString()
+                    else -> built.append(ch)
+                }
+            }
+            return built.toString()
+        }
+        fun readToken(): String {
+            val start = index
+            var depth = 0
+            while (index < body.length) {
+                val ch = body[index]
+                if (ch == '{' || ch == '[') depth++
+                if (ch == '}' || ch == ']') {
+                    if (depth == 0) break
+                    depth--
+                }
+                if (ch == ',' && depth == 0) break
+                index++
+            }
+            return body.substring(start, index).trim().trim('"')
+        }
+        while (index < body.length) {
+            skipWs()
+            if (index >= body.length) break
+            if (body[index] != '"') {
+                index++
+                continue
+            }
+            val key = readString()
+            skipWs()
+            if (index >= body.length || body[index] != ':') break
+            index++
+            skipWs()
+            val value = if (index < body.length && body[index] == '"') readString() else readToken()
+            out[key] = value
+            skipWs()
+            if (index < body.length && body[index] == ',') index++
+        }
+        return out
+    }
+
+    private val PROCESS_LINE =
+        Regex("""^(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\S+)\s+(\S+)\s*(.*)$""")
+    private val IPV4 = Regex("""^(?:\d{1,3}\.){3}\d{1,3}$""")
+    private val HEX_ADDR = Regex("""^[0-9a-f:]+$""")
+}
+
+enum class DockerContainerAction { START, STOP, RESTART, REMOVE, PAUSE, UNPAUSE }
+
+enum class ProcessSignal { TERM, KILL }
+
+data class DockerEngineStatus(
+    val installed: Boolean,
+    val socket: Boolean,
+    val version: String,
+    val raw: String = "",
+)
+
+data class DockerContainerInfo(
+    val id: String,
+    val name: String,
+    val image: String,
+    val status: String,
+    val state: String,
+    val ports: String,
+    val createdAt: String,
+) {
+    val running: Boolean
+        get() = state.equals("running", ignoreCase = true) ||
+            status.contains("up", ignoreCase = true) ||
+            status.contains("running", ignoreCase = true)
+
+    val target: String get() = id.ifBlank { name }
+}
+
+data class DockerImageInfo(
+    val id: String,
+    val repository: String,
+    val tag: String,
+    val size: String,
+    val createdAt: String,
+) {
+    val reference: String
+        get() = if (repository != "<none>" && tag != "<none>" && repository.isNotBlank()) {
+            "$repository:$tag"
+        } else {
+            id
+        }
+}
+
+data class CpuStat(val idle: Long, val total: Long)
+
+data class NetCounters(val rx: Long, val tx: Long)
+
+data class DiskCounters(val reads: Long, val writes: Long)
+
+data class HostStatsSample(
+    val cpu: CpuStat?,
+    val net: NetCounters,
+    val diskStats: Map<String, DiskCounters>,
+    val timestampMs: Long,
+)
+
+data class HostCpuInfo(
+    val usagePercent: Double,
+    val model: String,
+    val freq: String,
+    val cores: Int,
+)
+
+data class HostMemoryInfo(
+    val memUsedMb: Double,
+    val memTotalMb: Double,
+    val swapUsedMb: Double,
+    val swapTotalMb: Double,
+) {
+    val memPercent: Double
+        get() = if (memTotalMb <= 0.0) 0.0 else (memUsedMb / memTotalMb * 100.0).coerceIn(0.0, 100.0)
+
+    val swapPercent: Double
+        get() = if (swapTotalMb <= 0.0) 0.0 else (swapUsedMb / swapTotalMb * 100.0).coerceIn(0.0, 100.0)
+}
+
+data class HostDiskDevice(
+    val id: String,
+    val filesystem: String,
+    val mountpoint: String,
+    val diskName: String?,
+    val usedGb: Double,
+    val totalGb: Double,
+    val percent: Int,
+    val readKBps: Double,
+    val writeKBps: Double,
+)
+
+data class HostNetworkRates(val rxMbps: Double, val txMbps: Double)
+
+data class HostProcessInfo(
+    val pid: Int,
+    val user: String,
+    val cpuPercent: Double,
+    val memPercent: Double,
+    val stat: String,
+    val command: String,
+    val args: String,
+)
+
+data class HostStatsSnapshot(
+    val hostName: String,
+    val os: String,
+    val cpu: HostCpuInfo,
+    val memory: HostMemoryInfo,
+    val disks: List<HostDiskDevice>,
+    val network: HostNetworkRates,
+    val ipv4: String,
+    val ipv6: String,
+    val processes: List<HostProcessInfo>,
+    val sample: HostStatsSample,
+    val capturedAt: Long = sample.timestampMs,
+)

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -40,7 +40,11 @@ class SshRemoteFileConflict(
     val remoteModifiedAt: Long,
 ) : IllegalStateException("远端文件已变化：$path")
 
-private const val MAX_FILE_WRITE_BYTES = 1024 * 1024
+private const val MAX_FILE_WRITE_BYTES = 8 * 1024 * 1024
+private const val MAX_FILE_RANGE_BYTES = 32 * 1024 * 1024
+private const val DEFAULT_NEW_FILE_MODE = 0x1A4 // 0644
+
+
 
 /** Live direct SSH transport: shell, SFTP, exec and request/reply latency probes. */
 class SshjEngine(
@@ -202,24 +206,36 @@ class SshjEngine(
         }
     }
 
-    override suspend fun readFile(sessionId: String, path: String, maxBytes: Int): Result<SshRemoteFile> = withContext(io) {
+    override suspend fun readFile(sessionId: String, path: String, maxBytes: Int): Result<SshRemoteFile> =
+        readFileRange(sessionId, path, offset = 0L, maxBytes = maxBytes)
+
+    override suspend fun readFileRange(
+        sessionId: String,
+        path: String,
+        offset: Long,
+        maxBytes: Int,
+    ): Result<SshRemoteFile> = withContext(io) {
         runCatching {
-            require(maxBytes in 1..MAX_FILE_WRITE_BYTES) { "读取上限无效" }
+            require(offset >= 0L) { "读取偏移无效" }
+            require(maxBytes in 1..MAX_FILE_RANGE_BYTES) { "读取上限无效" }
             val live = sessions[sessionId] ?: error("SSH 会话已断开")
             live.client.newSFTPClient().use { sftp ->
                 val canonicalPath = sftp.canonicalize(path)
                 val attrs = sftp.stat(canonicalPath)
-                require(attrs.type == FileMode.Type.REGULAR) { "只能编辑普通文件" }
-                require(attrs.size <= maxBytes) { "文件过大，当前读取上限 ${maxBytes} bytes" }
-                val bytes = ByteArray(attrs.size.toInt())
-                sftp.open(canonicalPath, EnumSet.of(OpenMode.READ)).use { remote ->
-                    var offset = 0
-                    while (offset < bytes.size) {
-                        val read = remote.read(offset.toLong(), bytes, offset, bytes.size - offset)
-                        if (read <= 0) break
-                        offset += read
+                require(attrs.type == FileMode.Type.REGULAR) { "只能读取普通文件" }
+                val remaining = (attrs.size - offset).coerceAtLeast(0L)
+                val count = minOf(remaining, maxBytes.toLong()).toInt()
+                val bytes = ByteArray(count)
+                if (count > 0) {
+                    sftp.open(canonicalPath, EnumSet.of(OpenMode.READ)).use { remote ->
+                        var done = 0
+                        while (done < bytes.size) {
+                            val read = remote.read(offset + done, bytes, done, bytes.size - done)
+                            if (read <= 0) break
+                            done += read
+                        }
+                        require(done == bytes.size) { "远端文件读取不完整" }
                     }
-                    require(offset == bytes.size) { "远端文件读取不完整" }
                 }
                 SshRemoteFile(
                     path = canonicalPath,
@@ -242,23 +258,50 @@ class SshjEngine(
             require(bytes.size <= MAX_FILE_WRITE_BYTES) { "写入内容过大，当前上限 $MAX_FILE_WRITE_BYTES bytes" }
             val live = sessions[sessionId] ?: error("SSH 会话已断开")
             live.client.newSFTPClient().use { sftp ->
-                val canonicalPath = sftp.canonicalize(path)
-                val before = sftp.stat(canonicalPath)
-                if (expected != null && (before.size != expected.size || before.mtime * 1_000L != expected.modifiedAt)) {
-                    throw SshRemoteFileConflict(canonicalPath, before.size, before.mtime * 1_000L)
+                val leaf = path.substringAfterLast('/').ifBlank { path }
+                val parent = when {
+                    path == leaf -> ""
+                    path.lastIndexOf('/') <= 0 -> "/"
+                    else -> path.substringBeforeLast('/')
                 }
+                val canonicalParent = when {
+                    parent.isEmpty() -> sftp.canonicalize(".")
+                    parent == "/" -> "/"
+                    else -> sftp.canonicalize(parent)
+                }
+                val canonicalPath = if (leaf.isEmpty() || leaf == "/") {
+                    canonicalParent
+                } else if (canonicalParent == "/") {
+                    "/$leaf"
+                } else {
+                    "$canonicalParent/$leaf"
+                }
+                val before = runCatching { sftp.stat(canonicalPath) }.getOrNull()
+                if (expected != null) {
+                    if (before == null) {
+                        throw SshRemoteFileConflict(canonicalPath, 0L, 0L)
+                    }
+                    if (before.size != expected.size || before.mtime * 1_000L != expected.modifiedAt) {
+                        throw SshRemoteFileConflict(canonicalPath, before.size, before.mtime * 1_000L)
+                    }
+                }
+                val mode = before?.mode?.mask?.and(0xFFF) ?: DEFAULT_NEW_FILE_MODE
                 val temporary = "$canonicalPath.zephyr-${java.util.UUID.randomUUID()}.tmp"
                 try {
                     sftp.open(temporary, EnumSet.of(OpenMode.WRITE, OpenMode.CREAT, OpenMode.TRUNC)).use { remote ->
-                        var offset = 0
-                        while (offset < bytes.size) {
-                            val count = minOf(32 * 1024, bytes.size - offset)
-                            remote.write(offset.toLong(), bytes, offset, count)
-                            offset += count
+                        var written = 0
+                        while (written < bytes.size) {
+                            val count = minOf(32 * 1024, bytes.size - written)
+                            remote.write(written.toLong(), bytes, written, count)
+                            written += count
                         }
                     }
-                    sftp.chmod(temporary, before.mode.mask and 0xFFF)
-                    sftp.rename(temporary, canonicalPath, EnumSet.of(RenameFlags.OVERWRITE))
+                    sftp.chmod(temporary, mode)
+                    if (before == null) {
+                        sftp.rename(temporary, canonicalPath)
+                    } else {
+                        sftp.rename(temporary, canonicalPath, EnumSet.of(RenameFlags.OVERWRITE))
+                    }
                 } catch (failure: Throwable) {
                     runCatching { sftp.rm(temporary) }
                     throw failure
@@ -268,6 +311,9 @@ class SshjEngine(
             }
         }
     }
+
+    override suspend fun chmod(sessionId: String, path: String, mode: Int): Result<Unit> =
+        sftpUnit(sessionId) { chmod(path, mode and 0xFFF) }
 
     private suspend fun sftpUnit(
         sessionId: String,

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -42,7 +42,9 @@ class SshRemoteFileConflict(
 
 private const val MAX_FILE_WRITE_BYTES = 8 * 1024 * 1024
 private const val MAX_FILE_RANGE_BYTES = 32 * 1024 * 1024
+private const val STREAM_CHUNK_BYTES = 256 * 1024
 private const val DEFAULT_NEW_FILE_MODE = 0x1A4 // 0644
+
 
 
 
@@ -356,6 +358,133 @@ class SshjEngine(
                     remote.join()
                     SshExecResult(remote.exitStatus ?: -1, stdout.await(), stderr.await())
                 }
+            }
+        }
+    }
+
+    override fun execStream(sessionId: String, command: String): Flow<SshExecEvent> = callbackFlow {
+        require(command.isNotBlank()) { "远程命令不能为空" }
+        val live = sessions[sessionId] ?: error("SSH 会话已断开")
+        val commandSession = live.client.startSession()
+        val remote = commandSession.exec(command)
+        val stdoutJob = scope.launch {
+            val buffer = ByteArray(16 * 1024)
+            val input = remote.inputStream
+            while (true) {
+                val read = runCatching { input.read(buffer) }.getOrDefault(-1)
+                if (read < 0) break
+                if (read > 0) trySend(SshExecEvent.Stdout(buffer.copyOf(read)))
+            }
+        }
+        val stderrJob = scope.launch {
+            val buffer = ByteArray(8 * 1024)
+            val input = remote.errorStream
+            while (true) {
+                val read = runCatching { input.read(buffer) }.getOrDefault(-1)
+                if (read < 0) break
+                if (read > 0) trySend(SshExecEvent.Stderr(buffer.copyOf(read)))
+            }
+        }
+        val joinJob = scope.launch {
+            runCatching { remote.join() }
+            stdoutJob.join()
+            stderrJob.join()
+            trySend(SshExecEvent.Closed(remote.exitStatus ?: -1))
+            close()
+        }
+        awaitClose {
+            joinJob.cancel()
+            stdoutJob.cancel()
+            stderrJob.cancel()
+            runCatching { remote.close() }
+            runCatching { commandSession.close() }
+        }
+    }
+
+    override suspend fun readFileStream(
+        sessionId: String,
+        path: String,
+        offset: Long,
+        onChunk: suspend (offset: Long, bytes: ByteArray, total: Long) -> Unit,
+    ): Result<SshRemoteFileVersion> = withContext(io) {
+        runCatching {
+            require(offset >= 0L) { "读取偏移无效" }
+            val live = sessions[sessionId] ?: error("SSH 会话已断开")
+            live.client.newSFTPClient().use { sftp ->
+                val canonicalPath = sftp.canonicalize(path)
+                val attrs = sftp.stat(canonicalPath)
+                require(attrs.type == FileMode.Type.REGULAR) { "只能读取普通文件" }
+                sftp.open(canonicalPath, EnumSet.of(OpenMode.READ)).use { remote ->
+                    var cursor = offset
+                    val buffer = ByteArray(STREAM_CHUNK_BYTES)
+                    while (cursor < attrs.size) {
+                        val want = minOf(buffer.size.toLong(), attrs.size - cursor).toInt()
+                        val read = remote.read(cursor, buffer, 0, want)
+                        if (read <= 0) break
+                        onChunk(cursor, buffer.copyOf(read), attrs.size)
+                        cursor += read
+                    }
+                }
+                SshRemoteFileVersion(canonicalPath, attrs.size, attrs.mtime * 1_000L)
+            }
+        }
+    }
+
+    override suspend fun writeFileStream(
+        sessionId: String,
+        path: String,
+        expected: SshRemoteFileVersion?,
+        next: suspend () -> ByteArray?,
+    ): Result<SshRemoteFileVersion> = withContext(io) {
+        runCatching {
+            val live = sessions[sessionId] ?: error("SSH 会话已断开")
+            live.client.newSFTPClient().use { sftp ->
+                val leaf = path.substringAfterLast('/').ifBlank { path }
+                val parent = when {
+                    path == leaf -> ""
+                    path.lastIndexOf('/') <= 0 -> "/"
+                    else -> path.substringBeforeLast('/')
+                }
+                val canonicalParent = when {
+                    parent.isEmpty() -> sftp.canonicalize(".")
+                    parent == "/" -> "/"
+                    else -> sftp.canonicalize(parent)
+                }
+                val canonicalPath = if (leaf.isEmpty() || leaf == "/") {
+                    canonicalParent
+                } else if (canonicalParent == "/") {
+                    "/$leaf"
+                } else {
+                    "$canonicalParent/$leaf"
+                }
+                val before = runCatching { sftp.stat(canonicalPath) }.getOrNull()
+                if (expected != null) {
+                    if (before == null) throw SshRemoteFileConflict(canonicalPath, 0L, 0L)
+                    if (before.size != expected.size || before.mtime * 1_000L != expected.modifiedAt) {
+                        throw SshRemoteFileConflict(canonicalPath, before.size, before.mtime * 1_000L)
+                    }
+                }
+                val mode = before?.mode?.mask?.and(0xFFF) ?: DEFAULT_NEW_FILE_MODE
+                val temporary = "$canonicalPath.zephyr-${java.util.UUID.randomUUID()}.tmp"
+                try {
+                    sftp.open(temporary, EnumSet.of(OpenMode.WRITE, OpenMode.CREAT, OpenMode.TRUNC)).use { remote ->
+                        var written = 0L
+                        while (true) {
+                            val chunk = next() ?: break
+                            if (chunk.isEmpty()) continue
+                            remote.write(written, chunk, 0, chunk.size)
+                            written += chunk.size
+                        }
+                    }
+                    sftp.chmod(temporary, mode)
+                    if (before == null) sftp.rename(temporary, canonicalPath)
+                    else sftp.rename(temporary, canonicalPath, EnumSet.of(RenameFlags.OVERWRITE))
+                } catch (failure: Throwable) {
+                    runCatching { sftp.rm(temporary) }
+                    throw failure
+                }
+                val after = sftp.stat(canonicalPath)
+                SshRemoteFileVersion(canonicalPath, after.size, after.mtime * 1_000L)
             }
         }
     }

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshFileKindsTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshFileKindsTest.kt
@@ -1,0 +1,90 @@
+package one.zephyr.mobile.protocol.ssh
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SshFileKindsTest {
+
+    @Test
+    fun desktopExtensionTablesClassifyPreviewTargets() {
+        assertTrue(SshFileKinds.isImage("/var/www/logo.PNG"))
+        assertTrue(SshFileKinds.isImage("photo.heic"))
+        assertTrue(SshFileKinds.isVideo("clip.mkv"))
+        assertTrue(SshFileKinds.isAudio("track.flac"))
+        assertTrue(SshFileKinds.isMedia("movie.mp4"))
+        assertTrue(SshFileKinds.isArchive("backup.tar.gz"))
+        assertTrue(SshFileKinds.isArchive("app.apk"))
+        assertTrue(SshFileKinds.isText("nginx.conf"))
+        assertTrue(SshFileKinds.isText("README"))
+        assertFalse(SshFileKinds.isText("payload.bin"))
+        assertEquals(".tar.gz", SshFileKinds.archiveExtensionOf("db.dump.tar.gz"))
+    }
+
+    @Test
+    fun octalModeRoundTripsAndRejectsGarbage() {
+        assertEquals(0b110_100_100, SshFileKinds.decodeOctalMode("644"))
+        assertEquals(0b111_101_101, SshFileKinds.decodeOctalMode("0755"))
+        assertEquals("644", SshFileKinds.formatOctalMode(420))
+        try {
+            SshFileKinds.decodeOctalMode("999")
+            throw AssertionError("invalid mode accepted")
+        } catch (_: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun copyNamesAppendChineseCopySuffixWithoutClobberingArchives() {
+        val existing = setOf("notes.txt", "notes-复制.txt")
+        assertEquals("notes-复制2.txt", SshFileKinds.uniqueCopyName(existing, "notes.txt"))
+        assertEquals(
+            "backup-复制.tar.gz",
+            SshFileKinds.uniqueCopyName(setOf("backup.tar.gz"), "backup.tar.gz"),
+        )
+    }
+
+    @Test
+    fun compressExtractCopyAndDeleteCommandsMatchDesktopShell() {
+        assertEquals(
+            "tar -czf '/tmp/a.tar.gz' '/var/log' '/etc/nginx'",
+            SshFileKinds.compressCommand(listOf("/var/log", "/etc/nginx"), "/tmp/a.tar.gz"),
+        )
+        assertEquals(
+            "zip -r -- '/tmp/a.zip' '/var/log'",
+            SshFileKinds.compressCommand(listOf("/var/log"), "/tmp/a.zip"),
+        )
+        assertTrue(SshFileKinds.extractCommand("/tmp/a.zip", "/tmp/out").contains("unzip -o"))
+        assertTrue(SshFileKinds.extractCommand("/tmp/a.tar.gz", "/tmp/out").contains("tar -xzf"))
+        assertEquals(
+            "mkdir -p '/home/me' && cp -a -- '/src/a' '/home/me'",
+            SshFileKinds.copyCommand(listOf("/src/a"), "/home/me", cut = false),
+        )
+        assertEquals(
+            "mkdir -p '/home/me' && mv -- '/src/a' '/home/me'",
+            SshFileKinds.copyCommand(listOf("/src/a"), "/home/me", cut = true),
+        )
+        assertEquals("rm -rf -- '/tmp/old'", SshFileKinds.recursiveDeleteCommand("/tmp/old"))
+        try {
+            SshFileKinds.recursiveDeleteCommand("/")
+            throw AssertionError("root delete accepted")
+        } catch (_: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun treePropertiesParseJsonAndSurfaceRemoteErrors() {
+        val parsed = SshFileKinds.parseTreeProperties(
+            """{"path":"/var/log","size":4096,"fileCount":12,"dirCount":3,"mtime":1700000000}""",
+        )
+        assertEquals("/var/log", parsed.path)
+        assertEquals(4096L, parsed.sizeBytes)
+        assertEquals(12, parsed.fileCount)
+        try {
+            SshFileKinds.parseTreeProperties("""{"error":"Permission denied"}""")
+            throw AssertionError("error object accepted")
+        } catch (error: IllegalStateException) {
+            assertEquals("Permission denied", error.message)
+        }
+    }
+}

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOpsTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOpsTest.kt
@@ -117,12 +117,18 @@ class SshRemoteOpsTest {
             hostname = "edge-01",
         )
         val first = SshRemoteOps.parseRemoteStats(raw, previous = null, nowMs = 1_000L)
+        val firstCpu = SshRemoteOps.parseCpuStat("cpu  100 20 30 850 0 0 0 0 0 0")
+        val laterCpuLine = "cpu  200 40 60 900 0 0 0 0 0 0"
+        val laterCpu = SshRemoteOps.parseCpuStat(laterCpuLine)
+        assertTrue("first /proc/stat tick must parse", first.sample.cpu != null && firstCpu != null)
+        assertTrue("second /proc/stat tick must parse", laterCpu != null)
+        assertEquals(firstCpu!!.total, first.sample.cpu!!.total)
+        assertEquals(0.0, first.cpu.usagePercent, 0.001)
         assertEquals("edge-01", first.hostName)
         assertEquals("Linux 6.8.0 x86_64 GNU/Linux", first.os)
         assertEquals("Test CPU", first.cpu.model)
         assertEquals("2400 MHz", first.cpu.freq)
         assertEquals(2, first.cpu.cores)
-        assertEquals(0.0, first.cpu.usagePercent, 0.001)
         assertEquals(2000000.0 / 1024.0 - 500000.0 / 1024.0, first.memory.memUsedMb, 0.01)
         assertEquals(1, first.disks.size)
         assertEquals("/", first.disks.single().mountpoint)
@@ -133,13 +139,12 @@ class SshRemoteOpsTest {
         assertEquals(42, first.processes[0].pid)
         assertEquals("sshd", first.processes[0].command)
 
-        val laterCpu = "cpu  200 40 60 900 0 0 0 0 0 0"
         val later = SshRemoteOps.parseRemoteStats(
             buildStatsRaw(
-                cpu = laterCpu,
+                cpu = laterCpuLine,
                 mem = "MemTotal:        2000000 kB\nMemAvailable:     500000 kB\nSwapTotal:     1000000 kB\nSwapFree:       250000 kB",
                 disk = "Filesystem     1024-blocks     Used Available Capacity Mounted on\n/dev/sda1        104857600 52428800  52428800      50% /",
-                diskstats = "   8       0 sda 0 0 0 0 0 0 400 0 0 0 0 0 0 800",
+                diskstats = "   8       0 sda 0 0 400 0 0 0 800 0 0 0 0 0 0 0",
                 net = "Inter-|   Receive                                                |  Transmit\n eth0: 25000000 0 0 0 0 0 0 0 5000000 0 0 0 0 0 0 0",
                 ip4 = "203.0.113.10",
                 ip6 = "2001:db8::1",
@@ -151,11 +156,12 @@ class SshRemoteOpsTest {
             previous = first.sample,
             nowMs = 3_000L,
         )
-        assertEquals(75.0, later.cpu.usagePercent, 0.01)
-        assertTrue(later.network.rxMbps > 0.0)
-        assertTrue(later.network.txMbps > 0.0)
-        assertTrue(later.disks.single().readKBps > 0.0)
-        assertTrue(later.disks.single().writeKBps > 0.0)
+        val expectedCpu = SshRemoteOps.computeCpuUsage(laterCpu, firstCpu)
+        assertEquals(expectedCpu, later.cpu.usagePercent, 0.01)
+        assertTrue("second tick must show busy CPU, got ${later.cpu.usagePercent}", later.cpu.usagePercent > 1.0)
+        assertTrue("rx ${later.network.rxMbps}", later.network.rxMbps > 0.0)
+        assertTrue("tx ${later.network.txMbps}", later.network.txMbps > 0.0)
+        assertTrue("disk write ${later.disks.single().writeKBps}", later.disks.single().writeKBps > 0.0)
     }
 
     @Test

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOpsTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOpsTest.kt
@@ -85,6 +85,11 @@ class SshRemoteOpsTest {
         val quoted = SshRemoteOps.shellQuote("it's")
         assertEquals("'it'\\''s'", quoted)
         assertTrue(SshRemoteOps.dockerPullCommand("nginx:alpine").contains("'nginx:alpine'"))
+        val logs = SshRemoteOps.dockerLogsCommand("web")
+        assertTrue(logs.contains("--timestamps"))
+        assertTrue(logs.contains(" -f "))
+        assertTrue(logs.contains("'web'"))
+        assertFalse(SshRemoteOps.dockerLogsCommand("web", follow = false).contains(" -f"))
     }
 
     @Test

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOpsTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOpsTest.kt
@@ -1,0 +1,203 @@
+package one.zephyr.mobile.protocol.ssh
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SshRemoteOpsTest {
+
+    @Test
+    fun dockerStatusDetectsInstalledSocketAndVersion() {
+        val status = SshRemoteOps.parseDockerStatus(
+            """
+            __DOCKER_INSTALLED__=1
+            Docker version 27.1.1, build 1234
+            __DOCKER_SOCKET__=1
+            """.trimIndent(),
+        )
+        assertTrue(status.installed)
+        assertTrue(status.socket)
+        assertEquals("Docker version 27.1.1, build 1234", status.version)
+    }
+
+    @Test
+    fun dockerStatusDoesNotPretendInstalledWhenBinaryMissing() {
+        val status = SshRemoteOps.parseDockerStatus("__DOCKER_INSTALLED__=0\n")
+        assertFalse(status.installed)
+        assertFalse(status.socket)
+        assertEquals("", status.version)
+    }
+
+    @Test
+    fun dockerJsonLinesBecomeContainersAndImages() {
+        val containers = SshRemoteOps.parseDockerContainers(
+            """
+            {"ID":"abc123def456","Names":"/nginx","Image":"nginx:alpine","Status":"Up 3 hours","State":"running","Ports":"80/tcp","CreatedAt":"2026-08-01"}
+            not-json
+            {"ID":"deadbeef0001","Names":"worker","Image":"busybox","Status":"Exited (0)","State":"exited","Ports":"","CreatedAt":"2026-08-02"}
+            """.trimIndent(),
+        )
+        assertEquals(2, containers.size)
+        assertEquals("nginx", containers[0].name)
+        assertTrue(containers[0].running)
+        assertFalse(containers[1].running)
+        assertEquals("abc123def456", containers[0].target)
+
+        val images = SshRemoteOps.parseDockerImages(
+            """{"ID":"sha256:0123456789abcdef","Repository":"nginx","Tag":"alpine","Size":"12MB","CreatedAt":"3 days ago"}""",
+        )
+        assertEquals("nginx:alpine", images.single().reference)
+        assertEquals("0123456789ab", SshRemoteOps.shortId(images.single().id))
+    }
+
+    @Test
+    fun dockerMirrorsAreReadFromDaemonJson() {
+        val mirrors = SshRemoteOps.parseDockerMirrors(
+            """
+            {
+              "log-driver": "json-file",
+              "registry-mirrors": [
+                "https://mirror.ccs.tencentyun.com",
+                "https://docker.m.daocloud.io/"
+              ]
+            }
+            """.trimIndent(),
+        )
+        assertEquals(
+            listOf("https://mirror.ccs.tencentyun.com", "https://docker.m.daocloud.io/"),
+            mirrors,
+        )
+        assertTrue(SshRemoteOps.isValidMirror("https://example.com/v2"))
+        assertFalse(SshRemoteOps.isValidMirror("ftp://bad"))
+    }
+
+    @Test
+    fun containerActionAndSignalsRefuseDangerousTargets() {
+        assertEquals("docker start 'web'", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.START, "web"))
+        assertEquals("docker rm -f 'web'", SshRemoteOps.dockerContainerActionCommand(DockerContainerAction.REMOVE, "web"))
+        assertEquals("kill -s TERM 42", SshRemoteOps.processSignalCommand(42, ProcessSignal.TERM))
+        try {
+            SshRemoteOps.processSignalCommand(1, ProcessSignal.KILL)
+            throw AssertionError("pid 1 must be rejected")
+        } catch (_: IllegalArgumentException) {
+        }
+        val quoted = SshRemoteOps.shellQuote("it's")
+        assertEquals("'it'\\''s'", quoted)
+        assertTrue(SshRemoteOps.dockerPullCommand("nginx:alpine").contains("'nginx:alpine'"))
+    }
+
+    @Test
+    fun mirrorsSetScriptEmbedsBase64PayloadAndKeepsExistingKeys() {
+        val script = SshRemoteOps.dockerMirrorsSetCommand(listOf("https://mirror.example"))
+        assertTrue(script.contains("registry-mirrors"))
+        assertTrue(script.contains("base64.b64decode"))
+        assertTrue(script.contains("sudo -n cp"))
+        assertFalse(script.contains("https://mirror.example"))
+    }
+
+    @Test
+    fun statsParserFillsHostCpuMemoryDiskNetAndProcesses() {
+        val raw = buildStatsRaw(
+            cpu = "cpu  100 20 30 850 0 0 0 0 0 0",
+            mem = "MemTotal:        2000000 kB\nMemAvailable:     500000 kB\nSwapTotal:     1000000 kB\nSwapFree:       250000 kB",
+            disk = "Filesystem     1024-blocks     Used Available Capacity Mounted on\n/dev/sda1        104857600 52428800  52428800      50% /",
+            diskstats = "   8       0 sda 0 0 0 0 0 0 200 0 0 0 0 0 0 400",
+            net = "Inter-|   Receive                                                |  Transmit\n eth0: 12500000 0 0 0 0 0 0 0 2500000 0 0 0 0 0 0 0",
+            ip4 = "203.0.113.10",
+            ip6 = "2001:db8::1",
+            cpuinfo = "processor\t: 0\nmodel name\t: Test CPU\ncpu MHz\t\t: 2400.000\nprocessor\t: 1",
+            uname = "Linux 6.8.0 x86_64 GNU/Linux",
+            processes = "  42 root      12.5  3.0 S sshd /usr/sbin/sshd -D\n   7 nobody     1.0  0.2 S nginx nginx: worker",
+            hostname = "edge-01",
+        )
+        val first = SshRemoteOps.parseRemoteStats(raw, previous = null, nowMs = 1_000L)
+        assertEquals("edge-01", first.hostName)
+        assertEquals("Linux 6.8.0 x86_64 GNU/Linux", first.os)
+        assertEquals("Test CPU", first.cpu.model)
+        assertEquals("2400 MHz", first.cpu.freq)
+        assertEquals(2, first.cpu.cores)
+        assertEquals(0.0, first.cpu.usagePercent, 0.001)
+        assertEquals(2000000.0 / 1024.0 - 500000.0 / 1024.0, first.memory.memUsedMb, 0.01)
+        assertEquals(1, first.disks.size)
+        assertEquals("/", first.disks.single().mountpoint)
+        assertEquals(50, first.disks.single().percent)
+        assertEquals("203.0.113.10", first.ipv4)
+        assertEquals("2001:db8::1", first.ipv6)
+        assertEquals(2, first.processes.size)
+        assertEquals(42, first.processes[0].pid)
+        assertEquals("sshd", first.processes[0].command)
+
+        val laterCpu = "cpu  200 40 60 900 0 0 0 0 0 0"
+        val later = SshRemoteOps.parseRemoteStats(
+            buildStatsRaw(
+                cpu = laterCpu,
+                mem = "MemTotal:        2000000 kB\nMemAvailable:     500000 kB\nSwapTotal:     1000000 kB\nSwapFree:       250000 kB",
+                disk = "Filesystem     1024-blocks     Used Available Capacity Mounted on\n/dev/sda1        104857600 52428800  52428800      50% /",
+                diskstats = "   8       0 sda 0 0 0 0 0 0 400 0 0 0 0 0 0 800",
+                net = "Inter-|   Receive                                                |  Transmit\n eth0: 25000000 0 0 0 0 0 0 0 5000000 0 0 0 0 0 0 0",
+                ip4 = "203.0.113.10",
+                ip6 = "2001:db8::1",
+                cpuinfo = "processor\t: 0\nmodel name\t: Test CPU\ncpu MHz\t\t: 2400.000\nprocessor\t: 1",
+                uname = "Linux 6.8.0 x86_64 GNU/Linux",
+                processes = "  42 root      12.5  3.0 S sshd /usr/sbin/sshd -D",
+                hostname = "edge-01",
+            ),
+            previous = first.sample,
+            nowMs = 3_000L,
+        )
+        assertEquals(75.0, later.cpu.usagePercent, 0.01)
+        assertTrue(later.network.rxMbps > 0.0)
+        assertTrue(later.network.txMbps > 0.0)
+        assertTrue(later.disks.single().readKBps > 0.0)
+        assertTrue(later.disks.single().writeKBps > 0.0)
+    }
+
+    @Test
+    fun deletingTheRateSampleMustFailTheSecondTick() {
+        val raw = buildStatsRaw(
+            cpu = "cpu  100 0 0 100 0 0 0 0 0 0",
+            mem = "MemTotal: 1000 kB\nMemAvailable: 400 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB",
+            disk = "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1024 512 512 50% /",
+            diskstats = "8 0 sda 0 0 0 0 0 0 0 0 0 0 0 0 0",
+            net = "eth0: 100 0 0 0 0 0 0 0 100 0 0 0 0 0 0 0",
+            ip4 = "1.1.1.1",
+            ip6 = "",
+            cpuinfo = "processor : 0\nmodel name : X",
+            uname = "Linux",
+            processes = "",
+            hostname = "h",
+        )
+        val first = SshRemoteOps.parseRemoteStats(raw, previous = null, nowMs = 1_000L)
+        val second = SshRemoteOps.parseRemoteStats(raw.replace("cpu  100 0 0 100", "cpu  180 0 0 120"), previous = first.sample, nowMs = 2_000L)
+        assertTrue(second.cpu.usagePercent > 0.0)
+        val withoutSample = SshRemoteOps.parseRemoteStats(raw.replace("cpu  100 0 0 100", "cpu  180 0 0 120"), previous = null, nowMs = 2_000L)
+        assertEquals(0.0, withoutSample.cpu.usagePercent, 0.0)
+    }
+
+    private fun buildStatsRaw(
+        cpu: String,
+        mem: String,
+        disk: String,
+        diskstats: String,
+        net: String,
+        ip4: String,
+        ip6: String,
+        cpuinfo: String,
+        uname: String,
+        processes: String,
+        hostname: String,
+    ): String = listOf(
+        cpu, SshRemoteOps.MARKER_CPU,
+        mem, SshRemoteOps.MARKER_MEM,
+        disk, SshRemoteOps.MARKER_DISK,
+        diskstats, SshRemoteOps.MARKER_DISKSTATS,
+        net, SshRemoteOps.MARKER_NET,
+        ip4, SshRemoteOps.MARKER_IP4,
+        ip6, SshRemoteOps.MARKER_IP6,
+        cpuinfo, SshRemoteOps.MARKER_CPUINFO,
+        uname, SshRemoteOps.MARKER_UNAME,
+        processes, SshRemoteOps.MARKER_PROC,
+        hostname,
+    ).joinToString("\n")
+}

--- a/zephyr_one/mobile/tests/sftp-desktop-parity.test.mjs
+++ b/zephyr_one/mobile/tests/sftp-desktop-parity.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const pane = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt');
+const kinds = read('protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshFileKinds.kt');
+const policy = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpOpenPolicy.kt');
+const port = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpPort.kt');
+const engine = read('protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+const adapter = read('app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt');
+
+test('SFTP browser keeps desktop file-manager actions in the drawer', () => {
+  for (const needle of [
+    '新建文件夹', '新建文件', '上传文件', '粘贴', '复制', '剪切', '重命名', '删除',
+    '压缩', '权限', '下载', '属性', '解压到', '图片预览', '媒体预览',
+    '覆盖远端', '兼容', 'GetMultipleContents', 'CreateDocument',
+    'SftpTextEditor', 'SftpPreviewPane', 'VideoView', 'MediaPlayer', 'BitmapFactory',
+  ]) {
+    assert.match(pane, new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(pane, /BackHandler/);
+  assert.match(pane, /未保存/);
+  assert.match(pane, /port\.write\(/);
+  assert.match(pane, /canonicalPath/);
+  assert.match(pane, /parentPath/);
+});
+
+test('desktop extension tables and clipboard conflict modes are encoded', () => {
+  assert.match(kinds, /val IMAGE = setOf/);
+  assert.match(kinds, /"heic"/);
+  assert.match(kinds, /val VIDEO = setOf/);
+  assert.match(kinds, /"mkv"/);
+  assert.match(kinds, /val AUDIO = setOf/);
+  assert.match(kinds, /val ARCHIVE = setOf/);
+  assert.match(kinds, /fun compressCommand/);
+  assert.match(kinds, /fun extractCommand/);
+  assert.match(policy, /enum class SftpOpenKind/);
+  assert.match(policy, /SftpPasteConflictMode/);
+  assert.match(kinds, /uniqueCopyName/);
+  assert.match(kinds, /复制/);
+});
+
+test('SFTP engine can chmod, range-read, create-write and exec', () => {
+  assert.match(port, /suspend fun chmod/);
+  assert.match(port, /suspend fun readRange/);
+  assert.match(port, /suspend fun exec/);
+  assert.match(engine, /override suspend fun chmod/);
+  assert.match(engine, /override suspend fun readFileRange/);
+  assert.match(engine, /RenameFlags\.OVERWRITE/);
+  assert.match(adapter, /override suspend fun exec/);
+  assert.match(adapter, /override suspend fun chmod/);
+});

--- a/zephyr_one/mobile/tests/sftp-desktop-parity.test.mjs
+++ b/zephyr_one/mobile/tests/sftp-desktop-parity.test.mjs
@@ -19,9 +19,26 @@ test('SFTP browser keeps desktop file-manager actions in the drawer', () => {
     '压缩', '权限', '下载', '属性', '解压到', '图片预览', '媒体预览',
     '覆盖远端', '兼容', 'GetMultipleContents', 'CreateDocument',
     'SftpTextEditor', 'SftpPreviewPane', 'VideoView', 'MediaPlayer', 'BitmapFactory',
+    'writeStream', 'readStream', 'bundleCommand', 'upsertEditor', '搜目录', '大纲', '格式化', '撤回',
+    'openSelected', '正在自动连接', 'sourceConnectionId',
   ]) {
     assert.match(pane, new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
+});
+
+test('library SFTP opens hosts like the terminal rail', () => {
+  const notes = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt');
+  const tabs = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpHostTabs.kt');
+  assert.match(tabs, /fun open\(/);
+  assert.match(tabs, /fun close\(/);
+  assert.match(notes, /SftpHostPicker/);
+  assert.match(notes, /SftpHostRail/);
+  assert.match(notes, /再开一台主机/);
+  assert.match(notes, /不必先去首页连上/);
+  assert.match(notes, /ActionSheet/);
+});
+
+test('SFTP drawer expands fully and browser has navigation/edit safety', () => {
   assert.match(pane, /BackHandler/);
   assert.match(pane, /未保存/);
   assert.match(pane, /port\.write\(/);
@@ -48,9 +65,19 @@ test('SFTP engine can chmod, range-read, create-write and exec', () => {
   assert.match(port, /suspend fun chmod/);
   assert.match(port, /suspend fun readRange/);
   assert.match(port, /suspend fun exec/);
+  assert.match(port, /fun execStream/);
+  assert.match(port, /suspend fun readStream/);
+  assert.match(port, /suspend fun writeStream/);
   assert.match(engine, /override suspend fun chmod/);
   assert.match(engine, /override suspend fun readFileRange/);
+  assert.match(engine, /override fun execStream/);
+  assert.match(engine, /override suspend fun readFileStream/);
+  assert.match(engine, /override suspend fun writeFileStream/);
   assert.match(engine, /RenameFlags\.OVERWRITE/);
   assert.match(adapter, /override suspend fun exec/);
   assert.match(adapter, /override suspend fun chmod/);
+  assert.match(adapter, /override fun execStream/);
+  assert.match(adapter, /override suspend fun readStream/);
+  assert.match(adapter, /override suspend fun writeStream/);
+  assert.match(adapter, /pool\.acquire\(connectionId\)/);
 });

--- a/zephyr_one/mobile/tests/ssh-ops-parser-replica.py
+++ b/zephyr_one/mobile/tests/ssh-ops-parser-replica.py
@@ -93,6 +93,8 @@ def main() -> int:
         "systemctl restart docker",
         "ps -eo pid=,user=,pcpu=,pmem=,stat=,comm=,args=",
         "kill -s",
+        "docker logs",
+        "--timestamps",
     ):
         if needle not in text:
             raise AssertionError(f"missing {needle}")

--- a/zephyr_one/mobile/tests/ssh-ops-parser-replica.py
+++ b/zephyr_one/mobile/tests/ssh-ops-parser-replica.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Replica of SshRemoteOps parsers. A mutation that drops docker-status
+markers or CPU-rate math must fail here even when Gradle is unavailable."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def parse_docker_status(raw: str) -> dict:
+    return {
+        "installed": "__DOCKER_INSTALLED__=1" in raw,
+        "socket": "__DOCKER_SOCKET__=1" in raw,
+        "version": next((line.strip() for line in raw.splitlines() if line.lower().startswith("docker version")), ""),
+    }
+
+
+def parse_json_lines(raw: str) -> list[dict]:
+    out = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def parse_cpu_stat(raw: str):
+    for line in raw.splitlines():
+        if line.startswith("cpu "):
+            parts = [int(x) for x in line.split()[1:]]
+            idle = (parts[3] if len(parts) > 3 else 0) + (parts[4] if len(parts) > 4 else 0)
+            return {"idle": idle, "total": sum(parts)}
+    return None
+
+
+def compute_cpu(current, previous) -> float:
+    if not current or not previous:
+        return 0.0
+    total = current["total"] - previous["total"]
+    idle = current["idle"] - previous["idle"]
+    if total <= 0:
+        return 0.0
+    return max(0.0, min(100.0, (1.0 - idle / total) * 100.0))
+
+
+def unique_copy_name(existing: set[str], original: str) -> str:
+    if original not in existing:
+        return original
+    archive = next((ext for ext in [".tar.gz", ".tgz", ".zip"] if original.endswith(ext)), "")
+    stem = original[: -len(archive)] if archive else original.rsplit(".", 1)[0] if "." in original[1:] else original
+    suffix = archive or (("." + original.rsplit(".", 1)[1]) if "." in original[1:] else "")
+    index = 1
+    while True:
+        candidate = f"{stem}-复制{suffix}" if index == 1 else f"{stem}-复制{index}{suffix}"
+        if candidate not in existing:
+            return candidate
+        index += 1
+
+
+def main() -> int:
+    status = parse_docker_status("__DOCKER_INSTALLED__=1\nDocker version 27.1.1, build x\n__DOCKER_SOCKET__=1\n")
+    assert status["installed"] and status["socket"]
+    assert status["version"].startswith("Docker version 27.1.1")
+    missing = parse_docker_status("__DOCKER_INSTALLED__=0\n")
+    assert not missing["installed"]
+
+    rows = parse_json_lines('{"ID":"abc","Names":"/nginx","State":"running"}\nnot-json\n{"ID":"def","Names":"worker","State":"exited"}\n')
+    assert len(rows) == 2
+    assert rows[0]["Names"] == "/nginx"
+
+    first = parse_cpu_stat("cpu  100 0 0 100 0 0 0 0 0 0")
+    second = parse_cpu_stat("cpu  180 0 0 120 0 0 0 0 0 0")
+    usage = compute_cpu(second, first)
+    assert 79.0 < usage < 81.0, usage
+    assert compute_cpu(second, None) == 0.0
+
+    assert unique_copy_name({"notes.txt"}, "notes.txt") == "notes-复制.txt"
+    assert unique_copy_name({"backup.tar.gz"}, "backup.tar.gz") == "backup-复制.tar.gz"
+
+    # Mutation guard: the Android source must still emit the same markers and commands.
+    from pathlib import Path
+    src = Path(__file__).resolve().parents[1] / "android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRemoteOps.kt"
+    text = src.read_text(encoding="utf-8")
+    for needle in (
+        "__DOCKER_INSTALLED__",
+        "docker ps -a --no-trunc --format '{{json .}}'",
+        "docker image ls --no-trunc --format '{{json .}}'",
+        "registry-mirrors",
+        "systemctl restart docker",
+        "ps -eo pid=,user=,pcpu=,pmem=,stat=,comm=,args=",
+        "kill -s",
+    ):
+        if needle not in text:
+            raise AssertionError(f"missing {needle}")
+    print("ssh-ops-parser-replica: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr_one/mobile/tests/ssh-ops-parser-replica.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-ops-parser-replica.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+test('python replica of docker/stats parsers stays aligned with Kotlin', () => {
+  const result = spawnSync('python3', [path.join(here, 'ssh-ops-parser-replica.py')], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /ssh-ops-parser-replica: ok/);
+});

--- a/zephyr_one/mobile/tests/terminal-ime-sftp-password-selection.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-ime-sftp-password-selection.test.mjs
@@ -22,7 +22,7 @@ const notes = read('android/feature-notes/src/main/kotlin/one/zephyr/mobile/feat
 const exec = read('android/app/src/main/kotlin/one/zephyr/mobile/app/LiveSshExecPort.kt');
 test('SFTP drawer expands fully and browser has navigation/edit safety', () => {
   assert.match(workspace, /SHEET_MAX_FRACTION = 1\.00f/);
-  for (const p of [/canonicalPath/, /parentPath/, /LazyColumn/, /port\.write\(/, /decodeUtf8Text/, /BackHandler/, /未保存/]) assert.match(pane, p);
+  for (const p of [/canonicalPath/, /parentPath/, /LazyColumn/, /port\.write\(/, /decodeUtf8Text/, /BackHandler/, /未保存/, /SftpTextEditor/, /SftpPreviewPane/]) assert.match(pane, p);
   assert.match(notes, /fun SftpBrowserRoute/);
   assert.doesNotMatch(notes, /prod-web-01|deploy-2026/);
   assert.match(exec, /managed\.withSession/);

--- a/zephyr_one/mobile/tests/terminal-live-tools-theme.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-live-tools-theme.test.mjs
@@ -34,6 +34,9 @@ test('docker and monitor stay inside the SSH tool drawer', () => {
   assert.match(ops, /dockerMirrorsSetCommand/);
   assert.match(ops, /statsCommand/);
   assert.match(ops, /processSignalCommand/);
+  assert.match(ops, /dockerLogsCommand\(container\.target, tail = 200, follow = true\)/);
+  assert.match(ops, /client\.stream\(SshRemoteOps\.dockerPullCommand/);
+  assert.match(ops, /暂停滚动/);
   assert.match(tools, /HostDockerPanel\(/);
   assert.match(tools, /HostMonitorPanel\(/);
   assert.doesNotMatch(tools, /SSH 引擎尚未接入，当前无法读取容器状态/);

--- a/zephyr_one/mobile/tests/terminal-live-tools-theme.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-live-tools-theme.test.mjs
@@ -8,12 +8,36 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
 const panels = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt');
 const screen = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt');
+const sheet = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt');
+const workspace = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt');
 const bridge = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TermuxSessionBridge.kt');
+const ops = read('feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt');
+const tools = read('feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt');
+const root = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
 
 test('terminal tools never render demo files snippets or zero metrics', () => {
   assert.doesNotMatch(panels, /"nginx\.conf"|"access\.log"|Snippet\(id = "demo-|Meter\(colors, "CPU", "—"/);
   assert.match(panels, /listRemoteDirectory\(path\)/);
-  assert.match(panels, /remoteMetrics\(\)/);
+  assert.match(panels, /HostMonitorPanel\(/);
+  assert.match(panels, /HostDockerPanel\(/);
+});
+
+test('docker and monitor stay inside the SSH tool drawer', () => {
+  assert.match(workspace, /enum class TerminalToolKind[\s\S]*DOCKER/);
+  assert.match(sheet, /current == TerminalToolKind\.STATS \|\| current == TerminalToolKind\.DOCKER/);
+  assert.match(screen, /TerminalWorkspace\.openTool\(ws, TerminalToolKind\.DOCKER/);
+  assert.doesNotMatch(panels, /RootRoute\.Ops/);
+  assert.doesNotMatch(sheet, /RootRoute\.Ops/);
+  assert.match(ops, /dockerCheckCommand/);
+  assert.match(ops, /dockerListContainersCommand/);
+  assert.match(ops, /dockerPullCommand/);
+  assert.match(ops, /dockerMirrorsSetCommand/);
+  assert.match(ops, /statsCommand/);
+  assert.match(ops, /processSignalCommand/);
+  assert.match(tools, /HostDockerPanel\(/);
+  assert.match(tools, /HostMonitorPanel\(/);
+  assert.doesNotMatch(tools, /SSH 引擎尚未接入，当前无法读取容器状态/);
+  assert.match(root, /LiveSshExecPort\(sshEngine, account.sessions, managedSsh\)/);
 });
 
 test('terminal background opacity and blur affect rendering', () => {

--- a/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
@@ -20,7 +20,10 @@ test('phone tools are an in-flow drawer with demo detents', () => {
   assert.match(ws, /SHEET_DISMISS_VELOCITY_PX_PER_MS\s*=\s*0\.70f/);
   assert.match(screen, /TerminalToolSheet\(/);
   assert.match(sheet, /height\(maxHeight \* animatedFraction\)/);
-  assert.match(sheet, /tween\(260, easing = ZephyrMotionTokens\.easeDrawer\)/);
+  assert.match(sheet, /tween\(ZephyrMotionTokens\.SHEET_MS, easing = ZephyrMotionTokens\.easeDrawer\)/);
+  assert.match(ws, /fun finishClose/);
+  assert.match(codeOnly(screen), /ws\.sheetCurrent != null/);
+  assert.doesNotMatch(codeOnly(screen), /ws\.sheetFraction > 0f && ws\.sheetCurrent/);
 });
 
 test('terminal no longer renders movable floating tool panels', () => {

--- a/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
@@ -45,7 +45,8 @@ test('FILES drawer with its text editor survives an open IME', () => {
   // the whole tool sheet being removed — which made the file page vanish on focus.
   assert.match(
     codeOnly(screen),
-    /!imeOpen \|\| ws\.sheetCurrent == TerminalToolKind\.FILES/,
+    /!imeOpen \|\| ws\.sheetCurrent\?\.keepsIme == true/,
   );
+  assert.match(ws, /this == FILES \|\| this == STATS \|\| this == DOCKER/);
   assert.match(sheet, /SftpBrowserPane\(/);
 });


### PR DESCRIPTION
对照主端 SSH 终端，把 Mobile 的 Docker / 监控 / SFTP 从二级页和三根百分比条改成终端抽屉里的完整面。资料页 SFTP 按终端多开会话那套开主机，远程批量未连接会自己拨号。

## Docker / 监控
- 检测、容器启停重启删除、日志跟随（`docker logs --timestamps -f`）、镜像列表、流式拉取、被占用强制删、registry-mirrors、重启 Docker
- 监控对齐主端：主机/OS、CPU、内存/Swap、多盘、读写、上下行、IP、进程搜索排序、TERM/KILL
- 终端里打开，不再跳出到 `RootRoute.Ops`
- 抽屉开合走 420ms `easeDrawer`，关掉先收到 0 再卸节点

## SFTP
- 浏览、跳转、搜索、排序、隐藏点文件
- 新建文件夹/文件、上传/下载（流式）、多选打包下载
- 复制/剪切/粘贴（覆盖/跳过/兼容改名），跨主机流式拷
- 重命名、删除、压缩、解压、chmod、属性
- 文本多标签编辑、查找、大纲、格式化、搜目录
- 图片预览、音视频缓存预览
- 资料页：先选主机 → 自动连接 → 加号再开一台，多标签并存

## 远程批量
- 未连接的目标自动 `ManagedSshSessionPool.acquire`
- 拨号单独留 20 秒，失败写「自动连接失败」

## 测试
- 契约：`sftp-desktop-parity`、`terminal-live-tools-theme`、`terminal-tool-sheet`、`ssh-ops-parser-replica`
- JVM：Docker/stats 解析、SFTP 打开策略、编辑器辅助、主机标签、抽屉动画
