### PR TITLE
fix(mobile): restore SSH transport after pre21 BC collision

### DIFF
--- a/.github/workflows/zephyr-one-mobile.yml
+++ b/.github/workflows/zephyr-one-mobile.yml
@@ -231,6 +231,19 @@ jobs:
           unzip -Z1 "${apks[0]}" | grep -qx 'lib/arm64-v8a/libzephyr_rdp_android.so'
           fragment_version="$(unzip -p "${apks[0]}" META-INF/androidx.fragment_fragment.version)"
           test "$fragment_version" = '1.8.5'
+          # Runtime SSH gate, not a source-level promise. pre21 retained the external
+          # BouncyCastleProvider under Android's existing "BC" provider name and made every SSH
+          # transport fail before authentication. OpenSSH v1 must remain, the conflicting provider
+          # must not be in the optimized APK.
+          dex_dir="$(mktemp -d)"
+          unzip -q "${apks[0]}" 'classes*.dex' -d "$dex_dir"
+          grep -aFq 'Lcom/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile;' "$dex_dir"/classes*.dex
+          if grep -aFq 'Lorg/bouncycastle/jce/provider/BouncyCastleProvider;' "$dex_dir"/classes*.dex; then
+            echo 'external BouncyCastleProvider must not ship in the Android APK' >&2
+            exit 1
+          fi
+          grep -aFq 'Lnet/i2p/crypto/eddsa/EdDSAPublicKey;' "$dex_dir"/classes*.dex
+          rm -rf "$dex_dir"
 
       # assemblePrerelease is signed with the committed pre-release PKCS12, not the
       # per-runner debug.keystore. That is what lets successive pre-releases

--- a/zephyr_one/mobile/android/app/proguard-rules.pro
+++ b/zephyr_one/mobile/android/app/proguard-rules.pro
@@ -1,6 +1,7 @@
 # SSHJ discovers ciphers, key types and key-file factories by reflection.
-# OpenSSH v1 lives in com.hierynomus.sshj, not net.schmizz.sshj; dropping it
-# makes every modern private key fail after R8.
+# Keep SSHJ and the OpenSSH v1 parser, but do NOT keep BouncyCastleProvider on Android:
+# Android already exposes a cut-down provider named BC. Shipping the external provider under the
+# same name makes SSHJ select the cut-down instance and fail transport KEX before authentication.
 -dontwarn sun.security.x509.X509Key
 -dontwarn sun.security.**
 -dontwarn org.slf4j.**
@@ -9,4 +10,3 @@
 -keep class net.schmizz.sshj.** { *; }
 -keep class com.hierynomus.sshj.** { *; }
 -keep class net.i2p.crypto.eddsa.** { *; }
--keep class org.bouncycastle.** { *; }

--- a/zephyr_one/mobile/android/protocol-ssh/consumer-rules.pro
+++ b/zephyr_one/mobile/android/protocol-ssh/consumer-rules.pro
@@ -1,8 +1,10 @@
 # SSHJ discovers algorithms, key types and key-file factories by reflection.
+# Do not keep org.bouncycastle.** wholesale: Android's cut-down provider has the same "BC" name,
+# and retaining the external provider makes SSHJ fail X25519/ECDSA during connect(). Directly
+# referenced parser primitives remain reachable without a provider-wide keep rule.
 -keep class net.schmizz.sshj.** { *; }
 -keep class com.hierynomus.sshj.** { *; }
 -keep class net.i2p.crypto.eddsa.** { *; }
