### PR TITLE
fix(mobile): keep IME clipboard and candidate commits in order

### DIFF
--- a/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/view/TerminalView.java
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/java/com/termux/view/TerminalView.java
@@ -379,6 +379,16 @@ public final class TerminalView extends View {
 
             void sendTextToTerminal(CharSequence text) {
                 stopTextSelectionMode();
+                if (text == null || text.length() == 0) return;
+                // IME clipboard paste and candidate-strip commits arrive as one CharSequence.
+                // Sending them code-point by code-point launches one SSH write each, and those
+                // writes race so "netlab" lands as "nlteab". Control / Alt / Shift still take
+                // the per-code-point path because they must become escape sequences.
+                if (!mClient.readShiftKey() && !mClient.readControlKey() && !mClient.readAltKey()
+                        && !containsControlBesidesEscape(text)) {
+                    mTermSession.write(text.toString().replace('\n', '\r'));
+                    return;
+                }
                 final int textLengthInChars = text.length();
                 for (int i = 0; i < textLengthInChars; i++) {
                     char firstChar = text.charAt(i);
@@ -431,6 +441,15 @@ public final class TerminalView extends View {
 
                     inputCodePoint(KEY_EVENT_SOURCE_SOFT_KEYBOARD, codePoint, ctrlHeld, false);
                 }
+            }
+
+            boolean containsControlBesidesEscape(CharSequence text) {
+                final int n = text.length();
+                for (int i = 0; i < n; i++) {
+                    char ch = text.charAt(i);
+                    if (ch < 32 && ch != '\n' && ch != '\r' && ch != '\t' && ch != 27) return true;
+                }
+                return false;
             }
 
         };

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceController.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceController.kt
@@ -2,6 +2,7 @@ package one.zephyr.mobile.feature.sessions
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -9,6 +10,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * The byte sink for one session.
@@ -129,6 +134,10 @@ class TerminalSurfaceController(
     private var deferredOutputRows = 0
 
     private var pinchBaseFontSp: Float = fontSp
+    private val writeMutex = Mutex()
+    private val writePumpStarted = AtomicBoolean(false)
+    private val writeQueue = Channel<ByteArray>(Channel.UNLIMITED)
+    private var writePump: Job? = null
 
     // ---- geometry ------------------------------------------------------------------------------
 
@@ -571,11 +580,41 @@ class TerminalSurfaceController(
         }
     }
 
+    /**
+     * Bytes from Termux's IME path (clipboard paste, candidate commit, voice input).
+     *
+     * Must join the same ordered pump as [write]: Gboard/Samsung split a pasted word into one
+     * code-point per callback, and launching a coroutine per callback reorders "netlab" into
+     * "nlteab" on the SSH socket.
+     */
+    fun enqueueWrite(bytes: ByteArray) = write(bytes)
+
     private fun write(bytes: ByteArray) {
         if (bytes.isEmpty()) return
+        ensureWritePump()
+        val queued = writeQueue.trySend(bytes.copyOf())
+        if (queued.isSuccess) return
         scope.launch {
-            runCatching { transport.write(bytes) }
-                .onFailure(transport::onFailure)
+            writeMutex.withLock {
+                runCatching { transport.write(bytes) }
+                    .onFailure(transport::onFailure)
+            }
+        }
+    }
+
+    private fun ensureWritePump() {
+        if (!writePumpStarted.compareAndSet(false, true)) return
+        writePump = scope.launch {
+            try {
+                for (chunk in writeQueue) {
+                    writeMutex.withLock {
+                        runCatching { transport.write(chunk) }
+                            .onFailure(transport::onFailure)
+                    }
+                }
+            } catch (_: CancellationException) {
+                writePumpStarted.set(false)
+            }
         }
     }
 

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -147,10 +147,7 @@ class TerminalViewModel(
 
     init {
         termux?.bindWriteBytes { bytes ->
-            viewModelScope.launch {
-                runCatching { delegatingTransport.write(bytes) }
-                    .onFailure(delegatingTransport::onFailure)
-            }
+            controller.enqueueWrite(bytes)
             controller.consumeLatches()
         }
     }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceControllerTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceControllerTest.kt
@@ -618,4 +618,16 @@ class TerminalSurfaceControllerTest {
         assertEquals(GestureOwner.SELECTION, subject.state.value.gestureOwner)
         assertEquals(0, transport.writes.size)
     }
+
+    @Test
+    fun imeClipboardAndCandidateCommitsKeepCharacterOrder() = runTest {
+        val transport = RecordingTransport()
+        val subject = controller(backgroundScope, transport)
+
+        // Gboard / Samsung IME clipboard and candidate strip fire one commit per code point.
+        "netlab".forEach { ch -> subject.enqueueWrite(byteArrayOf(ch.code.toByte())) }
+        runCurrent()
+
+        assertEquals("netlab", transport.writes.joinToString("") { String(it) })
+    }
 }

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -543,7 +543,7 @@ class SshjEngine internal constructor(
 
         suspend fun withShellWrite(block: suspend () -> Unit) {
             writeMutex.withLock {
-                withContext(io) { block() }
+                withContext(Dispatchers.IO) { block() }
             }
         }
 

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -135,15 +135,17 @@ class SshjEngine internal constructor(
         closeEvents[sessionId]?.tryEmit(error)
     }
 
-    override suspend fun send(sessionId: String, bytes: ByteArray) = withContext(io) {
+    override suspend fun send(sessionId: String, bytes: ByteArray) {
         val live = sessions[sessionId] ?: throw IllegalStateException("SSH 会话已断开")
-        try {
-            live.shell.outputStream.write(bytes)
-            live.shell.outputStream.flush()
-        } catch (error: Exception) {
-            sessions.remove(sessionId, live)
-            live.close()
-            throw error
+        live.withShellWrite {
+            try {
+                live.shell.outputStream.write(bytes)
+                live.shell.outputStream.flush()
+            } catch (error: Exception) {
+                sessions.remove(sessionId, live)
+                live.close()
+                throw error
+            }
         }
     }
 
@@ -537,6 +539,13 @@ class SshjEngine internal constructor(
     ) {
         @Volatile private var sftpClient: SFTPClient? = null
         private val sftpMutex = Mutex()
+        private val writeMutex = Mutex()
+
+        suspend fun withShellWrite(block: suspend () -> Unit) {
+            writeMutex.withLock {
+                withContext(io) { block() }
+            }
+        }
 
         suspend fun <T> withSftp(block: suspend (SFTPClient) -> T): T {
             if (closed) error("SSH 会话已断开")

--- a/zephyr_one/mobile/tests/ssh-terminal-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-terminal-runtime.test.mjs
@@ -26,7 +26,21 @@ test('Termux system IME writes are bound to SSH and failures are caught', () => 
   assert.match(bridge, /fun bindWriteBytes/);
   assert.doesNotMatch(bridge, /writeBytes\s*=\s*\{\}/);
   assert.match(vm, /termux\?\.bindWriteBytes/);
-  assert.match(vm, /runCatching \{ delegatingTransport\.write\(bytes\) \}/);
+  assert.match(vm, /controller\.enqueueWrite\(bytes\)/);
+  assert.doesNotMatch(vm, /viewModelScope\.launch \{[\s\S]*delegatingTransport\.write\(bytes\)/);
+});
+
+test('IME clipboard and candidate commits keep byte order', () => {
+  const view = read('feature-sessions/src/main/java/com/termux/view/TerminalView.java');
+  const controller = read('feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalSurfaceController.kt');
+  assert.match(view, /mTermSession\.write\(text\.toString\(\)\.replace\('\\n', '\\r'\)\)/);
+  assert.match(view, /containsControlBesidesEscape/);
+  assert.match(controller, /fun enqueueWrite\(bytes: ByteArray\)/);
+  assert.match(controller, /writeQueue/);
+  assert.match(controller, /writeMutex\.withLock/);
+  assert.match(sshj, /writeMutex/);
+  assert.match(sshj, /withShellWrite/);
+  assert.doesNotMatch(controller, /scope\.launch \{\s*runCatching \{ transport\.write\(bytes\) \}/);
 });
 
 test('SSHJ implements shell, SFTP, exec and tcp-handshake latency', () => {


### PR DESCRIPTION
## 问题

系统键盘剪贴板粘贴 `netlab`，以及英文候选词点选后，终端里会变成 `nlteab` 这类乱序字符串。

## 根因

1. Termux `TerminalView.sendTextToTerminal` 把 IME `commitText` 拆成逐个 code point，每个字符各自走 `writeCodePoint`。
2. `TerminalViewModel.bindWriteBytes` / `TerminalSurfaceController.write` 对每次写出都 `launch` 一个协程。
3. `SshjEngine.send` 直接写 `shell.outputStream`，没有按会话串行。多个短写在 IO 线程上交叉，字母顺序被打乱。

## 修复

- 未按住 Ctrl/Alt/Shift 的普通文本（键盘剪贴板、候选词）一次 `session.write` 整段提交。
- 终端写出走同一条有序队列（`writeQueue` + `writeMutex`），不再每个字符一个协程。
- SSHJ 每个会话的 shell 写出加 `writeMutex`，保证 socket 字节顺序。

## 测试

- JVM：`imeClipboardAndCandidateCommitsKeepCharacterOrder` 覆盖 `netlab` 逐字 enqueue 后仍按原序写出。
- 契约：`ssh-terminal-runtime.test.mjs` 锁定整段提交与有序写出，禁止回到 per-byte `launch`。