### PR TITLE
fix(mobile): OpenSSH v1 key login and SFTP editor stutter

### DIFF
--- a/zephyr_one/mobile/android/app/proguard-rules.pro
+++ b/zephyr_one/mobile/android/app/proguard-rules.pro
@@ -1,7 +1,12 @@
-# SSHJ / EdDSA reference desktop-only JDK classes. They are never used on Android.
+# SSHJ discovers ciphers, key types and key-file factories by reflection.
+# OpenSSH v1 lives in com.hierynomus.sshj, not net.schmizz.sshj; dropping it
+# makes every modern private key fail after R8.
 -dontwarn sun.security.x509.X509Key
 -dontwarn sun.security.**
 -dontwarn org.slf4j.**
 -dontwarn org.bouncycastle.**
+-dontwarn com.hierynomus.**
 -keep class net.schmizz.sshj.** { *; }
+-keep class com.hierynomus.sshj.** { *; }
 -keep class net.i2p.crypto.eddsa.** { *; }
+-keep class org.bouncycastle.** { *; }

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt
@@ -81,9 +81,10 @@ class SshjSftpPort(
         force: Boolean,
     ): RemoteWriteReceipt {
         var expectedVersion: SshRemoteFileVersion? = null
-        if (!force && expectedSha256 != null) {
-            val current = engine.readFile(session(handle), path, EDIT_READ_LIMIT).getOrThrow()
-            if (current.modifiedAt != expectedMtimeMs || sha256(current.bytes) != expectedSha256) {
+        if (!force && (expectedMtimeMs != null || expectedSha256 != null)) {
+            val current = engine.stat(session(handle), path).getOrThrow()
+                ?: throw SshRemoteFileConflict(path, 0L, 0L)
+            if (expectedMtimeMs != null && current.modifiedAt != expectedMtimeMs) {
                 throw SshRemoteFileConflict(path, current.size, current.modifiedAt)
             }
             expectedVersion = SshRemoteFileVersion(path, current.size, current.modifiedAt)
@@ -197,8 +198,4 @@ class SshjSftpPort(
 
     private fun sha256(bytes: ByteArray): String =
         MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
-
-    companion object {
-        private const val EDIT_READ_LIMIT = 512 * 1024
-    }
 }

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -1681,17 +1681,26 @@ private suspend fun AccountContainer.connectionTestCredentials(
     connection: Connection,
     draft: ConnectionDraft,
 ): ConnectionTestCredentials {
-    val replacementPassword = draft.testPasswordChars()
-    val replacementKey = draft.testPrivateKeyChars()
-    if (replacementPassword != null || replacementKey != null) {
-        return ConnectionTestCredentials(password = replacementPassword, privateKey = replacementKey)
-    }
+    // Create starts the password field in Replace(""), which is not a secret. Treating that
+    // empty array as "user typed a password" hid the selected SSH key and made key login
+    // look like a failed password attempt.
+    val replacementPassword = draft.testPasswordChars().takeUnlessBlankSecret()
+    val replacementKey = draft.testPrivateKeyChars().takeUnlessBlankSecret()
     val stored = terminalCredentials(connection)
     return ConnectionTestCredentials(
-        password = stored.password,
-        privateKey = stored.privateKey,
+        password = replacementPassword ?: stored.password,
+        privateKey = replacementKey ?: stored.privateKey,
         passphrase = stored.passphrase,
     )
+}
+
+internal fun CharArray?.takeUnlessBlankSecret(): CharArray? {
+    if (this == null) return null
+    if (isEmpty() || all { it.isWhitespace() }) {
+        fill('\u0000')
+        return null
+    }
+    return this
 }
 
 internal suspend fun AccountContainer.terminalCredentials(connection: Connection): TerminalCredentials {

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/SecretProviderGateTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/SecretProviderGateTest.kt
@@ -4,6 +4,7 @@ import one.zephyr.mobile.model.SecretPresence
 import one.zephyr.mobile.model.SecretRef
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SecretProviderGateTest {
@@ -45,5 +46,27 @@ class SecretProviderGateTest {
                 "password",
             ),
         )
+    }
+
+    @Test
+    fun `an empty create-password field is not a replacement secret`() {
+        assertNull(null.takeUnlessBlankSecret())
+        val empty = CharArray(0)
+        assertNull(empty.takeUnlessBlankSecret())
+        val spaces = charArrayOf(' ', '\t')
+        assertNull(spaces.takeUnlessBlankSecret())
+        assertTrue(spaces.all { it.code == 0 })
+        val typed = charArrayOf('s', 'e', 'c', 'r', 'e', 't')
+        assertEquals("secret", typed.takeUnlessBlankSecret()?.concatToString())
+    }
+
+    @Test
+    fun `blank replacement password must not hide a stored ssh key`() {
+        val replacementPassword = "".toCharArray()
+        val storedKey = "-----BEGIN OPENSSH PRIVATE KEY-----".toCharArray()
+        val password = replacementPassword.takeUnlessBlankSecret()
+        val key = storedKey.takeUnlessBlankSecret()
+        assertNull(password)
+        assertEquals("-----BEGIN OPENSSH PRIVATE KEY-----", key?.concatToString())
     }
 }

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
@@ -28,10 +28,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -1121,23 +1119,18 @@ private fun SftpTextEditor(
     var outlineOpen by remember { mutableStateOf(false) }
     var workspaceQuery by remember { mutableStateOf("") }
     var workspaceOpen by remember { mutableStateOf(false) }
-    var draft by remember(file.path) {
-        mutableStateOf(TextFieldValue(file.text, TextRange(file.text.length)))
-    }
+    var draft by remember(file.path) { mutableStateOf(file.text) }
     LaunchedEffect(file.path, file.generation) {
-        if (draft.text != file.text) {
-            val nextSelection = draft.selection.start.coerceIn(0, file.text.length)
-            draft = TextFieldValue(file.text, TextRange(nextSelection))
-        }
+        if (draft != file.text) draft = file.text
     }
     var analysisText by remember(file.path) { mutableStateOf(file.text) }
-    LaunchedEffect(draft.text, findOpen, outlineOpen, findQuery) {
+    LaunchedEffect(draft, findOpen, outlineOpen, findQuery) {
         if (!findOpen && !outlineOpen) {
-            analysisText = draft.text
+            analysisText = draft
             return@LaunchedEffect
         }
         delay(180)
-        analysisText = draft.text
+        analysisText = draft
     }
     val hits = remember(analysisText, findQuery, findOpen) {
         if (!findOpen || findQuery.isBlank()) emptyList() else SftpEditorSupport.findInText(analysisText, findQuery)
@@ -1146,16 +1139,16 @@ private fun SftpTextEditor(
         if (!outlineOpen) emptyList() else SftpEditorSupport.outline(analysisText, file.path)
     }
     fun commitDraft() {
-        if (draft.text != file.text) {
-            onChange(draft.text, file.encoding, file.lineEnding, file.tabSize, file.wrap)
+        if (draft != file.text) {
+            onChange(draft, file.encoding, file.lineEnding, file.tabSize, file.wrap)
         }
     }
     // First differing keystroke marks dirty immediately so BackHandler cannot
     // drop the file as clean. Later keystrokes stay local for 140ms.
-    LaunchedEffect(draft.text, file.path, file.encoding, file.lineEnding, file.tabSize, file.wrap) {
-        if (draft.text == file.text) return@LaunchedEffect
+    LaunchedEffect(draft, file.path, file.encoding, file.lineEnding, file.tabSize, file.wrap) {
+        if (draft == file.text) return@LaunchedEffect
         if (file.dirty) delay(140)
-        onChange(draft.text, file.encoding, file.lineEnding, file.tabSize, file.wrap)
+        onChange(draft, file.encoding, file.lineEnding, file.tabSize, file.wrap)
     }
     Column(Modifier.fillMaxSize()) {
         Row(
@@ -1167,15 +1160,15 @@ private fun SftpTextEditor(
             Column(Modifier.weight(1f)) {
                 Text(file.title, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, maxLines = 1)
                 Text(
-                    (if (file.dirty || draft.text != file.text) "未保存 · " else "") + SftpEditorSupport.languageOf(file.path) + " · " + file.path,
+                    (if (file.dirty || draft != file.text) "未保存 · " else "") + SftpEditorSupport.languageOf(file.path) + " · " + file.path,
                     color = ZephyrTheme.palette.onFloatingSubtle,
                     fontSize = 10.sp,
                     maxLines = 1,
                 )
             }
             PrimaryButton(
-                onClick = { onSave(draft.text) },
-                enabled = file.dirty || draft.text != file.text,
+                onClick = { onSave(draft) },
+                enabled = file.dirty || draft != file.text,
             ) { Text("保存") }
         }
         Row(
@@ -1185,7 +1178,7 @@ private fun SftpTextEditor(
             files.forEachIndexed { index, tab ->
                 AssistChip(
                     onClick = { commitDraft(); onSelect(index) },
-                    label = { Text((if (tab.dirty || (index == activeIndex && draft.text != file.text)) "● " else "") + tab.title, fontSize = 11.sp) },
+                    label = { Text((if (tab.dirty || (index == activeIndex && draft != file.text)) "● " else "") + tab.title, fontSize = 11.sp) },
                 )
                 if (index == activeIndex) {
                     TextButton(onClick = { commitDraft(); onCloseTab(index) }) { Text("×") }
@@ -1205,14 +1198,14 @@ private fun SftpTextEditor(
                     label = { Text(encoding.label, fontSize = 11.sp) },
                 )
             }
-            FilterChip(selected = file.lineEnding == "lf", onClick = { onChange(draft.text, file.encoding, "lf", file.tabSize, file.wrap) }, label = { Text("LF", fontSize = 11.sp) })
-            FilterChip(selected = file.lineEnding == "crlf", onClick = { onChange(draft.text, file.encoding, "crlf", file.tabSize, file.wrap) }, label = { Text("CRLF", fontSize = 11.sp) })
-            FilterChip(selected = file.tabSize == 2, onClick = { onChange(draft.text, file.encoding, file.lineEnding, 2, file.wrap) }, label = { Text("Tab 2", fontSize = 11.sp) })
-            FilterChip(selected = file.tabSize == 4, onClick = { onChange(draft.text, file.encoding, file.lineEnding, 4, file.wrap) }, label = { Text("Tab 4", fontSize = 11.sp) })
-            FilterChip(selected = file.wrap, onClick = { onChange(draft.text, file.encoding, file.lineEnding, file.tabSize, !file.wrap) }, label = { Text("换行", fontSize = 11.sp) })
-            AssistChip(onClick = { commitDraft(); onUndo(draft.text) }, label = { Text("撤回", fontSize = 11.sp) })
-            AssistChip(onClick = { commitDraft(); onRedo(draft.text) }, label = { Text("前进", fontSize = 11.sp) })
-            AssistChip(onClick = { commitDraft(); onFormat(draft.text) }, label = { Text("格式化", fontSize = 11.sp) })
+            FilterChip(selected = file.lineEnding == "lf", onClick = { onChange(draft, file.encoding, "lf", file.tabSize, file.wrap) }, label = { Text("LF", fontSize = 11.sp) })
+            FilterChip(selected = file.lineEnding == "crlf", onClick = { onChange(draft, file.encoding, "crlf", file.tabSize, file.wrap) }, label = { Text("CRLF", fontSize = 11.sp) })
+            FilterChip(selected = file.tabSize == 2, onClick = { onChange(draft, file.encoding, file.lineEnding, 2, file.wrap) }, label = { Text("Tab 2", fontSize = 11.sp) })
+            FilterChip(selected = file.tabSize == 4, onClick = { onChange(draft, file.encoding, file.lineEnding, 4, file.wrap) }, label = { Text("Tab 4", fontSize = 11.sp) })
+            FilterChip(selected = file.wrap, onClick = { onChange(draft, file.encoding, file.lineEnding, file.tabSize, !file.wrap) }, label = { Text("换行", fontSize = 11.sp) })
+            AssistChip(onClick = { commitDraft(); onUndo(draft) }, label = { Text("撤回", fontSize = 11.sp) })
+            AssistChip(onClick = { commitDraft(); onRedo(draft) }, label = { Text("前进", fontSize = 11.sp) })
+            AssistChip(onClick = { commitDraft(); onFormat(draft) }, label = { Text("格式化", fontSize = 11.sp) })
             AssistChip(onClick = { findOpen = !findOpen }, label = { Text("查找", fontSize = 11.sp) })
             AssistChip(onClick = { outlineOpen = !outlineOpen }, label = { Text("大纲", fontSize = 11.sp) })
             AssistChip(onClick = { workspaceOpen = !workspaceOpen }, label = { Text("搜目录", fontSize = 11.sp) })
@@ -1253,7 +1246,8 @@ private fun SftpTextEditor(
                     fontSize = 13.sp,
                     lineHeight = 19.sp,
                 ),
-                softWrap = file.wrap,
+                singleLine = false,
+                maxLines = Int.MAX_VALUE,
             )
             if (outlineOpen) {
                 Column(

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt
@@ -28,11 +28,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import one.zephyr.mobile.model.MobileApiException
 import one.zephyr.mobile.protocol.ssh.SshFileKinds
@@ -43,8 +46,6 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
 
-private const val EDIT_WRITE_LIMIT = 2 * 1024 * 1024
-
 private data class BrowserFile(
     val path: String,
     val text: String,
@@ -54,8 +55,7 @@ private data class BrowserFile(
     val tabSize: Int = 4,
     val wrap: Boolean = true,
     val dirty: Boolean = false,
-    val undo: List<String> = emptyList(),
-    val redo: List<String> = emptyList(),
+    val generation: Int = 0,
 ) {
     val title: String get() = path.substringAfterLast('/').ifBlank { path }
 }
@@ -112,6 +112,7 @@ fun SftpBrowserPane(
     var editors by remember { mutableStateOf<List<BrowserFile>>(emptyList()) }
     var editorIndex by remember { mutableIntStateOf(0) }
     val editor = editors.getOrNull(editorIndex)
+    val histories = remember(connectionId) { mutableMapOf<String, SftpEditorHistory>() }
     var preview by remember { mutableStateOf<PreviewState?>(null) }
     var pendingClose by remember { mutableStateOf(false) }
     var dialog by remember { mutableStateOf<SftpDialog?>(null) }
@@ -164,6 +165,7 @@ fun SftpBrowserPane(
             return
         }
         val next = editors.toMutableList().also { it.removeAt(index) }
+        histories.remove(target.path)
         editors = next
         editorIndex = editorIndex.coerceAtMost((next.size - 1).coerceAtLeast(0))
     }
@@ -552,7 +554,14 @@ fun SftpBrowserPane(
                 onCloseTab = { closeEditor(force = false, index = it) },
                 onChange = { text, encoding, ending, tabSize, wrap ->
                     updateActive { current ->
-                        val history = (current.undo + current.text).takeLast(40)
+                        val sameText = current.text == text
+                        val sameMeta = current.encoding == encoding &&
+                            current.lineEnding == ending &&
+                            current.tabSize == tabSize &&
+                            current.wrap == wrap
+                        if (sameText && sameMeta) return@updateActive current
+                        val history = histories.getOrPut(current.path) { SftpEditorHistory() }
+                        history.record(current.text, text)
                         current.copy(
                             text = text,
                             encoding = encoding,
@@ -560,41 +569,32 @@ fun SftpBrowserPane(
                             tabSize = tabSize,
                             wrap = wrap,
                             dirty = true,
-                            undo = history,
-                            redo = emptyList(),
+                            generation = if (sameText) current.generation else current.generation + 1,
                         )
                     }
                 },
-                onUndo = {
+                onUndo = { latest ->
                     updateActive { current ->
-                        val previous = current.undo.lastOrNull() ?: return@updateActive current
-                        current.copy(
-                            text = previous,
-                            undo = current.undo.dropLast(1),
-                            redo = current.redo + current.text,
-                            dirty = true,
-                        )
+                        val previous = histories[current.path]?.undo(latest) ?: return@updateActive current
+                        current.copy(text = previous, dirty = true, generation = current.generation + 1)
                     }
                 },
-                onRedo = {
+                onRedo = { latest ->
                     updateActive { current ->
-                        val next = current.redo.lastOrNull() ?: return@updateActive current
-                        current.copy(
-                            text = next,
-                            redo = current.redo.dropLast(1),
-                            undo = current.undo + current.text,
-                            dirty = true,
-                        )
+                        val next = histories[current.path]?.redo(latest) ?: return@updateActive current
+                        current.copy(text = next, dirty = true, generation = current.generation + 1)
                     }
                 },
-                onFormat = {
+                onFormat = { latest ->
                     updateActive { current ->
-                        current.copy(text = SftpEditorSupport.formatDocument(current.text, current.tabSize), dirty = true)
+                        val formatted = SftpEditorSupport.formatDocument(latest, current.tabSize)
+                        histories.getOrPut(current.path) { SftpEditorHistory() }.record(latest, formatted)
+                        current.copy(text = formatted, dirty = true, generation = current.generation + 1)
                     }
                 },
                 onBack = { closeEditor(force = false) },
-                onSave = {
-                    val current = editor ?: return@SftpTextEditor
+                onSave = { latest ->
+                    val current = (editor ?: return@SftpTextEditor).copy(text = latest)
                     scope.launch {
                         runOp(onMessage, { busy = it }, { transfer = it }) {
                             val normalized = if (current.lineEnding == "crlf") {
@@ -618,12 +618,12 @@ fun SftpBrowserPane(
                                 }
                                 throw failure
                             }
+                            histories[current.path]?.clear()
                             upsertEditor(
                                 current.copy(
                                     baseline = RemoteFileRead(current.path, bytes, receipt.mtimeMs, receipt.sha256),
                                     dirty = false,
-                                    undo = emptyList(),
-                                    redo = emptyList(),
+                                    generation = current.generation + 1,
                                 ),
                             )
                             onMessage("已保存")
@@ -859,10 +859,12 @@ fun SftpBrowserPane(
                             runOp(onMessage, { busy = it }, { transfer = it }) {
                                 val bytes = currentFile.encoding.encode(currentFile.text)
                                 val receipt = port.write(currentHandle(), currentFile.path, bytes, null, null, force = true)
+                                histories[currentFile.path]?.clear()
                                 upsertEditor(
                                     currentFile.copy(
                                         baseline = RemoteFileRead(currentFile.path, bytes, receipt.mtimeMs, receipt.sha256),
                                         dirty = false,
+                                        generation = currentFile.generation + 1,
                                     ),
                                 )
                                 onMessage("已强制覆盖保存")
@@ -1105,11 +1107,11 @@ private fun SftpTextEditor(
     onSelect: (Int) -> Unit,
     onCloseTab: (Int) -> Unit,
     onChange: (String, FileEncoding, String, Int, Boolean) -> Unit,
-    onUndo: () -> Unit,
-    onRedo: () -> Unit,
-    onFormat: () -> Unit,
+    onUndo: (String) -> Unit,
+    onRedo: (String) -> Unit,
+    onFormat: (String) -> Unit,
     onBack: () -> Unit,
-    onSave: () -> Unit,
+    onSave: (String) -> Unit,
     onWorkspaceSearch: (String) -> Unit,
     onOpenHit: (String) -> Unit,
 ) {
@@ -1119,25 +1121,62 @@ private fun SftpTextEditor(
     var outlineOpen by remember { mutableStateOf(false) }
     var workspaceQuery by remember { mutableStateOf("") }
     var workspaceOpen by remember { mutableStateOf(false) }
-    val hits = remember(file.text, findQuery) { SftpEditorSupport.findInText(file.text, findQuery) }
-    val outline = remember(file.text, file.path) { SftpEditorSupport.outline(file.text, file.path) }
+    var draft by remember(file.path) {
+        mutableStateOf(TextFieldValue(file.text, TextRange(file.text.length)))
+    }
+    LaunchedEffect(file.path, file.generation) {
+        if (draft.text != file.text) {
+            val nextSelection = draft.selection.start.coerceIn(0, file.text.length)
+            draft = TextFieldValue(file.text, TextRange(nextSelection))
+        }
+    }
+    var analysisText by remember(file.path) { mutableStateOf(file.text) }
+    LaunchedEffect(draft.text, findOpen, outlineOpen, findQuery) {
+        if (!findOpen && !outlineOpen) {
+            analysisText = draft.text
+            return@LaunchedEffect
+        }
+        delay(180)
+        analysisText = draft.text
+    }
+    val hits = remember(analysisText, findQuery, findOpen) {
+        if (!findOpen || findQuery.isBlank()) emptyList() else SftpEditorSupport.findInText(analysisText, findQuery)
+    }
+    val outline = remember(analysisText, file.path, outlineOpen) {
+        if (!outlineOpen) emptyList() else SftpEditorSupport.outline(analysisText, file.path)
+    }
+    fun commitDraft() {
+        if (draft.text != file.text) {
+            onChange(draft.text, file.encoding, file.lineEnding, file.tabSize, file.wrap)
+        }
+    }
+    // First differing keystroke marks dirty immediately so BackHandler cannot
+    // drop the file as clean. Later keystrokes stay local for 140ms.
+    LaunchedEffect(draft.text, file.path, file.encoding, file.lineEnding, file.tabSize, file.wrap) {
+        if (draft.text == file.text) return@LaunchedEffect
+        if (file.dirty) delay(140)
+        onChange(draft.text, file.encoding, file.lineEnding, file.tabSize, file.wrap)
+    }
     Column(Modifier.fillMaxSize()) {
         Row(
             Modifier.fillMaxWidth().background(ZephyrTheme.palette.surfaces.content).padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            IconButton(onClick = onBack) { Icon(ZephyrIcons.Back, "返回文件列表") }
+            IconButton(onClick = { commitDraft(); onBack() }) { Icon(ZephyrIcons.Back, "返回文件列表") }
             Column(Modifier.weight(1f)) {
                 Text(file.title, color = ZephyrTheme.palette.onFloating, fontWeight = FontWeight.SemiBold, maxLines = 1)
                 Text(
-                    (if (file.dirty) "未保存 · " else "") + SftpEditorSupport.languageOf(file.path) + " · " + file.path,
+                    (if (file.dirty || draft.text != file.text) "未保存 · " else "") + SftpEditorSupport.languageOf(file.path) + " · " + file.path,
                     color = ZephyrTheme.palette.onFloatingSubtle,
                     fontSize = 10.sp,
                     maxLines = 1,
                 )
             }
-            PrimaryButton(onClick = onSave, enabled = file.dirty) { Text("保存") }
+            PrimaryButton(
+                onClick = { onSave(draft.text) },
+                enabled = file.dirty || draft.text != file.text,
+            ) { Text("保存") }
         }
         Row(
             Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp, vertical = 4.dp),
@@ -1145,11 +1184,11 @@ private fun SftpTextEditor(
         ) {
             files.forEachIndexed { index, tab ->
                 AssistChip(
-                    onClick = { onSelect(index) },
-                    label = { Text((if (tab.dirty) "● " else "") + tab.title, fontSize = 11.sp) },
+                    onClick = { commitDraft(); onSelect(index) },
+                    label = { Text((if (tab.dirty || (index == activeIndex && draft.text != file.text)) "● " else "") + tab.title, fontSize = 11.sp) },
                 )
                 if (index == activeIndex) {
-                    TextButton(onClick = { onCloseTab(index) }) { Text("×") }
+                    TextButton(onClick = { commitDraft(); onCloseTab(index) }) { Text("×") }
                 }
             }
         }
@@ -1166,14 +1205,14 @@ private fun SftpTextEditor(
                     label = { Text(encoding.label, fontSize = 11.sp) },
                 )
             }
-            FilterChip(selected = file.lineEnding == "lf", onClick = { onChange(file.text, file.encoding, "lf", file.tabSize, file.wrap) }, label = { Text("LF", fontSize = 11.sp) })
-            FilterChip(selected = file.lineEnding == "crlf", onClick = { onChange(file.text, file.encoding, "crlf", file.tabSize, file.wrap) }, label = { Text("CRLF", fontSize = 11.sp) })
-            FilterChip(selected = file.tabSize == 2, onClick = { onChange(file.text, file.encoding, file.lineEnding, 2, file.wrap) }, label = { Text("Tab 2", fontSize = 11.sp) })
-            FilterChip(selected = file.tabSize == 4, onClick = { onChange(file.text, file.encoding, file.lineEnding, 4, file.wrap) }, label = { Text("Tab 4", fontSize = 11.sp) })
-            FilterChip(selected = file.wrap, onClick = { onChange(file.text, file.encoding, file.lineEnding, file.tabSize, !file.wrap) }, label = { Text("换行", fontSize = 11.sp) })
-            AssistChip(onClick = onUndo, label = { Text("撤回", fontSize = 11.sp) })
-            AssistChip(onClick = onRedo, label = { Text("前进", fontSize = 11.sp) })
-            AssistChip(onClick = onFormat, label = { Text("格式化", fontSize = 11.sp) })
+            FilterChip(selected = file.lineEnding == "lf", onClick = { onChange(draft.text, file.encoding, "lf", file.tabSize, file.wrap) }, label = { Text("LF", fontSize = 11.sp) })
+            FilterChip(selected = file.lineEnding == "crlf", onClick = { onChange(draft.text, file.encoding, "crlf", file.tabSize, file.wrap) }, label = { Text("CRLF", fontSize = 11.sp) })
+            FilterChip(selected = file.tabSize == 2, onClick = { onChange(draft.text, file.encoding, file.lineEnding, 2, file.wrap) }, label = { Text("Tab 2", fontSize = 11.sp) })
+            FilterChip(selected = file.tabSize == 4, onClick = { onChange(draft.text, file.encoding, file.lineEnding, 4, file.wrap) }, label = { Text("Tab 4", fontSize = 11.sp) })
+            FilterChip(selected = file.wrap, onClick = { onChange(draft.text, file.encoding, file.lineEnding, file.tabSize, !file.wrap) }, label = { Text("换行", fontSize = 11.sp) })
+            AssistChip(onClick = { commitDraft(); onUndo(draft.text) }, label = { Text("撤回", fontSize = 11.sp) })
+            AssistChip(onClick = { commitDraft(); onRedo(draft.text) }, label = { Text("前进", fontSize = 11.sp) })
+            AssistChip(onClick = { commitDraft(); onFormat(draft.text) }, label = { Text("格式化", fontSize = 11.sp) })
             AssistChip(onClick = { findOpen = !findOpen }, label = { Text("查找", fontSize = 11.sp) })
             AssistChip(onClick = { outlineOpen = !outlineOpen }, label = { Text("大纲", fontSize = 11.sp) })
             AssistChip(onClick = { workspaceOpen = !workspaceOpen }, label = { Text("搜目录", fontSize = 11.sp) })
@@ -1199,15 +1238,22 @@ private fun SftpTextEditor(
         }
         Row(Modifier.fillMaxSize()) {
             BasicTextField(
-                value = file.text,
-                onValueChange = { onChange(it, file.encoding, file.lineEnding, file.tabSize, file.wrap) },
-                modifier = Modifier.weight(1f).fillMaxSize().background(ZephyrTheme.palette.surfaces.background).padding(14.dp),
+                value = draft,
+                onValueChange = { draft = it },
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(ZephyrTheme.palette.surfaces.background)
+                    .verticalScroll(rememberScrollState())
+                    .then(if (file.wrap) Modifier else Modifier.horizontalScroll(rememberScrollState()))
+                    .padding(14.dp),
                 textStyle = androidx.compose.ui.text.TextStyle(
                     color = ZephyrTheme.palette.onFloating,
                     fontFamily = FontFamily.Monospace,
                     fontSize = 13.sp,
                     lineHeight = 19.sp,
                 ),
+                softWrap = file.wrap,
             )
             if (outlineOpen) {
                 Column(

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistory.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistory.kt
@@ -1,0 +1,92 @@
+package one.zephyr.mobile.feature.notes
+
+/**
+ * Undo/redo for the in-drawer SFTP editor.
+ *
+ * The previous editor copied the whole file into a `List<String>` on every keystroke.
+ * A 200 KiB file then allocated another 200 KiB per character and recomputed outline
+ * plus find against the new snapshot. Typing felt stuck because it *was* stuck.
+ *
+ * Snapshots are still full strings (the editor already holds the current text), but
+ * successive small edits inside [coalesceMs] share one undo entry.
+ */
+class SftpEditorHistory(
+    private val capacity: Int = DEFAULT_CAPACITY,
+    private val coalesceMs: Long = DEFAULT_COALESCE_MS,
+    private val coalesceChars: Int = DEFAULT_COALESCE_CHARS,
+) {
+    private val undo = ArrayList<String>()
+    private val redo = ArrayList<String>()
+    private var lastPushAt = 0L
+
+    val undoSize: Int get() = undo.size
+    val redoSize: Int get() = redo.size
+    fun canUndo(): Boolean = undo.isNotEmpty()
+    fun canRedo(): Boolean = redo.isNotEmpty()
+
+    fun record(previous: String, next: String, nowMs: Long = System.currentTimeMillis()): Boolean {
+        if (previous == next) return false
+        val coalesce = undo.isNotEmpty() &&
+            nowMs - lastPushAt in 0..coalesceMs &&
+            isSmallSingleRegionEdit(previous, next)
+        if (!coalesce) {
+            undo += previous
+            if (undo.size > capacity) undo.removeAt(0)
+        }
+        lastPushAt = nowMs
+        redo.clear()
+        return true
+    }
+
+    fun undo(current: String): String? {
+        val previous = undo.removeLastOrNull() ?: return null
+        redo += current
+        lastPushAt = 0L
+        return previous
+    }
+
+    fun redo(current: String): String? {
+        val next = redo.removeLastOrNull() ?: return null
+        undo += current
+        lastPushAt = 0L
+        return next
+    }
+
+    fun clear() {
+        undo.clear()
+        redo.clear()
+        lastPushAt = 0L
+    }
+
+    private fun isSmallSingleRegionEdit(previous: String, next: String): Boolean {
+        val prefix = commonPrefix(previous, next)
+        val suffix = commonSuffix(previous, next, prefix)
+        val removed = previous.length - prefix - suffix
+        val inserted = next.length - prefix - suffix
+        return removed <= coalesceChars && inserted <= coalesceChars
+    }
+
+    private fun commonPrefix(left: String, right: String): Int {
+        val limit = minOf(left.length, right.length)
+        var index = 0
+        while (index < limit && left[index] == right[index]) index++
+        return index
+    }
+
+    private fun commonSuffix(left: String, right: String, prefix: Int): Int {
+        val leftRemain = left.length - prefix
+        val rightRemain = right.length - prefix
+        val limit = minOf(leftRemain, rightRemain)
+        var index = 0
+        while (index < limit && left[left.length - 1 - index] == right[right.length - 1 - index]) {
+            index++
+        }
+        return index
+    }
+
+    companion object {
+        const val DEFAULT_CAPACITY = 80
+        const val DEFAULT_COALESCE_MS = 400L
+        const val DEFAULT_COALESCE_CHARS = 24
+    }
+}

--- a/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistoryTest.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistoryTest.kt
@@ -1,0 +1,93 @@
+package one.zephyr.mobile.feature.notes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SftpEditorHistoryTest {
+
+    @Test
+    fun successiveKeystrokesShareOneUndoEntry() {
+        val history = SftpEditorHistory(coalesceMs = 400L)
+        var text = "hello"
+        text = type(history, text, "hello ", 1_000L)
+        text = type(history, text, "hello w", 1_050L)
+        text = type(history, text, "hello wo", 1_100L)
+        text = type(history, text, "hello wor", 1_150L)
+        assertEquals(1, history.undoSize)
+        assertEquals("hello", history.undo(text))
+    }
+
+    @Test
+    fun aPauseStartsANewUndoEntry() {
+        val history = SftpEditorHistory(coalesceMs = 400L)
+        var text = "a"
+        text = type(history, text, "ab", 1_000L)
+        text = type(history, text, "abc", 1_600L)
+        assertEquals(2, history.undoSize)
+        assertEquals("ab", history.undo(text))
+        assertEquals("a", history.undo("ab"))
+    }
+
+    @Test
+    fun identicalTextDoesNotGrowHistory() {
+        val history = SftpEditorHistory()
+        assertFalse(history.record("same", "same", 1L))
+        assertEquals(0, history.undoSize)
+    }
+
+    @Test
+    fun redoIsClearedByANewEdit() {
+        val history = SftpEditorHistory(coalesceMs = 0L)
+        history.record("a", "ab", 1L)
+        val undone = history.undo("ab")
+        assertEquals("a", undone)
+        assertTrue(history.canRedo())
+        history.record("a", "az", 2L)
+        assertFalse(history.canRedo())
+        assertNull(history.redo("az"))
+    }
+
+    @Test
+    fun aLargePasteDoesNotCoalesceWithThePreviousKeystroke() {
+        val history = SftpEditorHistory(coalesceMs = 400L, coalesceChars = 24)
+        var text = "head"
+        text = type(history, text, "headx", 1_000L)
+        val pasted = "headx" + "y".repeat(200)
+        history.record(text, pasted, 1_050L)
+        assertEquals(2, history.undoSize)
+        assertEquals("headx", history.undo(pasted))
+    }
+
+    @Test
+    fun deletingTheCoalesceWindowWouldSnapshotEveryCharacter() {
+        val coalesced = SftpEditorHistory(coalesceMs = 400L)
+        var text = ""
+        var now = 1_000L
+        for (ch in "typing-feels-fine") {
+            val next = text + ch
+            coalesced.record(text, next, now)
+            text = next
+            now += 20L
+        }
+        assertEquals(1, coalesced.undoSize)
+
+        val naive = SftpEditorHistory(coalesceMs = 0L)
+        text = ""
+        now = 1_000L
+        for (ch in "typing-feels-fine") {
+            val next = text + ch
+            naive.record(text, next, now)
+            text = next
+            now += 20L
+        }
+        assertEquals("typing-feels-fine".length, naive.undoSize)
+    }
+
+    private fun type(history: SftpEditorHistory, previous: String, next: String, nowMs: Long): String {
+        history.record(previous, next, nowMs)
+        return next
+    }
+}

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -37,7 +37,7 @@ class SshTerminalHost(
         }
         lastRequest[request.sessionId] = copyRequest(request)
         val route = SshRoute(listOf(RouteHop.Target(request.host, request.port)))
-        if (request.password == null && request.privateKey == null) {
+        if (request.password.isNullOrBlankChars() && request.privateKey.isNullOrBlankChars()) {
             request.wipe()
             return TerminalOpenOutcome.Failed(
                 MobileError.local(code = "auth_missing", message = "请先填写密码或选择 SSH Key", retryable = false),
@@ -96,14 +96,21 @@ class SshTerminalHost(
         engine.acceptHostKey(sessionId, remembered.host, remembered.port)
     }
 
-    private fun credentialOf(request: TerminalOpenRequest): SshCredential = when {
-        request.privateKey != null -> SshCredential.PrivateKey(
-            pem = request.privateKey.copyOf(),
-            passphrase = request.passphrase?.copyOf(),
-        )
-        request.password != null -> SshCredential.Password(request.password.copyOf())
-        else -> SshCredential.Interactive
+    private fun credentialOf(request: TerminalOpenRequest): SshCredential {
+        val privateKey = request.privateKey
+        val password = request.password
+        return when {
+            !privateKey.isNullOrBlankChars() -> SshCredential.PrivateKey(
+                pem = privateKey.copyOf(),
+                passphrase = request.passphrase?.copyOf(),
+            )
+            !password.isNullOrBlankChars() -> SshCredential.Password(password.copyOf())
+            else -> SshCredential.Interactive
+        }
     }
+
+    private fun CharArray?.isNullOrBlankChars(): Boolean =
+        this == null || this.isEmpty() || this.all { it.isWhitespace() }
 
     private fun copyRequest(request: TerminalOpenRequest): TerminalOpenRequest = request.copy(
         password = request.password?.copyOf(),

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -37,7 +37,7 @@ class SshTerminalHost(
         }
         lastRequest[request.sessionId] = copyRequest(request)
         val route = SshRoute(listOf(RouteHop.Target(request.host, request.port)))
-        if (request.password.isNullOrBlankChars() && request.privateKey.isNullOrBlankChars()) {
+        val credential = credentialOf(request) ?: run {
             request.wipe()
             return TerminalOpenOutcome.Failed(
                 MobileError.local(code = "auth_missing", message = "请先填写密码或选择 SSH Key", retryable = false),
@@ -48,7 +48,7 @@ class SshTerminalHost(
                 sessionId = request.sessionId,
                 route = route,
                 username = request.username,
-                credential = credentialOf(request),
+                credential = credential,
                 hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,
                 cols = request.columns,
                 rows = request.rows,
@@ -96,21 +96,23 @@ class SshTerminalHost(
         engine.acceptHostKey(sessionId, remembered.host, remembered.port)
     }
 
-    private fun credentialOf(request: TerminalOpenRequest): SshCredential {
-        val privateKey = request.privateKey
-        val password = request.password
+    private fun credentialOf(request: TerminalOpenRequest): SshCredential? {
+        val privateKey = request.privateKey.usableSecret()
+        val password = request.password.usableSecret()
         return when {
-            !privateKey.isNullOrBlankChars() -> SshCredential.PrivateKey(
-                pem = privateKey.copyOf(),
-                passphrase = request.passphrase?.copyOf(),
+            privateKey != null -> SshCredential.PrivateKey(
+                pem = privateKey,
+                passphrase = request.passphrase.usableSecret(),
             )
-            !password.isNullOrBlankChars() -> SshCredential.Password(password.copyOf())
-            else -> SshCredential.Interactive
+            password != null -> SshCredential.Password(password)
+            else -> null
         }
     }
 
-    private fun CharArray?.isNullOrBlankChars(): Boolean =
-        this == null || this.isEmpty() || this.all { it.isWhitespace() }
+    private fun CharArray?.usableSecret(): CharArray? {
+        if (this == null || isEmpty() || all { it.isWhitespace() }) return null
+        return copyOf()
+    }
 
     private fun copyRequest(request: TerminalOpenRequest): TerminalOpenRequest = request.copy(
         password = request.password?.copyOf(),

--- a/zephyr_one/mobile/android/protocol-ssh/consumer-rules.pro
+++ b/zephyr_one/mobile/android/protocol-ssh/consumer-rules.pro
@@ -1,6 +1,8 @@
-# SSHJ discovers algorithms and key types by reflection.
+# SSHJ discovers algorithms, key types and key-file factories by reflection.
 -keep class net.schmizz.sshj.** { *; }
+-keep class com.hierynomus.sshj.** { *; }
 -keep class net.i2p.crypto.eddsa.** { *; }
+-keep class org.bouncycastle.** { *; }
 -dontwarn net.schmizz.sshj.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.slf4j.**

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoader.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoader.kt
@@ -1,0 +1,152 @@
+package one.zephyr.mobile.protocol.ssh
+
+import com.hierynomus.sshj.common.KeyDecryptionFailedException
+import com.hierynomus.sshj.userauth.keyprovider.OpenSSHKeyV1KeyFile
+import java.util.Base64
+import net.schmizz.sshj.userauth.keyprovider.FileKeyProvider
+import net.schmizz.sshj.userauth.keyprovider.KeyFormat
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider
+import net.schmizz.sshj.userauth.keyprovider.KeyProviderUtil
+import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
+import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile
+import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
+import net.schmizz.sshj.userauth.password.PasswordUtils
+import org.bouncycastle.openssl.EncryptionException
+
+/**
+ * Loads an in-memory private key for SSH public-key auth.
+ *
+ * SSHJ's older [OpenSSHKeyFile] only understands the pre-2014 PEM form. A modern
+ * `BEGIN OPENSSH PRIVATE KEY` blob (the default `ssh-keygen` output, including every
+ * Ed25519 key) must go through [OpenSSHKeyV1KeyFile]. Feeding the v1 blob to the old
+ * parser throws and the UI surfaces it as a generic connect failure.
+ */
+object SshPrivateKeyLoader {
+
+    private val OPENSSH_V1_MAGIC = "openssh-key-v1\u0000".toByteArray(Charsets.US_ASCII)
+    private const val OPENSSH_NONE = "none"
+
+    data class Parsed(
+        val format: KeyFormat,
+        val pem: String,
+        val encrypted: Boolean,
+    )
+
+    fun normalize(raw: String): String {
+        val trimmed = raw.trim().removePrefix("\uFEFF").replace("\r\n", "\n").replace('\r', '\n')
+        val begin = trimmed.indexOf("-----BEGIN ")
+        if (begin < 0) return trimmed
+        val endToken = trimmed.indexOf("-----END ", begin)
+        if (endToken < 0) return trimmed.substring(begin)
+        val closing = trimmed.indexOf("-----", endToken + "-----END ".length)
+        if (closing < 0) return trimmed.substring(begin)
+        return trimmed.substring(begin, closing + 5)
+    }
+
+    fun inspect(raw: String): Parsed {
+        val pem = normalize(raw)
+        require(pem.isNotBlank()) { "私钥为空" }
+        val format = try {
+            KeyProviderUtil.detectKeyFileFormat(pem, false)
+        } catch (error: Exception) {
+            throw IllegalArgumentException("私钥格式无法识别", error)
+        }
+        require(format != KeyFormat.Unknown) { "私钥格式无法识别，请粘贴 OpenSSH 或 PEM 私钥" }
+        return Parsed(format = format, pem = pem, encrypted = isEncrypted(pem, format))
+    }
+
+    fun isEncrypted(pem: String, format: KeyFormat): Boolean {
+        val header = pem.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty()
+        if (header.contains("ENCRYPTED", ignoreCase = true)) return true
+        if (pem.contains("Proc-Type: 4,ENCRYPTED", ignoreCase = true)) return true
+        if (format != KeyFormat.OpenSSHv1) return false
+        val cipher = openSshV1CipherName(pem) ?: return false
+        return !cipher.equals(OPENSSH_NONE, ignoreCase = true)
+    }
+
+    fun load(raw: String, passphrase: CharArray?): KeyProvider {
+        val parsed = inspect(raw)
+        val finder = passphrase
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { PasswordUtils.createOneOff(it.copyOf()) }
+        if (parsed.encrypted && finder == null) {
+            throw IllegalArgumentException("该私钥已加密，请填写口令")
+        }
+        val provider = providerFor(parsed.format)
+        try {
+            provider.init(parsed.pem, null, finder)
+            // Force a parse now so a bad blob fails before authPublickey talks to the server.
+            provider.`private`
+            provider.`public`
+        } catch (error: Exception) {
+            throw wrap(error, parsed, finder != null)
+        }
+        return provider
+    }
+
+    internal fun providerFor(format: KeyFormat): FileKeyProvider = when (format) {
+        KeyFormat.OpenSSHv1 -> OpenSSHKeyV1KeyFile()
+        KeyFormat.OpenSSH -> OpenSSHKeyFile()
+        KeyFormat.PKCS8 -> PKCS8KeyFile()
+        KeyFormat.PuTTY -> PuTTYKeyFile()
+        KeyFormat.Unknown -> throw IllegalArgumentException("私钥格式无法识别，请粘贴 OpenSSH 或 PEM 私钥")
+    }
+
+    internal fun openSshV1CipherName(pem: String): String? {
+        val body = pem.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("-----") }
+            .joinToString("")
+            .filterNot(Char::isWhitespace)
+        val decoded = try {
+            Base64.getDecoder().decode(body)
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+        if (decoded.size < OPENSSH_V1_MAGIC.size + 8) return null
+        if (!decoded.copyOf(OPENSSH_V1_MAGIC.size).contentEquals(OPENSSH_V1_MAGIC)) return null
+        return readOpenSshString(decoded, OPENSSH_V1_MAGIC.size)
+    }
+
+    private fun readOpenSshString(bytes: ByteArray, offset: Int): String? {
+        if (offset + 4 > bytes.size) return null
+        val length = ((bytes[offset].toInt() and 0xff) shl 24) or
+            ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+            ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+            (bytes[offset + 3].toInt() and 0xff)
+        if (length < 0 || offset + 4 + length > bytes.size) return null
+        return String(bytes, offset + 4, length, Charsets.US_ASCII)
+    }
+
+    private fun wrap(error: Exception, parsed: Parsed, hadPassphrase: Boolean): IllegalArgumentException {
+        if (error is IllegalArgumentException) return error
+        val decryption = isDecryptionFailure(error)
+        val message = when {
+            decryption && !hadPassphrase -> "该私钥已加密，请填写口令"
+            decryption -> "私钥口令不正确"
+            parsed.format == KeyFormat.OpenSSHv1 ->
+                "无法解析 OpenSSH 私钥（${error.message ?: error.javaClass.simpleName}）"
+            else -> "无法解析私钥（${error.message ?: error.javaClass.simpleName}）"
+        }
+        return IllegalArgumentException(message, error)
+    }
+
+    private fun isDecryptionFailure(error: Throwable): Boolean {
+        var current: Throwable? = error
+        while (current != null) {
+            if (current is KeyDecryptionFailedException || current is EncryptionException) return true
+            val text = (current.message ?: current.javaClass.simpleName).lowercase()
+            if (
+                text.contains("decrypt") ||
+                text.contains("passphrase") ||
+                text.contains("password") ||
+                text.contains("bcrypt") ||
+                text.contains("mac check")
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+}

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoader.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoader.kt
@@ -11,7 +11,6 @@ import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
 import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile
 import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
 import net.schmizz.sshj.userauth.password.PasswordUtils
-import org.bouncycastle.openssl.EncryptionException
 
 /**
  * Loads an in-memory private key for SSH public-key auth.
@@ -134,7 +133,7 @@ object SshPrivateKeyLoader {
     private fun isDecryptionFailure(error: Throwable): Boolean {
         var current: Throwable? = error
         while (current != null) {
-            if (current is KeyDecryptionFailedException || current is EncryptionException) return true
+            if (current is KeyDecryptionFailedException) return true
             val text = (current.message ?: current.javaClass.simpleName).lowercase()
             if (
                 text.contains("decrypt") ||

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.connection.channel.direct.PTYMode
@@ -310,12 +312,12 @@ class SshjEngine(
 
     private suspend fun sftpUnit(
         sessionId: String,
-        block: SFTPClient.() -> Unit,
+        block: suspend SFTPClient.() -> Unit,
     ): Result<Unit> = withContext(io) {
         runCatching { withSftp(sessionId) { it.block() } }
     }
 
-    private fun <T> withSftp(sessionId: String, block: (SFTPClient) -> T): T {
+    private suspend fun <T> withSftp(sessionId: String, block: suspend (SFTPClient) -> T): T {
         val live = sessions[sessionId] ?: error("SSH 会话已断开")
         return live.withSftp(block)
     }
@@ -515,26 +517,23 @@ class SshjEngine(
         @Volatile var closed: Boolean = false,
     ) {
         @Volatile private var sftpClient: SFTPClient? = null
-        private val sftpLock = Any()
+        private val sftpMutex = Mutex()
 
-        fun <T> withSftp(block: (SFTPClient) -> T): T {
+        suspend fun <T> withSftp(block: suspend (SFTPClient) -> T): T {
             if (closed) error("SSH 会话已断开")
-            synchronized(sftpLock) {
+            return sftpMutex.withLock {
                 if (closed) error("SSH 会话已断开")
                 val existing = sftpClient
                 val usable = existing?.takeIf { it.getSFTPEngine().getSubsystem().isOpen }
                 val active = usable ?: this.client.newSFTPClient().also { sftpClient = it }
-                return block(active)
+                block(active)
             }
         }
 
         fun close() {
-            synchronized(sftpLock) {
-                if (closed) return
-                closed = true
-                runCatching { sftpClient?.close() }
-                sftpClient = null
-            }
+            closed = true
+            runCatching { sftpClient?.close() }
+            sftpClient = null
             runCatching { shell.close() }
             runCatching { session.close() }
             closeQuietly(client)

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -1,7 +1,6 @@
 package one.zephyr.mobile.protocol.ssh
 
 import java.io.InputStream
-import java.io.StringReader
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.security.PublicKey
@@ -20,18 +19,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import net.schmizz.sshj.SSHClient
-import net.schmizz.sshj.common.SSHPacket
 import net.schmizz.sshj.connection.channel.direct.PTYMode
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.sftp.FileMode
 import net.schmizz.sshj.sftp.OpenMode
 import net.schmizz.sshj.sftp.RenameFlags
+import net.schmizz.sshj.sftp.SFTPClient
 import net.schmizz.sshj.transport.verification.HostKeyVerifier
-import net.schmizz.sshj.userauth.keyprovider.KeyProvider
-import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
-import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile
-import net.schmizz.sshj.userauth.password.PasswordFinder
-import net.schmizz.sshj.userauth.password.PasswordUtils
+import net.schmizz.sshj.userauth.UserAuthException
 import one.zephyr.mobile.model.MobileError
 
 class SshRemoteFileConflict(
@@ -161,8 +156,7 @@ class SshjEngine(
 
     override suspend fun listDirectory(sessionId: String, path: String): Result<SftpDirectory> = withContext(io) {
         runCatching {
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { sftp ->
+            withSftp(sessionId) { sftp ->
                 val canonicalPath = sftp.canonicalize(path)
                 val entries = sftp.ls(canonicalPath)
                     .asSequence()
@@ -180,8 +174,7 @@ class SshjEngine(
 
     override suspend fun stat(sessionId: String, path: String): Result<SftpEntry?> = withContext(io) {
         runCatching {
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { sftp ->
+            withSftp(sessionId) { sftp ->
                 val canonical = sftp.canonicalize(path)
                 val attrs = sftp.stat(canonical)
                 attrs.toEntry(canonical.substringAfterLast('/').ifBlank { "/" }, canonical)
@@ -220,8 +213,7 @@ class SshjEngine(
         runCatching {
             require(offset >= 0L) { "读取偏移无效" }
             require(maxBytes in 1..MAX_FILE_RANGE_BYTES) { "读取上限无效" }
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { sftp ->
+            withSftp(sessionId) { sftp ->
                 val canonicalPath = sftp.canonicalize(path)
                 val attrs = sftp.stat(canonicalPath)
                 require(attrs.type == FileMode.Type.REGULAR) { "只能读取普通文件" }
@@ -258,8 +250,7 @@ class SshjEngine(
     ): Result<SshRemoteFileVersion> = withContext(io) {
         runCatching {
             require(bytes.size <= MAX_FILE_WRITE_BYTES) { "写入内容过大，当前上限 $MAX_FILE_WRITE_BYTES bytes" }
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { sftp ->
+            withSftp(sessionId) { sftp ->
                 val leaf = path.substringAfterLast('/').ifBlank { path }
                 val parent = when {
                     path == leaf -> ""
@@ -293,7 +284,7 @@ class SshjEngine(
                     sftp.open(temporary, EnumSet.of(OpenMode.WRITE, OpenMode.CREAT, OpenMode.TRUNC)).use { remote ->
                         var written = 0
                         while (written < bytes.size) {
-                            val count = minOf(32 * 1024, bytes.size - written)
+                            val count = minOf(STREAM_CHUNK_BYTES, bytes.size - written)
                             remote.write(written.toLong(), bytes, written, count)
                             written += count
                         }
@@ -319,12 +310,14 @@ class SshjEngine(
 
     private suspend fun sftpUnit(
         sessionId: String,
-        block: net.schmizz.sshj.sftp.SFTPClient.() -> Unit,
+        block: SFTPClient.() -> Unit,
     ): Result<Unit> = withContext(io) {
-        runCatching {
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { it.block() }
-        }
+        runCatching { withSftp(sessionId) { it.block() } }
+    }
+
+    private fun <T> withSftp(sessionId: String, block: (SFTPClient) -> T): T {
+        val live = sessions[sessionId] ?: error("SSH 会话已断开")
+        return live.withSftp(block)
     }
 
     private fun net.schmizz.sshj.sftp.FileAttributes.toEntry(name: String, path: String) = SftpEntry(
@@ -409,8 +402,7 @@ class SshjEngine(
     ): Result<SshRemoteFileVersion> = withContext(io) {
         runCatching {
             require(offset >= 0L) { "读取偏移无效" }
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { sftp ->
+            withSftp(sessionId) { sftp ->
                 val canonicalPath = sftp.canonicalize(path)
                 val attrs = sftp.stat(canonicalPath)
                 require(attrs.type == FileMode.Type.REGULAR) { "只能读取普通文件" }
@@ -437,8 +429,7 @@ class SshjEngine(
         next: suspend () -> ByteArray?,
     ): Result<SshRemoteFileVersion> = withContext(io) {
         runCatching {
-            val live = sessions[sessionId] ?: error("SSH 会话已断开")
-            live.client.newSFTPClient().use { sftp ->
+            withSftp(sessionId) { sftp ->
                 val leaf = path.substringAfterLast('/').ifBlank { path }
                 val parent = when {
                     path == leaf -> ""
@@ -498,8 +489,8 @@ class SshjEngine(
         when (val credential = request.credential) {
             is SshCredential.Password -> client.authPassword(request.username, String(credential.value))
             is SshCredential.PrivateKey -> {
-                val finder = credential.passphrase?.let { PasswordUtils.createOneOff(it) }
-                client.authPublickey(request.username, loadKey(String(credential.pem), finder))
+                val provider = SshPrivateKeyLoader.load(String(credential.pem), credential.passphrase)
+                client.authPublickey(request.username, provider)
             }
             SshCredential.Interactive -> error("keyboard-interactive 尚未接入")
         }
@@ -523,9 +514,27 @@ class SshjEngine(
         val shell: Session.Shell,
         @Volatile var closed: Boolean = false,
     ) {
+        @Volatile private var sftpClient: SFTPClient? = null
+        private val sftpLock = Any()
+
+        fun <T> withSftp(block: (SFTPClient) -> T): T {
+            if (closed) error("SSH 会话已断开")
+            synchronized(sftpLock) {
+                if (closed) error("SSH 会话已断开")
+                val existing = sftpClient
+                val usable = existing?.takeIf { it.getSFTPEngine().getSubsystem().isOpen }
+                val active = usable ?: this.client.newSFTPClient().also { sftpClient = it }
+                return block(active)
+            }
+        }
+
         fun close() {
-            if (closed) return
-            closed = true
+            synchronized(sftpLock) {
+                if (closed) return
+                closed = true
+                runCatching { sftpClient?.close() }
+                sftpClient = null
+            }
             runCatching { shell.close() }
             runCatching { session.close() }
             closeQuietly(client)
@@ -536,17 +545,15 @@ class SshjEngine(
         private const val LATENCY_PROBE_TIMEOUT_MS = 4_000
 
         private fun hostPort(host: String, port: Int): String = host.lowercase() + ":" + port
-        private fun loadKey(pem: String, finder: PasswordFinder?): KeyProvider =
-            if (pem.trim().contains("BEGIN OPENSSH PRIVATE KEY")) {
-                OpenSSHKeyFile().also { it.init(StringReader(pem.trim()), finder) }
-            } else {
-                PKCS8KeyFile().also { it.init(StringReader(pem.trim()), finder) }
-            }
         private fun closeQuietly(client: SSHClient) { runCatching { client.disconnect() } }
-        private fun mapError(error: Exception): MobileError = MobileError.local(
-            "ssh_connect_failed",
-            error.message?.takeIf(String::isNotBlank) ?: error.javaClass.simpleName,
-            true,
-        )
+        private fun mapError(error: Exception): MobileError {
+            val message = error.message?.takeIf(String::isNotBlank) ?: error.javaClass.simpleName
+            val code = when {
+                error is IllegalArgumentException && message.contains("私钥") -> "ssh_key_invalid"
+                error is UserAuthException -> "ssh_auth_failed"
+                else -> "ssh_connect_failed"
+            }
+            return MobileError.local(code, message, retryable = code == "ssh_connect_failed")
+        }
     }
 }

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoaderTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoaderTest.kt
@@ -1,0 +1,148 @@
+package one.zephyr.mobile.protocol.ssh
+
+import net.schmizz.sshj.userauth.keyprovider.KeyFormat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SshPrivateKeyLoaderTest {
+
+    @Test
+    fun modernOpenSshEd25519IsOpenSshV1NotLegacyPem() {
+        val parsed = SshPrivateKeyLoader.inspect(ED25519)
+        assertEquals(KeyFormat.OpenSSHv1, parsed.format)
+        assertFalse(parsed.encrypted)
+        assertEquals(
+            "OpenSSHKeyV1KeyFile",
+            SshPrivateKeyLoader.providerFor(parsed.format).javaClass.simpleName,
+        )
+        val key = SshPrivateKeyLoader.load(ED25519, passphrase = null)
+        assertEquals("EdDSA", key.`public`.algorithm)
+        assertEquals("EdDSA", key.`private`.algorithm)
+        assertEquals("none", SshPrivateKeyLoader.openSshV1CipherName(ED25519))
+    }
+
+    @Test
+    fun wrappedPastedKeyStillLoads() {
+        val wrapped = "请粘贴下面的内容\n\n$ED25519\n\n完"
+        val parsed = SshPrivateKeyLoader.inspect(wrapped)
+        assertEquals(KeyFormat.OpenSSHv1, parsed.format)
+        assertTrue(parsed.pem.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----"))
+        assertTrue(parsed.pem.endsWith("-----END OPENSSH PRIVATE KEY-----"))
+        SshPrivateKeyLoader.load(wrapped, null)
+    }
+
+    @Test
+    fun encryptedOpenSshKeyRequiresThePassphrase() {
+        val parsed = SshPrivateKeyLoader.inspect(ED25519_ENCRYPTED)
+        assertEquals(KeyFormat.OpenSSHv1, parsed.format)
+        assertTrue(parsed.encrypted)
+        assertEquals("aes256-ctr", SshPrivateKeyLoader.openSshV1CipherName(ED25519_ENCRYPTED))
+        assertTrue(SshPrivateKeyLoader.isEncrypted(parsed.pem, parsed.format))
+        assertFalse(ED25519_ENCRYPTED.contains("bcrypt"))
+        try {
+            SshPrivateKeyLoader.load(ED25519_ENCRYPTED, null)
+            throw AssertionError("encrypted key accepted without passphrase")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message!!.contains("口令"))
+        }
+        try {
+            SshPrivateKeyLoader.load(ED25519_ENCRYPTED, "wrong".toCharArray())
+            throw AssertionError("wrong passphrase accepted")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message!!.contains("口令"))
+        }
+        val key = SshPrivateKeyLoader.load(ED25519_ENCRYPTED, "correct horse".toCharArray())
+        assertEquals("EdDSA", key.`public`.algorithm)
+    }
+
+    @Test
+    fun pkcs1RsaStillUsesThePemProvider() {
+        val parsed = SshPrivateKeyLoader.inspect(RSA_PEM)
+        assertEquals(KeyFormat.PKCS8, parsed.format)
+        assertEquals("PKCS8KeyFile", SshPrivateKeyLoader.providerFor(parsed.format).javaClass.simpleName)
+        val key = SshPrivateKeyLoader.load(RSA_PEM, null)
+        assertEquals("RSA", key.`public`.algorithm)
+        assertEquals("RSA", key.`private`.algorithm)
+    }
+
+    @Test
+    fun garbageIsRejectedBeforeTalkingToAServer() {
+        try {
+            SshPrivateKeyLoader.load("not-a-key", null)
+            throw AssertionError("garbage accepted")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message!!.contains("私钥"))
+        }
+    }
+
+    @Test
+    fun deletingTheV1BranchWouldSendModernKeysToTheLegacyParser() {
+        val parsed = SshPrivateKeyLoader.inspect(ED25519)
+        val wrong = net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile()
+        wrong.init(parsed.pem, null, null)
+        try {
+            wrong.`private`
+            throw AssertionError("legacy OpenSSH parser accepted a v1 key")
+        } catch (_: Exception) {
+            // The whole point of SshPrivateKeyLoader: this is what the old loadKey did.
+        }
+        val right = SshPrivateKeyLoader.providerFor(parsed.format)
+        right.init(parsed.pem, null, null)
+        assertEquals("EdDSA", right.`public`.algorithm)
+    }
+
+    private companion object {
+        const val ED25519 = """
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDCNOa2VSpZOlSzO9Z8jXhGIJDyq02ESWICLwSdnUsotAAAAJDSAUTF0gFE
+xQAAAAtzc2gtZWQyNTUxOQAAACDCNOa2VSpZOlSzO9Z8jXhGIJDyq02ESWICLwSdnUsotA
+AAAEBRkilTYHsUxFV2w9xeaktHCWNOFQ6IWxPbDRy2rbh8/sI05rZVKlk6VLM71nyNeEYg
+kPKrTYRJYgIvBJ2dSyi0AAAAC3plcGh5ci10ZXN0AQI=
+-----END OPENSSH PRIVATE KEY-----
+"""
+
+        const val ED25519_ENCRYPTED = """
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABDud1KCPl
+RoyDsV2rlcmRtCAAAAGAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAILl3rdVFSpxo7ra/
+ZtL2W++WTixQz5hFrjH9t/GM8HbFAAAAkH5xkd0zNz+RvQLm4nEKwyexeV8+Toxm3mH6dY
+/RL5vISS/XPWos4z8nj2hZZweFNlmkjQKkXZNa+J8ZAzVglznX4Zw5dG1zHzu2gIOZayK6
+GjFy2yBnyNywu6QLUFlNnnZJHXbaHxDEFEbP0ktiI2VpqMDbhnUeosIurAhupnH7bgE9tU
+n78gVxzDzsPMyhHA==
+-----END OPENSSH PRIVATE KEY-----
+"""
+
+        const val RSA_PEM = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAra3cXUXWpS8OGmCQgaNmbi/L7Arx1T067ev2xPoTnye7Nh3v
+9SSvkxxPLooe6yI0KlsHHBrd40l7JhGEsvhCoNopLHjRo19EhM0lwYX3xZDPX0xm
+y8/GxNSCP9bFWFQdUymRW8k3G6m+sCTUoL4CSK48vRq6xaP0HenpwdNh/FcoXs4p
+cjqOlzAyHuN8LWDKVfhbWdzYy816yLnMZvOkm8eQiw2OLdJpK2JQGogInfQ0Cd8q
+Z2Oq/3qRcx1Jc6ApXGuVjvz4tKD1y9BYouB+bpeOqZBabnviDhtuDShkRxtKdZba
+q8ZvA70maWB68/bEIWq1uftJKlkJklI1XuhmhQIDAQABAoIBAACN8wjsxfw8K/f+
+RVBZEVR7BpWk2UJA0Cyrj3bwFPG+HX8b9+mO37PcaAAOKkfJN98eqVJXTwWeiBkO
+donIKbjYzz9lUB4y5hdF8JF44QBPlGLC0p6kNw0CP3zNoCM+Oaz5/yr6XIArQgOI
+FHFzMKgfmQH1zntxGI+TH081cuC42Wu8+2ZBaMsLunK9JcXFopQY/g5dhFxkWkKH
+jh/tAzwag2E+i9xjzsWago99+KGrrgqKE/RakAq1q7+fNPyHbCPj/lSBTdJYP0rJ
+plLMe7xzWUB3gwgI0PvGZt/BWxmys4DkchjlERjQegPkK+o+s8duzraNIFUtDnGq
+fhiY80ECgYEA3e4HuSOqzVfG2ChvLIZWPua8OXjqNq9d4sKaTzRCGl230m1tXYF2
+ClMHQH0CakPzqcm/rX22VgLTU9viB+b7xgoqu+gKw4+sYx7+noRCsppKsV7tqHk0
+VNGDEAQ6FE8nLUCDPO1zbYqjJfd5cIOwZtktYHURhdlb+3rdDIFdEokCgYEAyFeN
+O9+3ZPQdBP603rGAgovSkO/Jp72+Pw9okVtsBRoiE5br8e+Qk0Pp/CQHu2zVNfNW
+slK8GlDUBynsx6AicygFl2ObLEExrBDT6G3BljSymQAvufVclvpkf4c3xPgXnBCJ
+oe8/BfCXFh9Bm/gi4RmMmsdShy09JHsBCPhTpR0CgYEAyGZHjRO7CT+o68nfUfpg
+aN5bux4HiKfkhH4rbzgGNN7JvfdYGWZs27fLxZzckG6Z2Yi3UAdDnflhMMlOGsqm
+MVc+7X0EM0FKbhsv2p4dyD9xESdiPY5tBeZGjjDy7SHog4FMwLi+UX0uA3urqkEQ
+Cl80DXTJBO+YksaIUuGB1NkCgYA0/rPlerBQjCKBB79giSOtZL82h7eYH6ELnU/T
+45MXZmpNNEcFoJFl4zkp8X36HjfoJY5xbWFEtMzheD2iMMHsJFIWUcriUfyJv4nO
+mfnzec0km+AEGNt9NI8RDPu7psTYC6fcpiTNtW7B81Kvp1vSn6eJ6d/y0gyycbc8
+YDQAIQKBgQC1j1VuECJWHSL2/2/qRW/tppF+jQSyy5awq4wb0PrrkoReptuj0jJn
+NoDbLJYEiLMHInbw9rkcDYxxEc1UcsIbZSCOr/8KYnMI/HsC6XqjAeQ45KwX7gbj
+zcqdA0PFMknWOh7xH/PYZT5esVU13n8JGOePzHe+Ec18i/vUVm9RuA==
+-----END RSA PRIVATE KEY-----
+"""
+    }
+}

--- a/zephyr_one/mobile/tests/ssh-key-and-sftp-editor-replica.py
+++ b/zephyr_one/mobile/tests/ssh-key-and-sftp-editor-replica.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Replica of SshPrivateKeyLoader cipher probe + SftpEditorHistory coalesce.
+
+Gradle is unavailable in this sandbox. These two algorithms are the ones a
+regression would silently break: encrypted OpenSSH keys would look unencrypted,
+and the editor would snapshot the whole file on every keystroke again.
+"""
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+
+
+MAGIC = b"openssh-key-v1\x00"
+
+ED25519 = """-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDCNOa2VSpZOlSzO9Z8jXhGIJDyq02ESWICLwSdnUsotAAAAJDSAUTF0gFE
+xQAAAAtzc2gtZWQyNTUxOQAAACDCNOa2VSpZOlSzO9Z8jXhGIJDyq02ESWICLwSdnUsotA
+AAAEBRkilTYHsUxFV2w9xeaktHCWNOFQ6IWxPbDRy2rbh8/sI05rZVKlk6VLM71nyNeEYg
+kPKrTYRJYgIvBJ2dSyi0AAAAC3plcGh5ci10ZXN0AQI=
+-----END OPENSSH PRIVATE KEY-----"""
+
+ED25519_ENC = """-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABDud1KCPl
+RoyDsV2rlcmRtCAAAAGAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAILl3rdVFSpxo7ra/
+ZtL2W++WTixQz5hFrjH9t/GM8HbFAAAAkH5xkd0zNz+RvQLm4nEKwyexeV8+Toxm3mH6dY
+/RL5vISS/XPWos4z8nj2hZZweFNlmkjQKkXZNa+J8ZAzVglznX4Zw5dG1zHzu2gIOZayK6
+GjFy2yBnyNywu6QLUFlNnnZJHXbaHxDEFEbP0ktiI2VpqMDbhnUeosIurAhupnH7bgE9tU
+n78gVxzDzsPMyhHA==
+-----END OPENSSH PRIVATE KEY-----"""
+
+
+def normalize(raw: str) -> str:
+    trimmed = raw.strip().lstrip("\ufeff").replace("\r\n", "\n").replace("\r", "\n")
+    begin = trimmed.find("-----BEGIN ")
+    if begin < 0:
+        return trimmed
+    end_token = trimmed.find("-----END ", begin)
+    if end_token < 0:
+        return trimmed[begin:]
+    closing = trimmed.find("-----", end_token + len("-----END "))
+    if closing < 0:
+        return trimmed[begin:]
+    return trimmed[begin : closing + 5]
+
+
+def open_ssh_v1_cipher_name(pem: str) -> str | None:
+    body = "".join(
+        line.strip()
+        for line in pem.splitlines()
+        if line.strip() and not line.strip().startswith("-----")
+    )
+    try:
+        decoded = base64.b64decode(body, validate=True)
+    except Exception:
+        return None
+    if len(decoded) < len(MAGIC) + 8 or decoded[: len(MAGIC)] != MAGIC:
+        return None
+    offset = len(MAGIC)
+    length = int.from_bytes(decoded[offset : offset + 4], "big")
+    start = offset + 4
+    if length < 0 or start + length > len(decoded):
+        return None
+    return decoded[start : start + length].decode("ascii")
+
+
+def is_encrypted(pem: str) -> bool:
+    header = next((line.strip() for line in pem.splitlines() if line.strip()), "")
+    if "ENCRYPTED" in header.upper() or "Proc-Type: 4,ENCRYPTED" in pem:
+        return True
+    cipher = open_ssh_v1_cipher_name(pem)
+    return bool(cipher) and cipher.lower() != "none"
+
+
+class History:
+    def __init__(self, coalesce_ms: int = 400, coalesce_chars: int = 24) -> None:
+        self.undo: list[str] = []
+        self.redo: list[str] = []
+        self.last = 0
+        self.coalesce_ms = coalesce_ms
+        self.coalesce_chars = coalesce_chars
+
+    def record(self, previous: str, nxt: str, now: int) -> None:
+        if previous == nxt:
+            return
+        prefix = _prefix(previous, nxt)
+        suffix = _suffix(previous, nxt, prefix)
+        small = (len(previous) - prefix - suffix) <= self.coalesce_chars and (
+            len(nxt) - prefix - suffix
+        ) <= self.coalesce_chars
+        coalesce = self.undo and 0 <= now - self.last <= self.coalesce_ms and small
+        if not coalesce:
+            self.undo.append(previous)
+        self.last = now
+        self.redo.clear()
+
+
+def _prefix(left: str, right: str) -> int:
+    limit = min(len(left), len(right))
+    index = 0
+    while index < limit and left[index] == right[index]:
+        index += 1
+    return index
+
+
+def _suffix(left: str, right: str, prefix: int) -> int:
+    limit = min(len(left) - prefix, len(right) - prefix)
+    index = 0
+    while index < limit and left[-1 - index] == right[-1 - index]:
+        index += 1
+    return index
+
+
+def main() -> int:
+    plain = normalize("请粘贴\n\n" + ED25519 + "\n完")
+    enc = normalize(ED25519_ENC)
+    assert plain.startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+    assert open_ssh_v1_cipher_name(plain) == "none"
+    assert not is_encrypted(plain)
+    assert open_ssh_v1_cipher_name(enc) == "aes256-ctr"
+    assert is_encrypted(enc)
+    assert "bcrypt" not in enc
+
+    coalesced = History(coalesce_ms=400)
+    text = ""
+    now = 1000
+    for ch in "typing-feels-fine":
+        nxt = text + ch
+        coalesced.record(text, nxt, now)
+        text = nxt
+        now += 20
+    assert len(coalesced.undo) == 1, coalesced.undo
+
+    naive = History(coalesce_ms=0)
+    text = ""
+    now = 1000
+    for ch in "typing-feels-fine":
+        nxt = text + ch
+        naive.record(text, nxt, now)
+        text = nxt
+        now += 20
+    assert len(naive.undo) == len("typing-feels-fine")
+
+    root = Path(__file__).resolve().parents[1]
+    loader = (root / "android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoader.kt").read_text()
+    history = (root / "android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistory.kt").read_text()
+    engine = (root / "android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt").read_text()
+    for needle in ("OpenSSHKeyV1KeyFile", "openSshV1CipherName", "openssh-key-v1"):
+        if needle not in loader:
+            raise AssertionError(f"loader missing {needle}")
+    if 'pem.contains("bcrypt"' in loader:
+        raise AssertionError("loader still guesses encryption from a bcrypt substring")
+    if "SshPrivateKeyLoader.load(" not in engine:
+        raise AssertionError("engine no longer uses the v1-aware loader")
+    for needle in ("coalesceMs", "isSmallSingleRegionEdit"):
+        if needle not in history:
+            raise AssertionError(f"history missing {needle}")
+    print("ssh-key-and-sftp-editor-replica: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
@@ -35,8 +35,10 @@ function assertKeyLoginGuards({ loaderSrc, engineSrc, hostSrc, rootSrc, testerSr
   assert.doesNotMatch(engineSrc, /PKCS8KeyFile\(\)\.also/);
   assert.doesNotMatch(loaderSrc, /bouncycastle/);
   assert.doesNotMatch(loaderSrc, /EncryptionException/);
-  assert.match(hostSrc, /isNullOrBlankChars/);
-  assert.match(hostSrc, /!privateKey\.isNullOrBlankChars\(\)/);
+  assert.match(hostSrc, /usableSecret\(\)/);
+  assert.match(hostSrc, /privateKey != null -> SshCredential\.PrivateKey/);
+  assert.match(hostSrc, /credentialOf\(request\) \?: run/);
+  assert.doesNotMatch(hostSrc, /request\.privateKey != null -> SshCredential\.PrivateKey/);
   assert.match(rootSrc, /takeUnlessBlankSecret/);
   assert.match(rootSrc, /replacementPassword \?: stored\.password/);
   assert.match(rootSrc, /replacementKey \?: stored\.privateKey/);
@@ -135,6 +137,13 @@ test('guards reject the pre20 key parser and per-keystroke undo', () => {
       engineSrc: engine.replaceAll('suspend fun <T> withSftp', 'fun <T> withSftp'),
     }),
     /suspend fun <T> withSftp/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      hostSrc: host.replaceAll('usableSecret()', 'let { it }'),
+    }),
+    /usableSecret/,
   );
   assert.throws(
     () => assertKeyLoginGuards({

--- a/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
@@ -29,8 +29,12 @@ function assertKeyLoginGuards({ loaderSrc, engineSrc, hostSrc, rootSrc, testerSr
   assert.match(loaderSrc, /openssh-key-v1/);
   assert.doesNotMatch(loaderSrc, /pem\.contains\("bcrypt"/);
   assert.match(engineSrc, /SshPrivateKeyLoader\.load\(/);
+  assert.match(engineSrc, /private suspend fun <T> withSftp/);
+  assert.match(engineSrc, /suspend fun <T> withSftp\(block: suspend/);
   assert.doesNotMatch(engineSrc, /OpenSSHKeyFile\(\)\.also/);
   assert.doesNotMatch(engineSrc, /PKCS8KeyFile\(\)\.also/);
+  assert.doesNotMatch(loaderSrc, /bouncycastle/);
+  assert.doesNotMatch(loaderSrc, /EncryptionException/);
   assert.match(hostSrc, /isNullOrBlankChars/);
   assert.match(hostSrc, /!privateKey\.isNullOrBlankChars\(\)/);
   assert.match(rootSrc, /takeUnlessBlankSecret/);
@@ -122,6 +126,23 @@ test('guards reject the pre20 key parser and per-keystroke undo', () => {
       rootSrc: root.replaceAll('takeUnlessBlankSecret', 'identity'),
     }),
     /takeUnlessBlankSecret/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      engineSrc: engine.replaceAll('suspend fun <T> withSftp', 'fun <T> withSftp'),
+    }),
+    /suspend fun <T> withSftp/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      loaderSrc: loader.replace(
+        'import net.schmizz.sshj.userauth.password.PasswordUtils',
+        'import org.bouncycastle.openssl.EncryptionException\nimport net.schmizz.sshj.userauth.password.PasswordUtils',
+      ),
+    }),
+    /bouncycastle/,
   );
   assert.throws(
     () => assertEditorGuards({

--- a/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
@@ -1,0 +1,154 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, 'android', rel), 'utf8');
+const engine = read('protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+const loader = read('protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoader.kt');
+const loaderTest = read('protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshPrivateKeyLoaderTest.kt');
+const host = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt');
+const root = read('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+const tester = read('app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt');
+const pool = read('app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt');
+const pane = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpBrowserPane.kt');
+const history = read('feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistory.kt');
+const historyTest = read('feature-notes/src/test/kotlin/one/zephyr/mobile/feature/notes/SftpEditorHistoryTest.kt');
+const adapter = read('app/src/main/kotlin/one/zephyr/mobile/app/SshjSftpPort.kt');
+const proguard = read('app/proguard-rules.pro');
+const consumer = read('protocol-ssh/consumer-rules.pro');
+
+function assertKeyLoginGuards({ loaderSrc, engineSrc, hostSrc, rootSrc, testerSrc, poolSrc, proguardSrc, consumerSrc }) {
+  assert.match(loaderSrc, /OpenSSHKeyV1KeyFile/);
+  assert.match(loaderSrc, /KeyFormat\.OpenSSHv1\s*->\s*OpenSSHKeyV1KeyFile\(\)/);
+  assert.match(loaderSrc, /fun isEncrypted/);
+  assert.match(loaderSrc, /openSshV1CipherName/);
+  assert.match(loaderSrc, /openssh-key-v1/);
+  assert.doesNotMatch(loaderSrc, /pem\.contains\("bcrypt"/);
+  assert.match(engineSrc, /SshPrivateKeyLoader\.load\(/);
+  assert.doesNotMatch(engineSrc, /OpenSSHKeyFile\(\)\.also/);
+  assert.doesNotMatch(engineSrc, /PKCS8KeyFile\(\)\.also/);
+  assert.match(hostSrc, /isNullOrBlankChars/);
+  assert.match(hostSrc, /!privateKey\.isNullOrBlankChars\(\)/);
+  assert.match(rootSrc, /takeUnlessBlankSecret/);
+  assert.match(rootSrc, /replacementPassword \?: stored\.password/);
+  assert.match(rootSrc, /replacementKey \?: stored\.privateKey/);
+  assert.doesNotMatch(rootSrc, /if \(replacementPassword != null \|\| replacementKey != null\)/);
+  assert.match(testerSrc, /privateKey != null && privateKey\.isNotEmpty\(\)/);
+  assert.match(poolSrc, /privateKey != null && privateKey\.isNotEmpty\(\)/);
+  assert.match(proguardSrc, /keep class com\.hierynomus\.sshj\.\*\* \{ \*; \}/);
+  assert.match(consumerSrc, /keep class com\.hierynomus\.sshj\.\*\* \{ \*; \}/);
+}
+
+function assertEditorGuards({ paneSrc, historySrc, adapterSrc, engineSrc }) {
+  assert.match(paneSrc, /TextFieldValue/);
+  assert.match(paneSrc, /SftpEditorHistory/);
+  assert.match(paneSrc, /if \(file\.dirty\) delay\(140\)/);
+  assert.match(paneSrc, /onValueChange = \{ draft = it \}/);
+  assert.doesNotMatch(paneSrc, /val history = \(current\.undo \+ current\.text\)\.takeLast/);
+  assert.match(historySrc, /coalesceMs/);
+  assert.match(historySrc, /isSmallSingleRegionEdit/);
+  assert.match(adapterSrc, /engine\.stat\(session\(handle\), path\)/);
+  assert.doesNotMatch(adapterSrc, /engine\.readFile\(session\(handle\), path, EDIT_READ_LIMIT\)/);
+  assert.match(engineSrc, /fun <T> withSftp/);
+  assert.match(engineSrc, /this\.client\.newSFTPClient\(\)/);
+}
+
+const currentKey = {
+  loaderSrc: loader,
+  engineSrc: engine,
+  hostSrc: host,
+  rootSrc: root,
+  testerSrc: tester,
+  poolSrc: pool,
+  proguardSrc: proguard,
+  consumerSrc: consumer,
+};
+
+test('modern OpenSSH private keys go through the v1 loader', () => {
+  assertKeyLoginGuards(currentKey);
+  assert.match(loaderTest, /modernOpenSshEd25519IsOpenSshV1NotLegacyPem/);
+  assert.match(loaderTest, /encryptedOpenSshKeyRequiresThePassphrase/);
+  assert.match(loaderTest, /deletingTheV1BranchWouldSendModernKeysToTheLegacyParser/);
+  assert.match(loaderTest, /assertFalse\(ED25519_ENCRYPTED\.contains\("bcrypt"\)\)/);
+});
+
+test('SFTP editor typing no longer snapshots the whole file per keystroke', () => {
+  assertEditorGuards({
+    paneSrc: pane,
+    historySrc: history,
+    adapterSrc: adapter,
+    engineSrc: engine,
+  });
+  assert.match(historyTest, /successiveKeystrokesShareOneUndoEntry/);
+  assert.match(historyTest, /deletingTheCoalesceWindowWouldSnapshotEveryCharacter/);
+});
+
+test('guards reject the pre20 key parser and per-keystroke undo', () => {
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      loaderSrc: loader.replace('KeyFormat.OpenSSHv1 -> OpenSSHKeyV1KeyFile()', 'KeyFormat.OpenSSHv1 -> OpenSSHKeyFile()'),
+    }),
+    /OpenSSHv1/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      loaderSrc: loader.replace('openSshV1CipherName', 'pem.contains("bcrypt") || openSshV1CipherName'),
+    }),
+    /bcrypt/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      engineSrc: engine.replace('SshPrivateKeyLoader.load(', 'OpenSSHKeyFile().also { it.init(StringReader('),
+    }),
+    /SshPrivateKeyLoader/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      proguardSrc: proguard.replace('-keep class com.hierynomus.sshj.** { *; }\n', ''),
+    }),
+    /hierynomus/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      rootSrc: root.replaceAll('takeUnlessBlankSecret', 'identity'),
+    }),
+    /takeUnlessBlankSecret/,
+  );
+  assert.throws(
+    () => assertEditorGuards({
+      paneSrc: pane.replace('onValueChange = { draft = it }', 'onValueChange = { onChange(it, file.encoding, file.lineEnding, file.tabSize, file.wrap) }'),
+      historySrc: history,
+      adapterSrc: adapter,
+      engineSrc: engine,
+    }),
+    /draft = it/,
+  );
+  assert.throws(
+    () => assertEditorGuards({
+      paneSrc: pane,
+      historySrc: history,
+      adapterSrc: adapter.replace(
+        'engine.stat(session(handle), path)',
+        'engine.readFile(session(handle), path, EDIT_READ_LIMIT)',
+      ),
+      engineSrc: engine,
+    }),
+    /engine\.stat/,
+  );
+});
+
+test('python replica of cipher probe and undo coalesce stays in lockstep', () => {
+  const replica = path.join(ROOT, 'tests', 'ssh-key-and-sftp-editor-replica.py');
+  const result = spawnSync('python3', [replica], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /ssh-key-and-sftp-editor-replica: ok/);
+});

--- a/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
@@ -48,10 +48,12 @@ function assertKeyLoginGuards({ loaderSrc, engineSrc, hostSrc, rootSrc, testerSr
 }
 
 function assertEditorGuards({ paneSrc, historySrc, adapterSrc, engineSrc }) {
-  assert.match(paneSrc, /TextFieldValue/);
+  assert.match(paneSrc, /var draft by remember\(file\.path\) \{ mutableStateOf\(file\.text\) \}/);
   assert.match(paneSrc, /SftpEditorHistory/);
   assert.match(paneSrc, /if \(file\.dirty\) delay\(140\)/);
   assert.match(paneSrc, /onValueChange = \{ draft = it \}/);
+  assert.doesNotMatch(paneSrc, /TextFieldValue/);
+  assert.doesNotMatch(paneSrc, /softWrap = file\.wrap/);
   assert.doesNotMatch(paneSrc, /val history = \(current\.undo \+ current\.text\)\.takeLast/);
   assert.match(historySrc, /coalesceMs/);
   assert.match(historySrc, /isSmallSingleRegionEdit/);


### PR DESCRIPTION
## 问题

1. **密钥登录一用就报错**  
   引擎把 `BEGIN OPENSSH PRIVATE KEY`（`ssh-keygen` 默认输出，包括全部 Ed25519）喂给了 SSHJ 的旧 PEM 解析器 `OpenSSHKeyFile`。这条路径只认 2014 年前的 PKCS#1/OpenSSH PEM。现代 v1 密钥解析失败，UI 只看到泛化的连接错误。  
   次因：R8 只 keep 了 `net.schmizz.sshj.**`，v1 工厂在 `com.hierynomus.sshj`，release/prerelease 会被裁掉。  
   再次因：新建连接的密码框是 `Replace("")`，空密码被当成“用户填了密码”，盖住已选 SSH Key，密钥登录变成密码认证失败。

2. **SFTP 编辑文件卡顿**  
   每个按键：整文件复制进 `List<String>` 撤销栈、立刻重算大纲/查找、整页重组。保存前还会整文件回读做冲突检查，每次 SFTP 操作还 `newSFTPClient()` 开新子系统。

## 修复

- 新增 `SshPrivateKeyLoader`：按 `KeyProviderUtil` 识别 OpenSSH v1 / 旧 OpenSSH PEM / PKCS8 / PuTTY，先本地解析再 `authPublickey`。加密 v1 密钥从 blob 里读 cipher 名（`none` vs `aes256-ctr`），不再猜 PEM 正文里有没有 `bcrypt`。
- R8 / consumer rules keep `com.hierynomus.sshj.**` 和 BouncyCastle。
- 空白密码不再盖住已选密钥；终端侧空 `CharArray` 不当成有效凭据。
- 编辑器：本地 `TextFieldValue`、400ms 合并撤销、大纲/查找防抖、首键立刻标脏。会话复用一条加锁的 SFTP 通道。保存冲突改 `stat`，不再整文件回读。

## 测试

- JVM：`SshPrivateKeyLoaderTest`（明文/加密 Ed25519、PKCS1 RSA、粘贴包装、旧解析器变异必挂）、`SftpEditorHistoryTest`（合并/暂停/大粘贴/删 coalesce 必挂）、`SecretProviderGateTest`（空密码不能藏密钥）。
- 契约：`tests/ssh-key-and-sftp-editor.test.mjs` + replica；删 v1 分支、改回 bcrypt 猜测、去掉 R8 keep、改回每键 `onChange`、保存再整文件回读，都会挂。
- 本地已跑相关契约 + replica。本沙箱无 Android SDK，Gradle/JVM 单测交 CI。

CI 全绿后再合 main。