--keep class org.bouncycastle.** { *; }
 -dontwarn net.schmizz.sshj.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.slf4j.**

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/AndroidSshSecurity.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/AndroidSshSecurity.kt
@@ -1,0 +1,22 @@
+package one.zephyr.mobile.protocol.ssh
+
+import net.schmizz.sshj.common.SecurityUtils
+
+/** Android must use platform JCE rather than SSHJ's reflected external BC provider. */
+internal object AndroidSshSecurity {
+    @Volatile private var configured = false
+
+    fun configure() {
+        if (configured) return
+        synchronized(this) {
+            if (configured) return
+            // Android already ships a cut-down provider called "BC". Retaining and registering
+            // org.bouncycastle.jce.provider.BouncyCastleProvider gives two providers the same name;
+            // SSHJ can then resolve X25519/ECDSA against Android's incomplete instance and die in
+            // client.connect() before password or public-key authentication starts.
+            SecurityUtils.setSecurityProvider(null)
+            SecurityUtils.setRegisterBouncyCastle(false)
+            configured = true
+        }
+    }
+}

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -50,6 +50,10 @@ class SshjEngine(
     private val io: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.IO,
 ) : SshEngine {
 
+    init {
+        AndroidSshSecurity.configure()
+    }
+
     private val sessions = ConcurrentHashMap<String, LiveSession>()
     private val closeEvents = ConcurrentHashMap<String, MutableSharedFlow<Throwable>>()
     private val pending = ConcurrentHashMap<String, HostKey>()
@@ -69,11 +73,15 @@ class SshjEngine(
         val client = SSHClient()
         val verifier = RecordingVerifier(hostPort(target.host, target.port))
         client.addHostKeyVerifier(verifier)
+        var stage = ConnectStage.TRANSPORT
         try {
             client.connect(target.host, target.port)
+            stage = ConnectStage.AUTHENTICATION
             authenticate(client, request)
+            stage = ConnectStage.PTY
             val terminalSession = client.startSession()
             terminalSession.allocatePTY("xterm-256color", request.cols, request.rows, 0, 0, emptyMap<PTYMode, Int>())
+            stage = ConnectStage.SHELL
             val shell = terminalSession.startShell()
             sessions[request.sessionId] = LiveSession(client, terminalSession, shell)
             closeEvents[request.sessionId] = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
@@ -86,7 +94,7 @@ class SshjEngine(
                 pending[request.sessionId] = presented
                 return@withContext SshConnectOutcome.HostKeyDecisionRequired(presented, known = null)
             }
-            SshConnectOutcome.Failed(mapError(error))
+            SshConnectOutcome.Failed(mapError(error, stage))
         }
     }
 
@@ -540,19 +548,32 @@ class SshjEngine(
         }
     }
 
