### PR TITLE
fix(mobile): remove terminal tool drawer top corners

### DIFF
--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -96,9 +95,7 @@ internal fun TerminalToolSheet(
             Modifier
                 .fillMaxWidth()
                 .height(maxHeight * animatedFraction)
-                .clip(RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp))
-                .background(colors.chrome)
-                .border(width = 1.dp, color = colors.line, shape = RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)),
+                .background(colors.chrome),
         ) {
             Box(
                 Modifier

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
@@ -1,11 +1,27 @@
 package one.zephyr.mobile.feature.sessions
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 
 class TerminalToolSheetTest {
     private fun state() = TerminalWorkspaceState(paneA = "s1")
+
+    private fun codeOnly(source: String): String =
+        source
+            .replace(Regex("/\\*[\\s\\S]*?\\*/"), " ")
+            .replace(Regex("//[^\\n]*"), " ")
+
+    private val sheetSource: String by lazy {
+        val relative = "src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheet.kt"
+        val start = File(".").canonicalFile
+        val file = generateSequence(start) { it.parentFile }
+            .flatMap { root -> sequenceOf(File(root, relative), File(root, "feature-sessions/$relative")) }
+            .first { it.exists() }
+        file.readText()
+    }
 
     @Test
     fun phoneToolUsesInFlowSheetNeverFloatingState() {
@@ -67,6 +83,15 @@ class TerminalToolSheetTest {
         assertTrue(!TerminalToolKind.THEME.keepsIme)
         val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.DOCKER, phone = true)
         assertEquals(TerminalToolKind.DOCKER, opened.sheetCurrent)
+    }
+
+    @Test
+    fun phoneSheetIsASquareChromeFillNotARoundedCard() {
+        val source = codeOnly(sheetSource)
+        assertTrue(source.contains(".background(colors.chrome)"))
+        assertFalse(source.contains("RoundedCornerShape(topStart"))
+        assertFalse(source.contains(".border("))
+        assertTrue(source.contains("clip(RoundedCornerShape(3.dp))"))
     }
 
     @Test

--- a/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-tool-sheet.test.mjs
@@ -42,6 +42,20 @@ test('IME button closes tool drawer before showing keyboard', () => {
   assert.match(screen, /TerminalWorkspace\.closeSheet\(ws\)[\s\S]*onIntent\(intent\)/);
 });
 
+test('tool drawer is a square chrome fill, not a rounded card', () => {
+  // The sheet sits flush under the dock. Top rounded clip + rounded border left the
+  // terminal canvas showing through the two top corners. Fill only; keep the drag
+  // handle's own 3.dp radius.
+  assert.match(sheet, /\.background\(colors\.chrome\)/);
+  assert.doesNotMatch(sheet, /RoundedCornerShape\(topStart/);
+  assert.doesNotMatch(sheet, /clip\(RoundedCornerShape\(topStart/);
+  assert.doesNotMatch(
+    sheet.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' '),
+    /\.border\s*\(/,
+  );
+  assert.match(sheet, /clip\(RoundedCornerShape\(3\.dp\)\)/);
+});
+
 test('FILES drawer with its text editor survives an open IME', () => {
   // The file browser embeds a text editor that needs the system keyboard. When the IME opens
   // inside it the drawer must stay composed (shrunk above the keyboard via imePadding), instead of


### PR DESCRIPTION
## 修改
- 去掉手机端终端工具抽屉顶部 14dp 圆角裁剪
- 去掉对应圆角描边，仅保留 `colors.chrome` 纯色填充
- 保留拖拽把手自身的小圆角

## 验证
- `node --test tests/terminal-tool-sheet.test.mjs`：6/6
- 圆角回归 mutation：专项测试按预期失败
- `git diff --check`：通过
- 完整 contracts 中新增用例通过；本机其余既有失败来自 PRoot Java executable-memory 限制及 sparse FREEZE/server fixtures，交由 CI 完整验证