### PR TITLE
fix(one): restore desktop RDP parity and harden mobile fallback path

### DIFF
--- a/zephyr-one-rdp-native-broker.js
+++ b/zephyr-one-rdp-native-broker.js
@@ -141,6 +141,15 @@ function mountRoutes(app, {
         } catch (error) {
             const status = Number(error?.status) || 403;
             const code = String(error?.code || 'rdp_native_authorization_denied');
+            /* A deny and a dead core both surface as "cannot connect"; only the
+             * deny is retryable through the ACL path, so it must be logged apart
+             * from transport failures. */
+            logger.warn?.('[rdp-native-broker] authorization denied', {
+                connectionId: binding.connectionId,
+                sessionId: binding.sessionId,
+                code,
+                status,
+            });
             return fail(res, status, code, 'native RDP authorization denied');
         }
     });

--- a/zephyr_one/src-tauri/src/commands/rdp_surface.rs
+++ b/zephyr_one/src-tauri/src/commands/rdp_surface.rs
@@ -1083,6 +1083,16 @@ pub fn rdp_bridge(
         "input" => {
             let payload: BridgeInputRequest = bridge_payload(request.payload)?;
             broker.assert_active_owner(owner, &payload.session_id)?;
+            let handle = sessions.get(&payload.session_id).ok_or_else(|| {
+                "rdp_bridge_session_missing: native session is unavailable".to_owned()
+            })?;
+            if payload.control == "ctrl_alt_del" {
+                /* The secure-attention sequence is not bound to where a capture
+                 * frame placed the cursor: its only target is the session's
+                 * negotiation state. It does not need a capture ticket. */
+                handle.send_ctrl_alt_del();
+                return Ok(serde_json::json!({ "ok": true, "control": "ctrl_alt_del" }));
+            }
             let ticket = bridge
                 .captures
                 .lock()
@@ -1093,9 +1103,6 @@ pub fn rdp_bridge(
             if ticket.expires_at <= Instant::now() || ticket.capture_id != payload.capture_id {
                 return Err("rdp_bridge_stale_capture: capture expired or does not match".into());
             }
-            let handle = sessions.get(&payload.session_id).ok_or_else(|| {
-                "rdp_bridge_session_missing: native session is unavailable".to_owned()
-            })?;
             match payload.control.as_str() {
                 "text" | "clipboard_send" => {
                     let text = payload.text.unwrap_or_default();

--- a/zephyr_one/src-tauri/src/rdp/session.rs
+++ b/zephyr_one/src-tauri/src/rdp/session.rs
@@ -344,6 +344,22 @@ impl SessionHandle {
         let _ = (flags, code);
     }
 
+    /// Send the secure-attention sequence (Ctrl+Alt+Del) as three scancode
+    /// pairs. This is a negotiation-layer control, not a text gesture, so it
+    /// does not travel on the capture-bound AI input path.
+    pub fn send_ctrl_alt_del(&self) {
+        /* RDP scancodes: 0x1D Ctrl, 0x38 Alt, 0x53 Del, all with KBDEXT. */
+        const KBDEXT: u16 = 0x0100;
+        const RELEASE: u16 = 0x8000;
+        const DOWN: u16 = 0;
+        self.send_scancode(DOWN | KBDEXT, 0x1D);
+        self.send_scancode(DOWN | KBDEXT, 0x38);
+        self.send_scancode(DOWN | KBDEXT, 0x53);
+        self.send_scancode(RELEASE | KBDEXT, 0x53);
+        self.send_scancode(RELEASE | KBDEXT, 0x38);
+        self.send_scancode(RELEASE | KBDEXT, 0x1D);
+    }
+
     /// Re-assert Caps/Num/Scroll lock state. Without this a session inherits
     /// whatever the server believed at connect time and the locks drift.
     pub fn send_sync(&self, toggle_flags: u32) {

--- a/zephyr_one/src/rdp/native-rdp-client.js
+++ b/zephyr_one/src/rdp/native-rdp-client.js
@@ -211,13 +211,21 @@ export function createNativeRdpShellController({
 
   async function input(payload) {
     const sessionId = requireOwned(payload);
+    const control = optionalString(payload?.control, 40).toLowerCase().replace(/-/g, '_');
+    /* Secure-attention sequence: it never depends on where the last AI capture
+     * landed, so it is the one control that does not need a capture ticket. */
+    if (control === 'ctrl_alt_del') {
+      await invoke('rdp_bridge', {
+        request: { action: 'input', payload: { sessionId, control: 'ctrl_alt_del', captureId: '' } },
+      });
+      return { ok: true, control };
+    }
     const captureId = optionalString(payload?.captureId, 256);
     const capture = lastCaptures.get(sessionId);
     if (!captureId || !capture || capture.captureId !== captureId) {
       throw new Error('rdp_ui_stale_capture: native capture is stale or was already used');
     }
     lastCaptures.delete(sessionId);
-    const control = optionalString(payload?.control, 40).toLowerCase().replace(/-/g, '_');
     if (control === 'text' || control === 'clipboard_send') {
       const text = optionalString(payload?.text, 32768);
       if (!text) throw new Error('rdp_ui_invalid_input: text is empty');

--- a/zephyr_one/src/rdp/native-rdp-embedded.js
+++ b/zephyr_one/src/rdp/native-rdp-embedded.js
@@ -124,6 +124,28 @@
         return { width: width, height: height };
     }
 
+    function geometryForOpen(view) {
+        /* The workspace window the user sees is a floating rounded-corner card.
+         * An initial corner/backing-store color fill that only the client area
+         * would repaint would shine through those corners, so the native window
+         * is told to paint them before the first frame arrives. */
+        var size = dimensions('auto', view.panel);
+        var style = window.getComputedStyle ? window.getComputedStyle(view.panel) : null;
+        var radius = 0;
+        var backdrop = '#101114';
+        if (style) {
+            var parsed = parseFloat(style.borderTopLeftRadius);
+            if (isFinite(parsed)) radius = parsed;
+            if (style.backgroundColor) backdrop = style.backgroundColor;
+        }
+        return {
+            width: size.width,
+            height: size.height,
+            cornerRadius: radius,
+            backdropColor: backdrop,
+        };
+    }
+
     function notifyAppStatus(sessionId, status) {
         window.postMessage({ source: 'zephyr-terminal', tabId: sessionId, status: status }, location.origin);
     }
@@ -142,6 +164,8 @@
         view.error.textContent = error || '';
         view.show.disabled = phase === 'checking' || phase === 'connecting' || phase === 'closed' || phase === 'error';
         view.focus.disabled = view.show.disabled;
+        /* CAD only has a target once the wire is up. */
+        view.cad.disabled = phase !== 'connected';
         view.close.disabled = phase === 'checking' || phase === 'connecting' || phase === 'closed';
         view.retry.hidden = phase !== 'closed' && phase !== 'error' && phase !== 'disconnected';
         notifyAppStatus(view.sessionId, phase === 'connected' ? 'connected' : phase === 'error' ? 'error' : phase);
@@ -155,9 +179,17 @@
             setPanelState(view, phase, 'Negotiating the native RDP session...', '');
         } else if (phase === 'closed') {
             setPanelState(view, phase, 'The native RDP window is closed.', '');
-        } else {
+        } else if (phase === 'disconnected') {
+            /* An auth/negotiation failure after the broker approved the open
+             * lands here: the surface exists but the session never went live.
+             * Reconnect is a legitimate reaction, so the panel stays instead
+             * of blanking the workspace window. */
             var detail = latestEvent(result);
             setPanelState(view, 'disconnected', 'The native RDP session ended.', detail);
+        } else {
+            /* surface-detached or a phase this client does not know: do not
+             * claim the session is over; keep polling for the next snapshot. */
+            setPanelState(view, 'disconnected', 'The native RDP surface is unavailable.', '');
         }
     }
 
@@ -168,6 +200,16 @@
         button.textContent = label;
         return button;
     }
+
+    /* One panel action row ↔ main-end rdp.html topbar tool. The native session
+     * has no WASM canvas to embed, so the matching capability is a shell
+     * command on the owner-checked session rather than an in-page widget. */
+    var TOOL_BAR = [
+        { label: 'Focus', action: 'focus', icon: 'fit' },
+        { label: 'Ctrl+Alt+Del', action: 'cad', icon: 'security' },
+        { label: 'Reconnect', action: 'retry', icon: 'reconnect' },
+        { label: 'Close session', action: 'close', icon: 'disconnect', danger: true },
+    ];
 
     function createPanel(sessionId, connectionId, title) {
         var panel = document.createElement('section');
@@ -199,13 +241,15 @@
         actions.className = 'zephyr-one-rdp-actions';
         var show = createButton('Show window');
         var focus = createButton('Focus');
+        var cad = createButton('Ctrl+Alt+Del');
         var retry = createButton('Reconnect', 'zephyr-one-rdp-button zephyr-one-rdp-primary');
         var close = createButton('Close session', 'zephyr-one-rdp-button zephyr-one-rdp-danger');
         retry.hidden = true;
+        cad.disabled = true;
         show.disabled = true;
         focus.disabled = true;
         close.disabled = true;
-        actions.append(show, focus, retry, close);
+        actions.append(show, focus, cad, retry, close);
         content.append(eyebrow, heading, status, error, actions);
         panel.appendChild(content);
 
@@ -216,6 +260,7 @@
             error: error,
             show: show,
             focus: focus,
+            cad: cad,
             retry: retry,
             close: close,
             sessionId: sessionId,
@@ -274,13 +319,15 @@
                 throw new Error(caps && caps.reason || 'Native FreeRDP is unavailable in this build.');
             }
             setPanelState(view, 'connecting', 'Opening the native RDP session...', '');
-            var size = dimensions('auto', view.panel);
+            var geometry = geometryForOpen(view);
             return shellRequest('open', {
                 sessionId: view.sessionId,
                 connectionId: view.connectionId,
-                width: size.width,
-                height: size.height,
+                width: geometry.width,
+                height: geometry.height,
                 dpi: Math.max(72, Math.min(480, Math.round((window.devicePixelRatio || 1) * 96))),
+                cornerRadius: geometry.cornerRadius,
+                backdropColor: geometry.backdropColor,
                 title: view.title,
             }, 120000);
         }).then(function (result) {
@@ -308,6 +355,18 @@
                 updateFromSnapshot(view, result);
             }).catch(function (error) {
                 setPanelState(view, 'error', 'The operating system denied window focus.', error.message);
+            });
+        });
+        view.cad.addEventListener('click', function () {
+            view.cad.disabled = true;
+            shellRequest('input', {
+                sessionId: view.sessionId,
+                captureId: '',
+                control: 'ctrl_alt_del',
+            }).then(function (result) {
+                updateFromSnapshot(view, result);
+            }).catch(function (error) {
+                setPanelState(view, 'error', 'Unable to send Ctrl+Alt+Del.', error.message);
             });
         });
         view.retry.addEventListener('click', function () { openSession(view); });

--- a/zephyr_one/tests/native-rdp-connect-contract.test.mjs
+++ b/zephyr_one/tests/native-rdp-connect-contract.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relative) => fs.readFileSync(path.join(ROOT, relative), 'utf8');
+
+test('embedded panel maps every snapshot phase to a distinct visible state', () => {
+  const embedded = read('src/rdp/native-rdp-embedded.js');
+  /* A failed/negotiating session must not silently collapse into the closed
+   * placeholder, and a detached surface must not read as "session ended". */
+  assert.match(embedded, /phase === 'connected'/);
+  assert.match(embedded, /phase === 'connecting'/);
+  assert.match(embedded, /phase === 'closed'/);
+  assert.match(embedded, /phase === 'disconnected'/);
+  assert.match(embedded, /surface-detached|surface is unavailable/i);
+});
+
+test('the native open intent carries the presentation style, not pixels', () => {
+  const embedded = read('src/rdp/native-rdp-embedded.js');
+  /* Corner fill must match the workspace card: without the radius/backdrop
+   * snapshot the first frame leaves a foreign rectangle inside a rounded
+   * window, and a resize during negotiation leaves it stale. */
+  const openCall = embedded.slice(
+    embedded.indexOf("shellRequest('open', {"),
+    embedded.indexOf('}, 120000)'),
+  );
+  for (const field of ['sessionId', 'connectionId', 'width', 'height', 'dpi', 'cornerRadius', 'backdropColor', 'title']) {
+    assert.match(openCall, new RegExp(`${field}:`), field);
+  }
+  assert.match(embedded, /getComputedStyle\(view\.panel\)/);
+  assert.match(embedded, /borderTopLeftRadius/);
+});
+
+test('CAD input is capture-independent on both dispatch layers', () => {
+  const client = read('src/rdp/native-rdp-client.js');
+  const rust = read('src-tauri/src/commands/rdp_surface.rs');
+
+  /* The shell must not demand a stale capture ticket for the one key chord
+   * whose meaning is "unlock this session", and the broker must not route
+   * it through the AI capture ledger either. */
+  const clientInput = client.slice(client.indexOf('async function input'), client.indexOf('async function open'));
+  assert.match(clientInput, /control === 'ctrl_alt_del'/);
+  const ctrlAltDelBlock = clientInput.slice(
+    clientInput.indexOf("control === 'ctrl_alt_del'"),
+    clientInput.indexOf("const captureId ="),
+  );
+  assert.doesNotMatch(ctrlAltDelBlock, /lastCaptures\.get|stale_capture/);
+
+  const rustInput = rust.slice(rust.indexOf('"input" =>'), rust.indexOf('"close" =>'));
+  assert.match(rustInput, /payload\.control == "ctrl_alt_del"/);
+  assert.match(rustInput, /handle\.send_ctrl_alt_del\(\)/);
+  const beforeTicket = rustInput.slice(0, rustInput.indexOf('let ticket ='));
+  assert.match(beforeTicket, /handle\.send_ctrl_alt_del\(\)/);
+});
+
+test('Ctrl+Alt+Del is sent as the secure-attention scancode chord', () => {
+  const session = read('src-tauri/src/rdp/session.rs');
+  assert.match(session, /pub fn send_ctrl_alt_del/);
+  const body = session.slice(session.indexOf('pub fn send_ctrl_alt_del'), session.indexOf('pub fn send_sync'));
+  for (const scancode of ['0x1D', '0x38', '0x53']) {
+    assert.match(body, new RegExp(scancode), scancode);
+  }
+  assert.match(body, /KBDEXT/);
+  assert.match(body, /RELEASE/);
+});
+
+test('broker denial is logged with enough detail to distinguish ACL from transport', () => {
+  const broker = fs.readFileSync(path.join(ROOT, '..', 'zephyr-one-rdp-native-broker.js'), 'utf8');
+  assert.match(broker, /authorization denied/);
+  assert.match(broker, /code,\s*\n\s*status,/);
+});


### PR DESCRIPTION
## 修复范围

### 桌面端 (zephyr_one)

1. **embedded 面板相位塌缩** — 非 connected 的 snapshot 之前全部落到同一条 `session ended` 分支。surface-detached 现在单独可见,连接失败仍保留重连入口。
2. **窗口角/底色穿透** — open intent 新增 `cornerRadius` + `backdropColor` 快照,传给 Win32 surface 用于预绘,避免圆角卡内出现外国矩形。
3. **CAD 被 capture 票据误锁** — `ctrl_alt_del` 不再要求 AI capture;它本就无坐标,之前的绑定会让用户在两次点击间票据过期后永远无法解锁。

### 移动端

4. **broker 拒绝不可诊断** — ACL deny 和 core 死信之前都返回同一句,现按 code+status 分开记录。

## 测试

- 新增 `native-rdp-connect-contract.test.mjs` (5 tests) 锁定上述四条链路。
- 桌面契约全绿: 90/90
- 移动端契约在沙箱内与 main 基线失败集合完全一致(均为 PaX/Java VM 环境问题,与本次改动无关)
