### PR TITLE
fix(mobile): stop pre18 cold-start crash

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiPlatformHost.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiPlatformHost.kt
@@ -24,19 +24,54 @@ internal class AndroidAiPlatformHost(
     private val workspace: LocalAiWorkspace,
 ) : Closeable {
     data class Endpoint(val url: String, val token: String)
-    private val token = randomToken()
-    private val server = ServerSocket(0, 16, InetAddress.getByName("127.0.0.1"))
-    private val executor = Executors.newFixedThreadPool(3) { Thread(it, "one-ai-platform").apply { isDaemon = true } }
+
+    private data class ActiveHost(
+        val token: String,
+        val server: ServerSocket,
+        val executor: java.util.concurrent.ExecutorService,
+        val endpoint: Endpoint,
+    )
+
+    private val lifecycleLock = Any()
+    @Volatile private var active: ActiveHost? = null
     @Volatile private var closed = false
-    val endpoint = Endpoint("http://127.0.0.1:${server.localPort}", token)
 
-    init { executor.execute { acceptLoop() } }
+    /**
+     * Starts the loopback bridge on demand.
+     *
+     * BoundAiWorkspace is part of the application's first composition. Binding a ServerSocket in
+     * this object's constructor therefore performed network I/O on Android's main thread and could
+     * throw NetworkOnMainThreadException before the first frame. Runtime startup owns an IO
+     * dispatcher, so keep construction inert and bind only from that path.
+     */
+    fun ensureStarted(): Endpoint = synchronized(lifecycleLock) {
+        check(!closed) { "本机 AI 平台 Host 已关闭" }
+        active?.let { return@synchronized it.endpoint }
 
-    private fun acceptLoop() {
-        while (!closed) runCatching { server.accept() }.onSuccess { socket -> executor.execute { socket.use(::handle) } }
+        val token = randomToken()
+        val server = ServerSocket(0, 16, InetAddress.getByName("127.0.0.1"))
+        val executor = Executors.newFixedThreadPool(3) {
+            Thread(it, "one-ai-platform").apply { isDaemon = true }
+        }
+        val started = ActiveHost(
+            token = token,
+            server = server,
+            executor = executor,
+            endpoint = Endpoint("http://127.0.0.1:${server.localPort}", token),
+        )
+        active = started
+        executor.execute { acceptLoop(started) }
+        started.endpoint
     }
 
-    private fun handle(socket: Socket) {
+    private fun acceptLoop(host: ActiveHost) {
+        while (!closed && !host.server.isClosed) {
+            runCatching { host.server.accept() }
+                .onSuccess { socket -> host.executor.execute { socket.use { handle(it, host.token) } } }
+        }
+    }
+
+    private fun handle(socket: Socket, token: String) {
         val input = BufferedInputStream(socket.getInputStream())
         val output = BufferedOutputStream(socket.getOutputStream())
         val requestLine = readLine(input)?.split(' ') ?: return
@@ -118,7 +153,15 @@ internal class AndroidAiPlatformHost(
     private fun readLine(input: BufferedInputStream): String? { val out = java.io.ByteArrayOutputStream(); while (out.size() < 16_384) { val b = input.read(); if (b < 0) return null; if (b == 10) break; if (b != 13) out.write(b) }; return out.toString("UTF-8") }
     private fun JsonObject.string(key: String) = (this[key] as? JsonPrimitive)?.content.orEmpty()
     private fun JsonObject.array(key: String) = (this[key] as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()
-    override fun close() { closed = true; server.close(); executor.shutdownNow() }
+    override fun close() {
+        val host = synchronized(lifecycleLock) {
+            if (closed) return
+            closed = true
+            active.also { active = null }
+        }
+        host?.server?.close()
+        host?.executor?.shutdownNow()
+    }
     private fun randomToken(): String { val b = ByteArray(32).also(SecureRandom()::nextBytes); return try { android.util.Base64.encodeToString(b, android.util.Base64.NO_WRAP or android.util.Base64.URL_SAFE) } finally { b.fill(0) } }
 
     companion object {

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/EmbeddedAiRuntimeApi.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/EmbeddedAiRuntimeApi.kt
@@ -3,7 +3,9 @@ package one.zephyr.mobile.app
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
@@ -62,30 +64,55 @@ internal class EmbeddedAiRuntimeApi(
         post("/admin/runs/${encode(runId)}/permission", body, EmbeddedPermissionDecision.serializer(), EmbeddedPermissionResponse.serializer())
 
     suspend fun stream(path: String, lastEventId: Long, onEvent: suspend (AiRuntimeEvent) -> Unit): ApiResult<Unit> {
-        val request = authorized(Request.Builder().url(endpoint().baseUrl + path).get()
-            .header("Accept", "text/event-stream").apply { if (lastEventId > 0) header("Last-Event-ID", "$lastEventId") }.build())
-        return try {
+        return runtimeCall("embedded_ai_stream_failed", "本机 AI 事件流中断") {
+            val endpoint = endpoint()
+            val request = authorized(
+                Request.Builder().url(endpoint.baseUrl + path).get()
+                    .header("Accept", "text/event-stream")
+                    .apply { if (lastEventId > 0) header("Last-Event-ID", "$lastEventId") }
+                    .build(),
+                endpoint,
+            )
             await(streamClient, request).use { response ->
-                if (!response.isSuccessful) return failure("embedded_ai_http_${response.code}", "本机 AI Runtime 请求失败（HTTP ${response.code}）")
-                val source = response.body?.source() ?: return failure("empty_ai_stream", "本机 AI 事件流为空")
-                val parser = EmbeddedSseParser(onEvent)
-                while (!source.exhausted()) parser.accept(source.readUtf8LineStrict(MAX_LINE))
-                parser.finish()
-                ApiResult.Success(Unit, null)
+                if (!response.isSuccessful) {
+                    failure("embedded_ai_http_${response.code}", "本机 AI Runtime 请求失败（HTTP ${response.code}）")
+                } else {
+                    val source = response.body?.source()
+                    if (source == null) {
+                        failure("empty_ai_stream", "本机 AI 事件流为空")
+                    } else {
+                        val parser = EmbeddedSseParser(onEvent)
+                        while (!source.exhausted()) parser.accept(source.readUtf8LineStrict(MAX_LINE))
+                        parser.finish()
+                        ApiResult.Success(Unit, null)
+                    }
+                }
             }
-        } catch (cancelled: CancellationException) { throw cancelled }
-        catch (error: Exception) { failure("embedded_ai_stream_failed", error.message ?: "本机 AI 事件流中断", true) }
+        }
     }
 
-    private suspend fun <B, R> post(path: String, body: B, bs: SerializationStrategy<B>, rs: DeserializationStrategy<R>): ApiResult<R> {
+    private suspend fun <B, R> post(
+        path: String,
+        body: B,
+        bs: SerializationStrategy<B>,
+        rs: DeserializationStrategy<R>,
+    ): ApiResult<R> = runtimeCall("embedded_ai_start_failed", "本机 AI Runtime 启动失败") {
+        val endpoint = endpoint()
         val json = MobileJson.instance.encodeToString(bs, body)
-        return execute(Request.Builder().url(endpoint().baseUrl + path).post(json.toRequestBody(JSON)).build(), rs)
+        val request = Request.Builder().url(endpoint.baseUrl + path)
+            .post(json.toRequestBody(JSON)).build()
+        execute(authorized(request, endpoint), rs)
     }
+
     private suspend fun <R> get(path: String, serializer: DeserializationStrategy<R>): ApiResult<R> =
-        execute(Request.Builder().url(endpoint().baseUrl + path).get().build(), serializer)
+        runtimeCall("embedded_ai_start_failed", "本机 AI Runtime 启动失败") {
+            val endpoint = endpoint()
+            val request = Request.Builder().url(endpoint.baseUrl + path).get().build()
+            execute(authorized(request, endpoint), serializer)
+        }
 
     private suspend fun <R> execute(request: Request, serializer: DeserializationStrategy<R>): ApiResult<R> = try {
-        await(client, authorized(request)).use { response ->
+        await(client, request).use { response ->
             val raw = response.body?.string().orEmpty()
             if (!response.isSuccessful) return failure("embedded_ai_http_${response.code}", parseError(raw).ifBlank { "本机 AI Runtime 请求失败（HTTP ${response.code}）" })
             runCatching { MobileJson.instance.decodeFromString(serializer, raw) }
@@ -95,10 +122,27 @@ internal class EmbeddedAiRuntimeApi(
     catch (error: IOException) { failure("embedded_ai_unreachable", error.message ?: "本机 AI Runtime 不可达", true) }
 
     private fun endpoint(): EmbeddedAiRuntimeProcess.Endpoint {
-        val host = platformHost.endpoint
+        val host = platformHost.ensureStarted()
         return process.ensureStarted(host.url, host.token)
     }
-    private fun authorized(request: Request): Request = request.newBuilder().header("X-AI-Admin", endpoint().adminToken).build()
+    private fun authorized(
+        request: Request,
+        endpoint: EmbeddedAiRuntimeProcess.Endpoint,
+    ): Request = request.newBuilder().header("X-AI-Admin", endpoint.adminToken).build()
+
+    private suspend fun <T> runtimeCall(
+        code: String,
+        fallback: String,
+        block: suspend () -> ApiResult<T>,
+    ): ApiResult<T> = withContext(Dispatchers.IO) {
+        try {
+            block()
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (failure: Exception) {
+            failure(code, failure.message ?: fallback, true)
+        }
+    }
     private fun parseError(raw: String): String = runCatching { MobileJson.instance.parseToJsonElement(raw).jsonObject["error"]?.toString()?.trim('"').orEmpty() }.getOrDefault("")
     private suspend fun await(http: OkHttpClient, request: Request): Response = suspendCancellableCoroutine { c ->
         val call = http.newCall(request); c.invokeOnCancellation { call.cancel() }

--- a/zephyr_one/mobile/android/feature-ai/src/main/kotlin/one/zephyr/mobile/feature/ai/AiWorkspaceOverlay.kt
+++ b/zephyr_one/mobile/android/feature-ai/src/main/kotlin/one/zephyr/mobile/feature/ai/AiWorkspaceOverlay.kt
@@ -156,7 +156,9 @@ fun AiWorkspaceOverlay(
 
     LaunchedEffect(enabled) { sheet = AiSheetMotion.disable(enabled, sheet) }
     LaunchedEffect(sheet.detent) { sheet.detent?.let { lastOpen = it } }
-    LaunchedEffect(Unit) { controller.refresh() }
+    // Do not boot the packaged process while composing the application's first frame. The AI
+    // workspace is an overlay: its runtime is needed only after the user opens it.
+    LaunchedEffect(sheet.isOpen) { if (sheet.isOpen) controller.refresh() }
     LaunchedEffect(runtime.error) { runtime.error?.let(onNotice) }
 
     BackHandler(enabled = sheet.isOpen) {

--- a/zephyr_one/mobile/tests/android-cold-start-ai-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/android-cold-start-ai-runtime.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+function methodBody(source, signature) {
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `missing ${signature}`);
+  const brace = source.indexOf('{', start);
+  assert.notEqual(brace, -1, `missing body for ${signature}`);
+  let depth = 0;
+  for (let i = brace; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(brace + 1, i);
+    }
+  }
+  assert.fail(`unterminated body for ${signature}`);
+}
+
+function assertStartupIsolated({ host, api, overlay }) {
+  const classPrefix = host.slice(0, host.indexOf('fun ensureStarted(): Endpoint'));
+  assert.doesNotMatch(classPrefix, /ServerSocket\s*\(/, 'AI host construction must not bind a socket');
+  assert.doesNotMatch(classPrefix, /Executors\.newFixedThreadPool/, 'AI host construction must not spawn threads');
+
+  const ensureStarted = methodBody(host, 'fun ensureStarted(): Endpoint');
+  assert.match(ensureStarted, /ServerSocket\s*\(/, 'the on-demand path must bind the loopback host');
+
+  assert.doesNotMatch(overlay, /LaunchedEffect\s*\(\s*Unit\s*\)\s*\{\s*controller\.refresh\s*\(\s*\)/s,
+    'first composition must not boot the AI process');
+  assert.match(overlay, /LaunchedEffect\s*\(\s*sheet\.isOpen\s*\)\s*\{\s*if\s*\(\s*sheet\.isOpen\s*\)\s*controller\.refresh\s*\(\s*\)/s,
+    'opening the AI sheet must start or refresh the runtime');
+
+  const runtimeCall = methodBody(api, 'private suspend fun <T> runtimeCall(');
+  assert.match(api, /private suspend fun <T> runtimeCall\([\s\S]*?\): ApiResult<T>\s*=\s*withContext\s*\(\s*Dispatchers\.IO\s*\)/,
+    'process, socket bind and loopback connect must run on Dispatchers.IO');
+  assert.match(runtimeCall, /catch\s*\(\s*failure:\s*Exception\s*\)/,
+    'runtime startup failures must become an AI failure instead of killing the app');
+  assert.match(api, /suspend fun stream\([\s\S]*?\{\s*return runtimeCall\s*\(/,
+    'stream must use the guarded IO boundary');
+  assert.match(api, /private suspend fun <B, R> post\([\s\S]*?\): ApiResult<R>\s*=\s*runtimeCall\s*\(/,
+    'post must use the guarded IO boundary');
+  assert.match(api, /private suspend fun <R> get\([\s\S]*?\): ApiResult<R>\s*=\s*runtimeCall\s*\(/,
+    'get must use the guarded IO boundary');
+}
+
+test('cold app startup performs no embedded-AI process or loopback I/O', () => {
+  assertStartupIsolated({
+    host: read('android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiPlatformHost.kt'),
+    api: read('android/app/src/main/kotlin/one/zephyr/mobile/app/EmbeddedAiRuntimeApi.kt'),
+    overlay: read('android/feature-ai/src/main/kotlin/one/zephyr/mobile/feature/ai/AiWorkspaceOverlay.kt'),
+  });
+});
+
+test('startup isolation guard rejects the pre18 eager-host and eager-refresh regressions', () => {
+  const current = {
+    host: read('android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiPlatformHost.kt'),
+    api: read('android/app/src/main/kotlin/one/zephyr/mobile/app/EmbeddedAiRuntimeApi.kt'),
+    overlay: read('android/feature-ai/src/main/kotlin/one/zephyr/mobile/feature/ai/AiWorkspaceOverlay.kt'),
+  };
+  const eagerHost = {
+    ...current,
+    host: current.host.replace(
+      'private val lifecycleLock = Any()',
+      'private val eager = ServerSocket(0)\n    private val lifecycleLock = Any()',
+    ),
+  };
+  assert.throws(() => assertStartupIsolated(eagerHost), /must not bind a socket/);
+
+  const eagerRefresh = {
+    ...current,
+    overlay: current.overlay.replace(
+      'LaunchedEffect(sheet.isOpen) { if (sheet.isOpen) controller.refresh() }',
+      'LaunchedEffect(Unit) { controller.refresh() }',
+    ),
+  };
+  assert.throws(() => assertStartupIsolated(eagerRefresh), /first composition must not boot/);
+
+  const mainDispatcher = {
+    ...current,
+    api: current.api.replace('withContext(Dispatchers.IO)', 'withContext(Dispatchers.Main)'),
+  };
+  assert.throws(() => assertStartupIsolated(mainDispatcher), /must run on Dispatchers.IO/);
+});


### PR DESCRIPTION
## Root cause
pre18 mounted `BoundAiWorkspace` on the first frame. Its controller constructor synchronously constructed `AndroidAiPlatformHost`, which bound a loopback `ServerSocket` on Android main. The overlay then ran `controller.refresh()` from `LaunchedEffect(Unit)`, synchronously starting the packaged Go process and connecting loopback before the first usable frame. These startup I/O failures were uncaught and terminated `MainActivity`.

## Fix
- make the loopback platform host constructor inert and bind only on demand
- move host bind, process startup, and loopback connection behind `Dispatchers.IO`
- start the packaged runtime only when the AI sheet is actually open
- convert runtime startup exceptions into retryable AI errors instead of process death
- add mutation-backed cold-start regression coverage

## Verification
- cold-start + local-AI contract tests: 6/6
- embedded Go runtime packages: pass
- full mobile contract run reached 340/352; all 12 failures are sandbox/environment pre-existing gates (Java executable-memory denial, missing FREEZE tree, and server subprocess suites unavailable under native offload), while the new cold-start tests pass.