### PR TITLE
fix(mobile): fix host-key dialog bottom clipping and persist SSH trusted hosts

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
@@ -87,7 +87,7 @@ class AppContainer(private val context: Context) {
 
     /** Process-scoped SSH client. Direct password / key auth only. */
     val sshEngine: one.zephyr.mobile.protocol.ssh.SshEngine by lazy {
-        one.zephyr.mobile.protocol.ssh.SshjEngine()
+        one.zephyr.mobile.protocol.ssh.SshjEngine(context.filesDir)
     }
 
     /** Packaged Go agent loop; binding only changes its optional data source. */

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
@@ -262,18 +262,23 @@ fun AlertDialog(
     ) {
         val composeView = LocalView.current
         val configuration = LocalConfiguration.current
-        val screenWidthDp = configuration.screenWidthDp
         val screenHeightDp = configuration.screenHeightDp.toFloat()
         SideEffect {
-            val window = (composeView.parent as? DialogWindowProvider)?.window ?: return@SideEffect
-            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-            window.setBackgroundDrawableResource(android.R.color.transparent)
-            window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            var parent = composeView.parent
+            while (parent != null) {
+                if (parent is DialogWindowProvider) {
+                    val window = parent.window
+                    window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+                    window.setBackgroundDrawableResource(android.R.color.transparent)
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                    break
+                }
+                parent = parent.parent
+            }
         }
         BoxWithConstraints(
             modifier = modifier
-                .width(screenWidthDp.dp)
-                .height(screenHeightDp.dp)
+                .fillMaxSize()
                 .background(palette.surfaces.scrim)
                 .imePadding()
                 .clickable(

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt
@@ -1,0 +1,177 @@
+package one.zephyr.mobile.protocol.ssh
+
+import java.io.File
+import java.util.Locale
+import java.util.Properties
+
+interface SshKnownHostsBook {
+    fun find(host: String, port: Int): HostKey?
+    fun put(host: String, port: Int, key: HostKey)
+    fun remove(host: String, port: Int)
+
+    companion object {
+        fun key(host: String, port: Int): String =
+            host.trim().lowercase(Locale.ROOT) + ":" + port
+    }
+}
+
+class MemorySshKnownHostsBook : SshKnownHostsBook {
+    private val values = LinkedHashMap<String, HostKey>()
+
+    @Synchronized
+    override fun find(host: String, port: Int): HostKey? = values[SshKnownHostsBook.key(host, port)]
+
+    @Synchronized
+    override fun put(host: String, port: Int, key: HostKey) {
+        values[SshKnownHostsBook.key(host, port)] = key
+    }
+
+    @Synchronized
+    override fun remove(host: String, port: Int) {
+        values.remove(SshKnownHostsBook.key(host, port))
+    }
+}
+
+class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
+    private val lock = Any()
+
+    override fun find(host: String, port: Int): HostKey? = synchronized(lock) {
+        load()[SshKnownHostsBook.key(host, port)]
+    }
+
+    override fun put(host: String, port: Int, key: HostKey) {
+        synchronized(lock) {
+            val values = load()
+            values[SshKnownHostsBook.key(host, port)] = key
+            save(values)
+        }
+    }
+
+    override fun remove(host: String, port: Int) {
+        synchronized(lock) {
+            val values = load()
+            if (values.remove(SshKnownHostsBook.key(host, port)) != null) save(values)
+        }
+    }
+
+    private fun load(): LinkedHashMap<String, HostKey> {
+        val values = LinkedHashMap<String, HostKey>()
+        if (!file.isFile) return values
+        val properties = Properties()
+        file.inputStream().use { properties.load(it) }
+        for ((rawKey, rawValue) in properties) {
+            val key = (rawKey as? String)?.trim().orEmpty()
+            val raw = (rawValue as? String)?.trim().orEmpty()
+            if (key.isNotEmpty() && raw.isNotEmpty()) {
+                val parsed = parseHostKey(raw)
+                if (parsed != null) values[key] = parsed
+            }
+        }
+        return values
+    }
+
+    private fun save(values: Map<String, HostKey>) {
+        file.parentFile?.mkdirs()
+        val properties = Properties()
+        for ((key, value) in values) {
+            properties[key] = serializeHostKey(value)
+        }
+        val staging = File(file.parentFile, file.name + ".tmp")
+        staging.outputStream().use { properties.store(it, "Zephyr One SSH known hosts") }
+        if (!staging.renameTo(file)) {
+            staging.copyTo(file, overwrite = true)
+            staging.delete()
+        }
+    }
+
+    companion object {
+        fun serializeHostKey(key: HostKey): String =
+            key.algorithm + " " + encodeBase64(key.blob)
+
+        fun parseHostKey(raw: String): HostKey? {
+            val trimmed = raw.trim()
+            val space = trimmed.indexOf(' ')
+            if (space <= 0 || space >= trimmed.length - 1) return null
+            val algo = trimmed.substring(0, space).trim()
+            val b64 = trimmed.substring(space + 1).trim()
+            val blob = decodeBase64(b64) ?: return null
+            if (algo.isEmpty() || blob.isEmpty()) return null
+            return HostKey(algorithm = algo, blob = blob)
+        }
+
+        private const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+        fun encodeBase64(bytes: ByteArray): String {
+            val out = StringBuilder((bytes.size + 2) / 3 * 4)
+            var index = 0
+            while (index + 2 < bytes.size) {
+                val chunk = ((bytes[index].toInt() and 0xFF) shl 16) or
+                    ((bytes[index + 1].toInt() and 0xFF) shl 8) or
+                    (bytes[index + 2].toInt() and 0xFF)
+                out.append(ALPHABET[(chunk shr 18) and 0x3F])
+                out.append(ALPHABET[(chunk shr 12) and 0x3F])
+                out.append(ALPHABET[(chunk shr 6) and 0x3F])
+                out.append(ALPHABET[chunk and 0x3F])
+                index += 3
+            }
+            when (bytes.size - index) {
+                1 -> {
+                    val chunk = (bytes[index].toInt() and 0xFF) shl 16
+                    out.append(ALPHABET[(chunk shr 18) and 0x3F])
+                    out.append(ALPHABET[(chunk shr 12) and 0x3F])
+                    out.append("==")
+                }
+                2 -> {
+                    val chunk = ((bytes[index].toInt() and 0xFF) shl 16) or
+                        ((bytes[index + 1].toInt() and 0xFF) shl 8)
+                    out.append(ALPHABET[(chunk shr 18) and 0x3F])
+                    out.append(ALPHABET[(chunk shr 12) and 0x3F])
+                    out.append(ALPHABET[(chunk shr 6) and 0x3F])
+                    out.append("=")
+                }
+            }
+            return out.toString()
+        }
+
+        fun decodeBase64(raw: String): ByteArray? {
+            val s = raw.trim().trimEnd('=')
+            if (s.isEmpty()) return ByteArray(0)
+            val alphabet = ALPHABET
+            val out = ArrayList<Byte>(s.length * 3 / 4)
+            var index = 0
+            while (index < s.length) {
+                val rem = s.length - index
+                if (rem >= 4) {
+                    val c0 = alphabet.indexOf(s[index]); if (c0 < 0) return null
+                    val c1 = alphabet.indexOf(s[index + 1]); if (c1 < 0) return null
+                    val c2 = alphabet.indexOf(s[index + 2]); if (c2 < 0) return null
+                    val c3 = alphabet.indexOf(s[index + 3]); if (c3 < 0) return null
+                    val chunk = (c0 shl 18) or (c1 shl 12) or (c2 shl 6) or c3
+                    out.add(((chunk shr 16) and 0xFF).toByte())
+                    out.add(((chunk shr 8) and 0xFF).toByte())
+                    out.add((chunk and 0xFF).toByte())
+                    index += 4
+                } else if (rem == 3) {
+                    val c0 = alphabet.indexOf(s[index]); if (c0 < 0) return null
+                    val c1 = alphabet.indexOf(s[index + 1]); if (c1 < 0) return null
+                    val c2 = alphabet.indexOf(s[index + 2]); if (c2 < 0) return null
+                    val chunk = (c0 shl 18) or (c1 shl 12) or (c2 shl 6)
+                    out.add(((chunk shr 16) and 0xFF).toByte())
+                    out.add(((chunk shr 8) and 0xFF).toByte())
+                    index += 3
+                } else if (rem == 2) {
+                    val c0 = alphabet.indexOf(s[index]); if (c0 < 0) return null
+                    val c1 = alphabet.indexOf(s[index + 1]); if (c1 < 0) return null
+                    val chunk = (c0 shl 18) or (c1 shl 12)
+                    out.add(((chunk shr 16) and 0xFF).toByte())
+                    index += 2
+                } else {
+                    return null
+                }
+            }
+            val result = ByteArray(out.size)
+            for (i in out.indices) result[i] = out[i]
+            return result
+        }
+    }
+}

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -1,5 +1,6 @@
 package one.zephyr.mobile.protocol.ssh
 
+import java.io.File
 import java.io.InputStream
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -46,9 +47,17 @@ private const val DEFAULT_NEW_FILE_MODE = 0x1A4 // 0644
 
 
 /** Live direct SSH transport: shell, SFTP, exec and request/reply latency probes. */
-class SshjEngine(
+class SshjEngine internal constructor(
     private val io: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.IO,
+    private val knownHosts: SshKnownHostsBook = MemorySshKnownHostsBook(),
 ) : SshEngine {
+
+    constructor() : this(Dispatchers.IO, MemorySshKnownHostsBook())
+
+    constructor(filesDir: File) : this(
+        io = Dispatchers.IO,
+        knownHosts = FileSshKnownHostsBook(File(filesDir, TRUST_FILE_NAME)),
+    )
 
     init {
         AndroidSshSecurity.configure()
@@ -57,7 +66,6 @@ class SshjEngine(
     private val sessions = ConcurrentHashMap<String, LiveSession>()
     private val closeEvents = ConcurrentHashMap<String, MutableSharedFlow<Throwable>>()
     private val pending = ConcurrentHashMap<String, HostKey>()
-    private val trusted = ConcurrentHashMap<String, HostKey>()
     private val scope = CoroutineScope(SupervisorJob() + io)
 
     override val isAvailable: Boolean = true
@@ -71,7 +79,7 @@ class SshjEngine(
         sessions.remove(request.sessionId)?.close()
         val target = request.route.target
         val client = SSHClient()
-        val verifier = RecordingVerifier(hostPort(target.host, target.port))
+        val verifier = RecordingVerifier(target.host, target.port)
         client.addHostKeyVerifier(verifier)
         var stage = ConnectStage.TRANSPORT
         try {
@@ -92,7 +100,7 @@ class SshjEngine(
             val presented = verifier.presented ?: pending[request.sessionId]
             if (presented != null && !verifier.accepted) {
                 pending[request.sessionId] = presented
-                return@withContext SshConnectOutcome.HostKeyDecisionRequired(presented, known = null)
+                return@withContext SshConnectOutcome.HostKeyDecisionRequired(presented, known = verifier.storedKey)
             }
             SshConnectOutcome.Failed(mapError(error, stage))
         }
@@ -492,7 +500,7 @@ class SshjEngine(
 
     override fun acceptHostKey(sessionId: String, host: String, port: Int) {
         val key = pending.remove(sessionId) ?: return
-        trusted[hostPort(host, port)] = key
+        knownHosts.put(host, port, key)
     }
 
     private fun authenticate(client: SSHClient, request: SshConnectRequest) {
@@ -506,13 +514,16 @@ class SshjEngine(
         }
     }
 
-    private inner class RecordingVerifier(private val scope: String) : HostKeyVerifier {
+    private inner class RecordingVerifier(private val host: String, private val port: Int) : HostKeyVerifier {
         @Volatile var presented: HostKey? = null
         @Volatile var accepted: Boolean = false
+        @Volatile var storedKey: HostKey? = null
+
         override fun verify(hostname: String, port: Int, key: PublicKey): Boolean {
             val seen = HostKey(key.algorithm, key.encoded)
             presented = seen
-            val known = trusted[hostPort(hostname, port)] ?: trusted[scope]
+            val known = knownHosts.find(this.host, this.port) ?: knownHosts.find(hostname, port)
+            storedKey = known
             return (known != null && known == seen).also { accepted = it }
         }
         override fun findExistingAlgorithms(hostname: String, port: Int): List<String> = emptyList()
@@ -560,9 +571,10 @@ class SshjEngine(
     }
 
     companion object {
+        const val TRUST_FILE_NAME = "ssh_known_hosts.properties"
         private const val LATENCY_PROBE_TIMEOUT_MS = 4_000
 
-        private fun hostPort(host: String, port: Int): String = host.lowercase() + ":" + port
+        private fun hostPort(host: String, port: Int): String = SshKnownHostsBook.key(host, port)
         private fun closeQuietly(client: SSHClient) { runCatching { client.disconnect() } }
         private fun mapError(error: Exception, stage: ConnectStage): MobileError {
             val root = generateSequence(error as Throwable?) { it.cause }.lastOrNull() ?: error

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBookTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBookTest.kt
@@ -1,0 +1,92 @@
+package one.zephyr.mobile.protocol.ssh
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SshKnownHostsBookTest {
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
+
+    @Test
+    fun `memory book records and removes keys`() {
+        val book = MemorySshKnownHostsBook()
+        assertNull(book.find("10.0.0.5", 22))
+
+        book.put("10.0.0.5", 22, KEY_A)
+        assertEquals(KEY_A, book.find("10.0.0.5", 22))
+        assertEquals(KEY_A, book.find("10.0.0.5", 22))
+        assertNull(book.find("10.0.0.5", 2222))
+        assertNull(book.find("10.0.0.6", 22))
+
+        book.remove("10.0.0.5", 22)
+        assertNull(book.find("10.0.0.5", 22))
+    }
+
+    @Test
+    fun `file book persists across distinct instances`() {
+        val file = File(tempDir.newFolder(), "ssh_known_hosts.properties")
+        val book1 = FileSshKnownHostsBook(file)
+        assertNull(book1.find("192.168.1.10", 22))
+
+        book1.put("192.168.1.10", 22, KEY_ED25519)
+        book1.put("srv.example.com", 2222, KEY_A)
+
+        val book2 = FileSshKnownHostsBook(file)
+        assertEquals(KEY_ED25519, book2.find("192.168.1.10", 22))
+        assertEquals(KEY_A, book2.find("srv.example.com", 2222))
+        assertEquals(KEY_A, book2.find("SRV.EXAMPLE.COM", 2222))
+        assertNull(book2.find("srv.example.com", 22))
+
+        book2.remove("192.168.1.10", 22)
+
+        val book3 = FileSshKnownHostsBook(file)
+        assertNull(book3.find("192.168.1.10", 22))
+        assertEquals(KEY_A, book3.find("srv.example.com", 2222))
+    }
+
+    @Test
+    fun `replacing a key updates the stored key value`() {
+        val file = File(tempDir.newFolder(), "ssh_known_hosts.properties")
+        val book = FileSshKnownHostsBook(file)
+
+        book.put("host-1", 22, KEY_A)
+        assertEquals(KEY_A, book.find("host-1", 22))
+
+        book.put("host-1", 22, KEY_B)
+        assertEquals(KEY_B, book.find("host-1", 22))
+
+        val reloaded = FileSshKnownHostsBook(file)
+        assertEquals(KEY_B, reloaded.find("host-1", 22))
+    }
+
+    @Test
+    fun `base64 roundtrip handles all alignment lengths`() {
+        for (len in 0..128) {
+            val original = ByteArray(len) { i -> ((i * 7 + 13) and 0xFF).toByte() }
+            val encoded = FileSshKnownHostsBook.encodeBase64(original)
+            val decoded = FileSshKnownHostsBook.decodeBase64(encoded)
+            assertNotNull(decoded)
+            assertTrue("Length $len mismatch", original.contentEquals(decoded))
+        }
+    }
+
+    @Test
+    fun `parseHostKey rejects malformed serialized entries`() {
+        assertNull(FileSshKnownHostsBook.parseHostKey(""))
+        assertNull(FileSshKnownHostsBook.parseHostKey("   "))
+        assertNull(FileSshKnownHostsBook.parseHostKey("ssh-rsa"))
+        assertNull(FileSshKnownHostsBook.parseHostKey("ssh-rsa invalid!base64"))
+        assertNull(FileSshKnownHostsBook.parseHostKey("  AAAAB3NzaC1yc2EA"))
+
+        val valid = FileSshKnownHostsBook.serializeHostKey(KEY_A)
+        val parsed = FileSshKnownHostsBook.parseHostKey(valid)
+        assertEquals(KEY_A, parsed)
+    }
+}

--- a/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
+++ b/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
@@ -25,11 +25,10 @@ test('alert dialog is bounded by the actual available window', () => {
   assert.match(alert, /\.heightIn\(max = availableHeight\)/);
   assert.match(alert, /\.navigationBarsPadding\(\)/);
   assert.match(alert, /setLayout\(ViewGroup\.LayoutParams\.MATCH_PARENT, ViewGroup\.LayoutParams\.MATCH_PARENT\)/);
-  assert.match(alert, /\.width\(screenWidthDp\.dp\)/);
-  assert.match(alert, /\.height\(screenHeightDp\.dp\)/);
+  assert.match(alert, /\.fillMaxSize\(\)/);
+  assert.match(alert, /DialogWindowProvider/);
   assert.match(layout, /fun availableHeightDp\(windowHeightDp: Float\)/);
   assert.doesNotMatch(alert, /val availableHeight = min\(maxHeight\.value - 20f, 640f\)/);
-  assert.doesNotMatch(alert, /modifier\s*\n\s*\.fillMaxSize\(\)/);
 });
 
 test('host-key and certificate sheets stay opaque and wrap the fingerprint', () => {

--- a/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
@@ -34,9 +34,11 @@ test('app wires SSHJ instead of the unavailable stub', () => {
   assert.doesNotMatch(root, /emulator = SimpleVtEmulator\(/);
   assert.match(root, /autoConnect = true/);
   assert.doesNotMatch(root, /UnavailableTerminalHost\(TERMINAL_ENGINE_MISSING\)/);
-  assert.match(read(CONTAINER), /SshjEngine\(/);
+  assert.match(read(CONTAINER), /SshjEngine\(context\.filesDir\)/);
   assert.match(read(HOST), /class SshTerminalHost/);
   assert.match(read(ENGINE), /class SshjEngine/);
+  assert.match(read(ENGINE), /TRUST_FILE_NAME = "ssh_known_hosts\.properties"/);
+  assert.match(read(ENGINE), /FileSshKnownHostsBook/);
 });
 
 test('terminal uses the system IME by default', () => {


### PR DESCRIPTION
## 概要

### 1. 弹窗底部超出屏幕显示（取消按钮被裁切）
- **根因**：
  1. `AlertDialog` 在 `SideEffect` 中直接取 `(composeView.parent as? DialogWindowProvider)`，但在 Android Compose Dialog 视图层级中，`composeView.parent` 是 `FrameLayout`/`DialogLayout`，并不直接实现 `DialogWindowProvider`，导致类型转换失败提前 `return@SideEffect`，Window 未能被设置为 `MATCH_PARENT, MATCH_PARENT` 全屏浮层。
  2. `BoxWithConstraints` 显式设置了 `.width(screenWidthDp.dp).height(screenHeightDp.dp)`，在非全屏浮层下尺寸小于物理屏幕并在居中时偏离屏幕真实底部，导致 `.navigationBarsPadding()` 无法贴底生效，弹窗底部（取消按钮）被挤到屏幕之外。
- **修复**：
  - 向上递归遍历 `view.parent` 查找 `DialogWindowProvider`，确保将 Dialog Window 成功设置为 `MATCH_PARENT` 并清理背景与 dim。
  - 将 `BoxWithConstraints` 恢复为 `.fillMaxSize()` 占满全屏，配合 `Alignment.BottomCenter` 与 `.navigationBarsPadding()`，使弹窗与取消按钮稳定停留在屏幕底部安全区上方。

### 2. 每次重新打开 App 新建连接都会重复弹出指纹确认
- **根因**：
  - `SshjEngine` 原先仅使用内存中的 `ConcurrentHashMap<String, HostKey>()` 保存已信任主机指纹。在 App 重启或进程重建后，已信任记录全部丢失，再次连接同一主机时依然被判定为未信任，反复弹出确认。
- **修复**：
  - 新增 `SshKnownHostsBook`（包含内存版 `MemorySshKnownHostsBook` 与持久化文件版 `FileSshKnownHostsBook`），将信任记录持久化存储到 `ssh_known_hosts.properties`（与 RDP 的 `FileRdpFingerprintBook` 对齐）。
  - `AppContainer` 中构造 `SshjEngine(context.filesDir)`，首次信任后持久化写入磁盘；再次连接时自动核对指纹，指纹一致直接连通，仅在指纹变更时拦截并提示。