### PR TITLE
fix(mobile): hide disabled AI and stop SFTP action crashes

### DIFF
--- a/.github/workflows/zephyr-one-mobile.yml
+++ b/.github/workflows/zephyr-one-mobile.yml
@@ -229,6 +229,8 @@ jobs:
           test "$package" = 'one.zephyr.mobile.debug'
           ! $ANDROID_HOME/build-tools/35.0.0/aapt dump badging "${apks[0]}" | grep -q '^application-debuggable$'
           unzip -Z1 "${apks[0]}" | grep -qx 'lib/arm64-v8a/libzephyr_rdp_android.so'
+          fragment_version="$(unzip -p "${apks[0]}" META-INF/androidx.fragment_fragment.version)"
+          test "$fragment_version" = '1.8.5'
 
       # assemblePrerelease is signed with the committed pre-release PKCS12, not the
       # per-runner debug.keystore. That is what lets successive pre-releases

--- a/zephyr_one/mobile/android/app/build.gradle.kts
+++ b/zephyr_one/mobile/android/app/build.gradle.kts
@@ -113,6 +113,11 @@ dependencies {
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.lifecycle.service)
     implementation(libs.androidx.activity.compose)
+    // Biometric 1.2.0-alpha05 still declares Fragment 1.2.5 transitively. That legacy
+    // FragmentActivity rejects ActivityResultRegistry's high request codes, crashing every SAF
+    // picker (SFTP upload/download, AI attachment, directory authorizer). Pin a compatible
+    // Fragment implementation at the application boundary.
+    implementation(libs.androidx.fragment)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.navigation.compose)

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AiWorkspaceHost.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AiWorkspaceHost.kt
@@ -30,7 +30,13 @@ internal fun BoundAiWorkspace(
     onNotice: (String) -> Unit,
 ) {
     val prefs by account.settings.observePreferences().collectAsState(initial = emptyMap())
-    val chrome = AiWorkspaceBinding.chrome(prefs)
+    val catalog by account.localAi.observe().collectAsState(
+        initial = one.zephyr.mobile.data.repository.LocalAiCatalog(enabled = false),
+    )
+    val chrome = AiWorkspaceBinding.chrome(prefs, catalog.enabled)
+    // Disabled means absent, not merely a closed sheet. Returning before controller construction
+    // removes the FAB immediately and disposes any live local runtime/loopback host when toggled.
+    if (!chrome.enabled) return
     val context = AiWorkspaceBinding.context(destination, session)
     val scope = rememberCoroutineScope()
     val runtime = remember(account) {
@@ -64,8 +70,14 @@ internal fun BoundAiWorkspace(
 
 internal object AiWorkspaceBinding {
 
-    fun chrome(prefs: Map<String, JsonObject>): AiWorkspaceChrome = AiPreferenceMapping.chrome(
-        enabled = flag(prefs, SettingsRepository.PREF_AI_ENABLED, true),
+    fun chrome(
+        prefs: Map<String, JsonObject>,
+        catalogEnabled: Boolean = true,
+    ): AiWorkspaceChrome = AiPreferenceMapping.chrome(
+        // The full local-AI settings page owns the authoritative switch in LocalAiCatalog. The
+        // legacy preference is still honoured for upgraded installs, but it must never turn a
+        // disabled catalog back on or leave the floating button visible.
+        enabled = catalogEnabled && flag(prefs, SettingsRepository.PREF_AI_ENABLED, true),
         provider = text(prefs, SettingsRepository.PREF_AI_PROVIDER),
         model = text(prefs, SettingsRepository.PREF_AI_MODEL),
         collaboration = text(prefs, SettingsRepository.PREF_AI_COLLAB),
@@ -114,8 +126,11 @@ internal object AiWorkspaceBinding {
         return JsonObject(values)
     }
 
-    fun settingsSummary(prefs: Map<String, JsonObject>): String {
-        val chrome = chrome(prefs)
+    fun settingsSummary(
+        prefs: Map<String, JsonObject>,
+        catalogEnabled: Boolean = true,
+    ): String {
+        val chrome = chrome(prefs, catalogEnabled)
         return AiWorkspaceCopy.settingsSub(chrome.enabled, chrome.model, chrome.collaboration)
     }
 

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -1196,6 +1196,9 @@ private fun ToolsDestination(
 ) {
     val connections by account.connections.observeAll(ownerUserId).collectAsState(initial = emptyList())
     val prefs by account.settings.observePreferences().collectAsState(initial = emptyMap())
+    val localAiCatalog by account.localAi.observe().collectAsState(
+        initial = one.zephyr.mobile.data.repository.LocalAiCatalog(enabled = false),
+    )
     val language = one.zephyr.mobile.ui.locale.AppLanguage.fromStored(
         prefs[one.zephyr.mobile.data.repository.SettingsRepository.PREF_LANGUAGE]?.let {
             one.zephyr.mobile.data.EntityCodec.string(it, "value")
@@ -1218,7 +1221,7 @@ private fun ToolsDestination(
         inventory = inventory,
         summaries = ToolsRootSummaries(
             language = languageLabel,
-            ai = AiWorkspaceBinding.settingsSummary(prefs),
+            ai = AiWorkspaceBinding.settingsSummary(prefs, localAiCatalog.enabled),
         ),
         onOpenBatchExecution = onOpenBatch,
         onOpenDocker = { onOpenTool(ToolEntry.DOCKER) },

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/AiWorkspaceBindingTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/AiWorkspaceBindingTest.kt
@@ -40,6 +40,11 @@ class AiWorkspaceBindingTest {
         )
         val chrome = AiWorkspaceBinding.chrome(prefs)
         assertFalse(chrome.enabled)
+        assertFalse(AiWorkspaceBinding.chrome(emptyMap(), catalogEnabled = false).enabled)
+        assertEquals(
+            "已停用 · 导航与工作区不再显示 AI",
+            AiWorkspaceBinding.settingsSummary(emptyMap(), catalogEnabled = false),
+        )
         assertEquals("Claude Sonnet", chrome.model)
         assertEquals("只读", chrome.collaboration)
         assertEquals("全部询问", chrome.permission)

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
@@ -773,7 +773,9 @@ fun SftpBrowserPane(
                 onDismissRequest = { dialog = null },
                 title = { Text(current.title) },
                 text = {
-                    Column(Modifier.verticalScroll(rememberScrollState())) {
+                    // AlertDialog owns the sole bounded verticalScroll. Nesting another scrollable
+                    // Column here makes Compose measure it with infinite height and crash.
+                    Column {
                         current.lines.forEach { (label, value) ->
                             val jump = label.contains(':') && label.startsWith("/")
                             Text(

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -194,6 +194,12 @@ private fun DemoTerminalSurface(
     val splitRightMsg = stringResource(R.string.terminal_split_right)
     val needSecondMsg = stringResource(R.string.terminal_need_second_session)
     val insertToastMsg = stringResource(R.string.terminal_insert_toast)
+    val openConnectionIds = liveSessions.mapTo(mutableSetOf()) { it.connectionId }.apply {
+        add(content.connection.id)
+    }
+    val addableConnections = connections.filter { connection ->
+        connection.protocol.isTerminal && connection.id !in openConnectionIds
+    }
 
     LaunchedEffect(containerW, containerH, focusedSurface.fontSp) {
         if (containerW <= 0 || containerH <= 0) return@LaunchedEffect
@@ -213,7 +219,8 @@ private fun DemoTerminalSurface(
         )
     }
 
-    BoxWithConstraints(Modifier.fillMaxSize().background(colors.termBg)) {
+    Box(Modifier.fillMaxSize()) {
+        BoxWithConstraints(Modifier.fillMaxSize().background(colors.termBg)) {
         val pad = maxWidth >= TerminalWorkspace.PAD_RAIL_MIN_DP.dp
         DemoTermBackground(ws, colors)
         Row(Modifier.fillMaxSize()) {
@@ -380,7 +387,7 @@ private fun DemoTerminalSurface(
         groups = listOf(
             ActionSheetGroup(
                 title = stringResource(R.string.terminal_new_session_title),
-                items = connections.filter { it.protocol.isTerminal }.map { connection ->
+                items = addableConnections.map { connection ->
                     ActionSheetItem(
                         label = connection.name,
                         subtitle = connection.displayAddress,
@@ -430,6 +437,7 @@ private fun DemoTerminalSurface(
             ),
         ),
     )
+    }
     @Suppress("UNUSED_VARIABLE", "UNUSED_PARAMETER")
     val keep = Triple(surfaceRevision, readFrame, remoteTitle)
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/res/values-en/strings.xml
@@ -67,7 +67,7 @@
     <string name="terminal_pasted">Pasted into %1$s</string>
     <string name="terminal_disconnect_title">Disconnect %1$s? The session cannot be restored</string>
     <string name="terminal_disconnect_confirm">Disconnect</string>
-    <string name="terminal_new_session_title">New session · pick a connection</string>
+    <string name="terminal_new_session_title">Open another host</string>
     <string name="terminal_bg_none">No custom background</string>
     <string name="terminal_bg_image">Image (demo gradient)</string>
     <string name="terminal_bg_big">Large background</string>

--- a/zephyr_one/mobile/android/feature-sessions/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="terminal_pasted">已粘贴到 %1$s</string>
     <string name="terminal_disconnect_title">断开 %1$s？会话不可恢复</string>
     <string name="terminal_disconnect_confirm">断开连接</string>
-    <string name="terminal_new_session_title">新建会话 · 选择连接</string>
+    <string name="terminal_new_session_title">再开一台主机</string>
     <string name="terminal_bg_none">不使用自定义背景</string>
     <string name="terminal_bg_image">图片（演示渐变）</string>
     <string name="terminal_bg_big">大背景</string>

--- a/zephyr_one/mobile/android/gradle/libs.versions.toml
+++ b/zephyr_one/mobile/android/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ composeCompiler = "1.5.15"
 coreKtx = "1.15.0"
 lifecycle = "2.8.7"
 activityCompose = "1.9.3"
+fragment = "1.8.5"
 navigationCompose = "2.8.5"
 room = "2.6.1"
 sqlite = "2.6.2"
@@ -35,6 +36,7 @@ androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", 
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "fragment" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }

--- a/zephyr_one/mobile/tests/android-ai-toggle-visibility.test.mjs
+++ b/zephyr_one/mobile/tests/android-ai-toggle-visibility.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+function assertAiToggleGuard({ host, root }) {
+  assert.match(host, /account\.localAi\.observe\(\)\.collectAsState\([\s\S]*?LocalAiCatalog\(enabled = false\)/,
+    'AI overlay must observe the authoritative local catalog fail-closed');
+  assert.match(host, /AiWorkspaceBinding\.chrome\(prefs, catalog\.enabled\)/,
+    'AI chrome must combine legacy preferences with the catalog switch');
+  assert.match(host, /enabled\s*=\s*catalogEnabled\s*&&\s*flag\(prefs, SettingsRepository\.PREF_AI_ENABLED, true\)/,
+    'a disabled catalog must never be overridden by a stale preference');
+  assert.match(host, /if\s*\(!chrome\.enabled\)\s*return[\s\S]*?val runtime = remember\(account\)/,
+    'disabled AI must leave composition before the FAB/runtime are constructed');
+  assert.match(root, /account\.localAi\.observe\(\)\.collectAsState[\s\S]*?AiWorkspaceBinding\.settingsSummary\(prefs, localAiCatalog\.enabled\)/,
+    'the tools summary must report the same authoritative switch');
+}
+
+test('disabling local AI removes its floating button and runtime', () => {
+  assertAiToggleGuard({
+    host: read('android/app/src/main/kotlin/one/zephyr/mobile/app/AiWorkspaceHost.kt'),
+    root: read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt'),
+  });
+});
+
+test('AI toggle guard rejects the stale pre19 preference-only wiring', () => {
+  const current = {
+    host: read('android/app/src/main/kotlin/one/zephyr/mobile/app/AiWorkspaceHost.kt'),
+    root: read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt'),
+  };
+  assert.throws(
+    () => assertAiToggleGuard({ ...current, host: current.host.replace('if (!chrome.enabled) return', '') }),
+    /must leave composition/,
+  );
+  assert.throws(
+    () => assertAiToggleGuard({ ...current, host: current.host.replace('catalogEnabled && ', '') }),
+    /must never be overridden/,
+  );
+});

--- a/zephyr_one/mobile/tests/android-sftp-picker-properties-crash.test.mjs
+++ b/zephyr_one/mobile/tests/android-sftp-picker-properties-crash.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const repo = path.resolve(mobile, '..', '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+function assertPickerAndPropertiesGuards({ versions, app, workflow, sftp }) {
+  assert.match(versions, /^fragment\s*=\s*"1\.8\.5"$/m,
+    'Fragment must override Biometric alpha transitive Fragment 1.2.5');
+  assert.match(versions, /androidx-fragment\s*=\s*\{\s*module\s*=\s*"androidx\.fragment:fragment",\s*version\.ref\s*=\s*"fragment"\s*\}/,
+    'the version catalog must expose the pinned Fragment');
+  assert.match(app, /implementation\(libs\.androidx\.fragment\)/,
+    'the application must resolve the compatible FragmentActivity implementation');
+  assert.match(workflow, /META-INF\/androidx\.fragment_fragment\.version[\s\S]*?1\.8\.5/,
+    'release validation must inspect the resolved APK, not trust only Gradle source');
+  assert.match(sftp, /ActivityResultContracts\.GetMultipleContents\(\)/,
+    'SFTP upload must remain a system multi-document picker');
+  assert.match(sftp, /ActivityResultContracts\.CreateDocument\("\*\/\*"\)/,
+    'SFTP download must remain a system create-document picker');
+
+  const properties = sftp.match(/is SftpDialog\.Properties -> AlertDialog\(([\s\S]*?)\n\s*is SftpDialog\.Chmod ->/u)?.[1];
+  assert.ok(properties, 'missing SFTP properties dialog');
+  assert.doesNotMatch(properties, /verticalScroll\s*\(/,
+    'AlertDialog already scrolls its bounded text body; properties must not nest scrolling');
+}
+
+test('SFTP upload, download and properties retain crash guards', () => {
+  assertPickerAndPropertiesGuards({
+    versions: read('android/gradle/libs.versions.toml'),
+    app: read('android/app/build.gradle.kts'),
+    workflow: fs.readFileSync(path.join(repo, '.github/workflows/zephyr-one-mobile.yml'), 'utf8'),
+    sftp: read('android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt'),
+  });
+});
+
+test('guards reject pre19 picker and nested-scroll regressions', () => {
+  const current = {
+    versions: read('android/gradle/libs.versions.toml'),
+    app: read('android/app/build.gradle.kts'),
+    workflow: fs.readFileSync(path.join(repo, '.github/workflows/zephyr-one-mobile.yml'), 'utf8'),
+    sftp: read('android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt'),
+  };
+  assert.throws(
+    () => assertPickerAndPropertiesGuards({ ...current, versions: current.versions.replace('fragment = "1.8.5"', 'fragment = "1.2.5"') }),
+    /Fragment must override/,
+  );
+  assert.throws(
+    () => assertPickerAndPropertiesGuards({ ...current, app: current.app.replace('implementation(libs.androidx.fragment)', '') }),
+    /application must resolve/,
+  );
+  assert.throws(
+    () => assertPickerAndPropertiesGuards({
+      ...current,
+      sftp: current.sftp.replace('Column {\n                        current.lines.forEach', 'Column(Modifier.verticalScroll(rememberScrollState())) {\n                        current.lines.forEach'),
+    }),
+    /must not nest scrolling/,
+  );
+});

--- a/zephyr_one/mobile/tests/terminal-add-host-sheet.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-add-host-sheet.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+function blockAt(source, marker) {
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${marker}`);
+  const brace = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = brace; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(brace + 1, i);
+    }
+  }
+  assert.fail(`unterminated ${marker}`);
+}
+
+function assertTerminalAddHost({ screen, root, zh, sftp }) {
+  const overlay = blockAt(screen, 'Box(Modifier.fillMaxSize()) {');
+  assert.match(overlay, /BoxWithConstraints\(Modifier\.fillMaxSize\(\)\.background\(colors\.termBg\)\)/,
+    'terminal content must remain the base layer');
+  assert.match(overlay, /ActionSheet\([\s\S]*?visible\s*=\s*ws\.addSheetOpen/,
+    'the add-host sheet must be inside the same full-screen Box, above terminal content');
+  assert.match(screen, /openConnectionIds[\s\S]*?it\.connectionId[\s\S]*?connection\.id !in openConnectionIds/,
+    'the picker must offer only terminal connections not already open');
+  assert.match(screen, /items\s*=\s*addableConnections\.map/,
+    'the sheet rows must use the filtered host list');
+  assert.match(root, /onAddSession\s*=\s*\{\s*connection\s*->[\s\S]*?routeForProtocol\(UUID\.randomUUID\(\)\.toString\(\), connection\.id, connection\.protocol\)/,
+    'selecting a host must create and navigate to a real new terminal session');
+  assert.match(zh, /<string name="terminal_new_session_title">再开一台主机<\/string>/,
+    'terminal and SFTP must use the same add-host title');
+  assert.match(sftp, /ActionSheet\([\s\S]*?title\s*=\s*"再开一台主机"/,
+    'terminal behavior is intentionally aligned with the SFTP host picker');
+}
+
+test('terminal plus overlays the SFTP-style add-host picker', () => {
+  assertTerminalAddHost({
+    screen: read('android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt'),
+    root: read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt'),
+    zh: read('android/feature-sessions/src/main/res/values/strings.xml'),
+    sftp: read('android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt'),
+  });
+});
+
+test('terminal plus guard rejects the pre19 below-screen sheet', () => {
+  const current = {
+    screen: read('android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt'),
+    root: read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt'),
+    zh: read('android/feature-sessions/src/main/res/values/strings.xml'),
+    sftp: read('android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt'),
+  };
+  assert.throws(
+    () => assertTerminalAddHost({ ...current, screen: current.screen.replace('Box(Modifier.fillMaxSize()) {', 'Column(Modifier.fillMaxSize()) {') }),
+    /missing Box\(Modifier\.fillMaxSize/,
+  );
+  assert.throws(
+    () => assertTerminalAddHost({ ...current, screen: current.screen.replace('items = addableConnections.map', 'items = connections.map') }),
+    /filtered host list/,
+  );
+});


### PR DESCRIPTION
## Fixed
- AI authoritative LocalAiCatalog.enabled removes the overlay/FAB and tears down its runtime.
- SFTP upload/download no longer crash through FragmentActivity high request codes: pin Fragment 1.8.5 over Biometric alpha transitive Fragment 1.2.5.
- SFTP properties removes nested vertical scrolling.
- Terminal tab + now overlays the same add-host sheet above the terminal, lists only unopened terminal hosts, then creates and switches to a real session.
- Tools summary follows the AI authority.

## Verification
Focused mutation-backed AI/SFTP/terminal/cold-start contracts pass. Android CI compiles prerelease, runs unit tests, verifies signing, and inspects packaged Fragment metadata.