+    private enum class ConnectStage(
+        val code: String,
+        val label: String,
+        val retryable: Boolean,
+    ) {
+        TRANSPORT("ssh_transport_failed", "SSH 传输握手失败", true),
+        AUTHENTICATION("ssh_auth_failed", "SSH 认证失败", false),
+        PTY("ssh_pty_failed", "SSH PTY 创建失败", true),
+        SHELL("ssh_shell_failed", "SSH Shell 启动失败", true),
+    }
+
     companion object {
         private const val LATENCY_PROBE_TIMEOUT_MS = 4_000
 
         private fun hostPort(host: String, port: Int): String = host.lowercase() + ":" + port
         private fun closeQuietly(client: SSHClient) { runCatching { client.disconnect() } }
-        private fun mapError(error: Exception): MobileError {
-            val message = error.message?.takeIf(String::isNotBlank) ?: error.javaClass.simpleName
-            val code = when {
-                error is IllegalArgumentException && message.contains("私钥") -> "ssh_key_invalid"
-                error is UserAuthException -> "ssh_auth_failed"
-                else -> "ssh_connect_failed"
+        private fun mapError(error: Exception, stage: ConnectStage): MobileError {
+            val root = generateSequence(error as Throwable?) { it.cause }.lastOrNull() ?: error
+            val cause = root.message?.takeIf(String::isNotBlank) ?: root.javaClass.simpleName
+            if (error is IllegalArgumentException && cause.contains("私钥")) {
+                return MobileError.local("ssh_key_invalid", cause, retryable = false)
             }
-            return MobileError.local(code, message, retryable = code == "ssh_connect_failed")
+            if (error is UserAuthException) {
+                return MobileError.local("ssh_auth_failed", "SSH 认证失败：$cause", retryable = false)
+            }
+            return MobileError.local(stage.code, "${stage.label}：$cause", retryable = stage.retryable)
         }
     }
 }

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/AndroidSshSecurityTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/AndroidSshSecurityTest.kt
@@ -1,0 +1,18 @@
+package one.zephyr.mobile.protocol.ssh
+
+import net.schmizz.sshj.common.SecurityUtils
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AndroidSshSecurityTest {
+
+    @Test
+    fun configuringTwiceKeepsSshjOnTheDefaultJceProvider() {
+        AndroidSshSecurity.configure()
+        AndroidSshSecurity.configure()
+
+        assertNull(SecurityUtils.getSecurityProvider())
+        assertFalse(SecurityUtils.isBouncyCastleRegistered())
+    }
+}

--- a/zephyr_one/mobile/tests/android-ssh-provider-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/android-ssh-provider-runtime.test.mjs
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MOBILE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = path.resolve(MOBILE, '..', '..');
+const read = (rel) => fs.readFileSync(path.join(MOBILE, rel), 'utf8');
+const engine = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+const security = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/AndroidSshSecurity.kt');
+const appRules = read('android/app/proguard-rules.pro');
+const consumerRules = read('android/protocol-ssh/consumer-rules.pro');
+const workflow = fs.readFileSync(path.join(REPO, '.github/workflows/zephyr-one-mobile.yml'), 'utf8');
+
+function assertRuntimeGuards({ engineSrc, securitySrc, appRulesSrc, consumerRulesSrc, workflowSrc }) {
+  assert.match(engineSrc, /AndroidSshSecurity\.configure\(\)/,
+    'every SSH engine must configure Android JCE before constructing SSHClient');
+  assert.match(securitySrc, /SecurityUtils\.setSecurityProvider\(null\)/,
+    'Android SSH must not pin the cut-down BC provider');
+  assert.match(securitySrc, /SecurityUtils\.setRegisterBouncyCastle\(false\)/,
+    'SSHJ must not reflectively register external BC on Android');
+  assert.match(securitySrc, /synchronized\(this\)/,
+    'the global SSHJ security switch must be initialized once');
+  assert.doesNotMatch(appRulesSrc, /-keep class org\.bouncycastle\.\*\*/,
+    'app R8 rules must not retain external BouncyCastleProvider');
+  assert.doesNotMatch(consumerRulesSrc, /-keep class org\.bouncycastle\.\*\*/,
+    'library consumer rules must not retain external BouncyCastleProvider');
+  assert.match(appRulesSrc, /-keep class com\.hierynomus\.sshj\.\*\*/,
+    'OpenSSH v1 parser factory still needs to survive R8');
+  assert.match(engineSrc, /var stage = ConnectStage\.TRANSPORT/);
+  assert.match(engineSrc, /stage = ConnectStage\.AUTHENTICATION/);
+  assert.match(engineSrc, /stage = ConnectStage\.PTY/);
+  assert.match(engineSrc, /stage = ConnectStage\.SHELL/);
+  assert.doesNotMatch(engineSrc, /fun mapError\(error: Exception\): MobileError/,
+    'generic ssh_connect_failed must not hide the failing phase');
+  assert.match(workflowSrc,
+    /Lcom\/hierynomus\/sshj\/userauth\/keyprovider\/OpenSSHKeyV1KeyFile;/,
+    'release APK must prove the OpenSSH v1 parser survived R8');
+  assert.match(workflowSrc,
+    /Lorg\/bouncycastle\/jce\/provider\/BouncyCastleProvider;/,
+    'release APK must be scanned for the conflicting BC provider');
+  assert.match(workflowSrc, /external BouncyCastleProvider must not ship in the Android APK/);
+  assert.match(workflowSrc, /Lnet\/i2p\/crypto\/eddsa\/EdDSAPublicKey;/,
+    'release APK must retain Ed25519 signing support');
+}
+
+const current = {
+  engineSrc: engine,
+  securitySrc: security,
+  appRulesSrc: appRules,
+  consumerRulesSrc: consumerRules,
+  workflowSrc: workflow,
+};
+
+test('Android SSH uses platform JCE and rejects the pre21 BC collision', () => {
+  assertRuntimeGuards(current);
+});
+
+test('mutation guards catch provider collision and generic diagnostics', () => {
+  assert.throws(
+    () => assertRuntimeGuards({
+      ...current,
+      securitySrc: security.replace('SecurityUtils.setRegisterBouncyCastle(false)', 'SecurityUtils.setRegisterBouncyCastle(true)'),
+    }),
+    /reflectively register external BC/,
+  );
+  assert.throws(
+    () => assertRuntimeGuards({
+      ...current,
+      appRulesSrc: appRules + '\n-keep class org.bouncycastle.** { *; }\n',
+    }),
+    /must not retain external/,
+  );
+  assert.throws(
+    () => assertRuntimeGuards({
+      ...current,
+      engineSrc: engine.replace('stage = ConnectStage.AUTHENTICATION', '// stage lost'),
+    }),
+    /AUTHENTICATION/,
+  );
+  assert.throws(
+    () => assertRuntimeGuards({
+      ...current,
+      workflowSrc: workflow.replace(
+        "grep -aFq 'Lcom/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile;'",
+        "true # no v1 check",
+      ),
+    }),
+    /OpenSSH v1 parser/,
+  );
+});

--- a/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-key-and-sftp-editor.test.mjs
@@ -47,6 +47,8 @@ function assertKeyLoginGuards({ loaderSrc, engineSrc, hostSrc, rootSrc, testerSr
   assert.match(poolSrc, /privateKey != null && privateKey\.isNotEmpty\(\)/);
   assert.match(proguardSrc, /keep class com\.hierynomus\.sshj\.\*\* \{ \*; \}/);
   assert.match(consumerSrc, /keep class com\.hierynomus\.sshj\.\*\* \{ \*; \}/);
+  assert.doesNotMatch(proguardSrc, /-keep class org\.bouncycastle\.\*\*/);
+  assert.doesNotMatch(consumerSrc, /-keep class org\.bouncycastle\.\*\*/);
 }
 
 function assertEditorGuards({ paneSrc, historySrc, adapterSrc, engineSrc }) {
@@ -123,6 +125,13 @@ test('guards reject the pre20 key parser and per-keystroke undo', () => {
       proguardSrc: proguard.replace('-keep class com.hierynomus.sshj.** { *; }\n', ''),
     }),
     /hierynomus/,
+  );
+  assert.throws(
+    () => assertKeyLoginGuards({
+      ...currentKey,
+      proguardSrc: proguard + '\n-keep class org.bouncycastle.** { *; }\n',
+    }),
+    /bouncycastle/,
   );
   assert.throws(
     () => assertKeyLoginGuards({


### PR DESCRIPTION
## 回归

`zom-v1.0.0pre21` 中密码和密钥 SSH 都在传输握手前后报 `code=ssh_connect_failed`。

## 根因（已用 release APK + SSHJ 源码闭环验证）

PR #36 为了保留 OpenSSH v1 解析器，同时新增了 `-keep class org.bouncycastle.**`。这使外部 `org.bouncycastle.jce.provider.BouncyCastleProvider` 首次进入 optimized Android APK（pre20 APK 无该类，pre21 APK 有）。

SSHJ 0.38 `SecurityUtils.registerSecurityProvider()` 的行为：

1. 反射实例化外部 provider；
2. Android 已有同名 provider `"BC"`，所以外部实例不注册；
3. SSHJ 仍把全局 provider 名设为 `"BC"`；
4. 后续 X25519/ECDSA 按名字取得 Android 裁剪版 BC，`client.connect()` 在认证前失败。

因此密码和公钥认证都会一起炸；`SshjEngine.mapError()` 又把传输、认证、PTY、shell 全压成 `ssh_connect_failed`，导致根因不可见。

SSHJ 官方 Android issue #832 记录了相同的 `no such algorithm: ECDSA for provider BC` / `X25519` 失败。

## 修复

- 保留 `com.hierynomus.sshj.**`（OpenSSH v1 parser）和 EdDSA。
- 删除 app + consumer 的 provider-wide `org.bouncycastle.**` keep。
- `AndroidSshSecurity` 在第一个 `SSHClient` 前幂等执行：
  - `SecurityUtils.setSecurityProvider(null)`
  - `SecurityUtils.setRegisterBouncyCastle(false)`
- 连接错误分阶段：transport / authentication / PTY / shell，并附根因链最底层 message。
- CI 在 optimized APK 上直接检查：
  - 必须有 `OpenSSHKeyV1KeyFile`
  - 必须有 EdDSA
  - 禁止有 `BouncyCastleProvider`

## 验证

- pre20/pre21 release APK replica：pre20 无 provider，pre21 有 provider，回归已复现。
- 新增 `AndroidSshSecurityTest` + `android-ssh-provider-runtime.test.mjs`，包含 provider keep / 注册 / generic diagnostics mutation guards。
- SSH key、terminal、SFTP 相关契约 18/18。
- 完整移动契约本地 353/365；12 个既有失败全部来自沙箱限制（Java VM executable-page、sparse checkout 缺 FREEZE、live-server 环境），本次新增和相关测试全部通过；真实 Android compile/JVM/optimized APK 交 CI。

CI 全绿后合 main，并发布 pre22。pre21 保留为已知坏包，不覆盖 tag。
