### PR TITLE
fix(mobile): host-key dialog cancel clipped and trust not persisted on pre24

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -423,6 +423,12 @@ private fun BoundRoot(
             credentialsProvider = account::terminalCredentials,
         )
     }
+    val terminalHost = remember(account, sshEngine) {
+        SshTerminalHost(
+            engine = sshEngine,
+            findConnection = { id -> account.connections.find(id) },
+        )
+    }
     val managedHostKeyPrompt by managedSsh.prompt.collectAsState()
     val managedSftp = remember(managedSsh, sshEngine, account.sessions) {
         SshjSftpPort(managedSsh, sshEngine, account.sessions)
@@ -775,10 +781,7 @@ private fun BoundRoot(
                             connectionId = current.connectionId,
                             registry = account.sessions,
                             connections = account.connections,
-                            host = SshTerminalHost(
-                                engine = sshEngine,
-                                findConnection = { id -> account.connections.find(id) },
-                            ),
+                            host = terminalHost,
                             emulator = productionTerminalEmulator(
                                 onCopy = { text ->
                                     if (text.isNotEmpty()) {

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt
@@ -36,6 +36,38 @@ object AlertDialogLayout {
         minOf(windowHeightDp - EDGE_GUTTER_DP * 2f, MAX_SHEET_DP).coerceAtLeast(120f)
 
     /**
+     * Compose Dialog's wrap-content window reports a short [measuredHeightDp].
+     * The sheet must still be measured against the physical screen, otherwise
+     * the cancel group is laid out below the wrap window and clipped.
+     */
+    fun dialogWindowHeightDp(screenHeightDp: Float, measuredHeightDp: Float): Float =
+        maxOf(screenHeightDp, measuredHeightDp)
+
+    /** Forces wrap-content Dialog windows to occupy the real screen. */
+    fun forcedWindowWidthDp(screenWidthDp: Float): Float = screenWidthDp.coerceAtLeast(1f)
+
+    fun forcedWindowHeightDp(screenHeightDp: Float): Float = screenHeightDp.coerceAtLeast(1f)
+
+    /**
+     * True when the cancel group sits above the system navigation bar.
+     * Evaluates the *measured* Dialog window, not the forced screen height:
+     * a wrap-content window shorter than the screen is the screenshot, and
+     * must fail even if the sheet would fit a full-screen window.
+     */
+    fun cancelGroupOnScreen(
+        screenHeightDp: Float,
+        measuredWindowHeightDp: Float,
+        bodyHeightDp: Float,
+        hasDismiss: Boolean,
+        navigationBarDp: Float,
+    ): Boolean {
+        if (measuredWindowHeightDp + 0.01f < screenHeightDp) return false
+        val stacked = stackedHeightDp(bodyHeightDp, hasDismiss)
+        val bottomReserve = EDGE_GUTTER_DP + navigationBarDp
+        return stacked + bottomReserve <= measuredWindowHeightDp + 0.01f
+    }
+
+    /**
      * The sheet is fully visible only when it is shorter than the window and still has room
      * for the cancel group after the body has taken its share.
      */

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
@@ -19,14 +19,16 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -43,7 +45,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
+import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.view.WindowManager
 import kotlinx.coroutines.delay
 import one.zephyr.mobile.ui.theme.ProvideContentColor
@@ -238,9 +243,11 @@ class ZephyrToastHostState {
  * Confirmation that looks like the demo action sheet, not a Material dialog.
  * Kept as `AlertDialog` so existing call sites only change the import.
  *
- * The platform Dialog is WRAP_CONTENT. Stretching it to MATCH_PARENT and
- * measuring against the *window* (not the wrap height) is what keeps the
- * cancel group on screen for SSH / RDP / VNC host-key prompts.
+ * Compose Dialog reverts [Window.setLayout] to WRAP_CONTENT after every
+ * measure. A one-shot SideEffect therefore still leaves the cancel group
+ * sitting in the system navigation bar. The window is pinned MATCH_PARENT
+ * on every pre-draw, and the content is [requiredWidth]/[requiredHeight]
+ * to the configuration screen so even a wrap window is screen-sized.
  */
 @Composable
 fun AlertDialog(
@@ -262,22 +269,15 @@ fun AlertDialog(
     ) {
         val composeView = LocalView.current
         val configuration = LocalConfiguration.current
+        val screenWidthDp = configuration.screenWidthDp.toFloat()
         val screenHeightDp = configuration.screenHeightDp.toFloat()
-        SideEffect {
-            var parent = composeView.parent
-            while (parent != null) {
-                if (parent is DialogWindowProvider) {
-                    val window = parent.window
-                    window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-                    window.setBackgroundDrawableResource(android.R.color.transparent)
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-                    break
-                }
-                parent = parent.parent
-            }
-        }
+        MatchParentDialogWindow(composeView)
+        // requiredWidth/requiredHeight pin the wrap-content Dialog to the
+        // configuration screen so the cancel group is measured against it.
         BoxWithConstraints(
             modifier = modifier
+                .requiredWidth(AlertDialogLayout.forcedWindowWidthDp(screenWidthDp).dp)
+                .requiredHeight(AlertDialogLayout.forcedWindowHeightDp(screenHeightDp).dp)
                 .fillMaxSize()
                 .background(palette.surfaces.scrim)
                 .imePadding()
@@ -288,14 +288,14 @@ fun AlertDialog(
                 ),
             contentAlignment = Alignment.BottomCenter,
         ) {
-            val windowHeightDp = maxOf(screenHeightDp, maxHeight.value)
+            val windowHeightDp = AlertDialogLayout.dialogWindowHeightDp(screenHeightDp, maxHeight.value)
             val availableHeight = AlertDialogLayout.availableHeightDp(windowHeightDp).dp
             Column(
                 Modifier
                     .fillMaxWidth()
                     .heightIn(max = availableHeight)
-                    .padding(start = 10.dp, end = 10.dp, bottom = 10.dp)
                     .navigationBarsPadding()
+                    .padding(start = 10.dp, end = 10.dp, bottom = 10.dp)
                     .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) {},
             ) {
                 Column(
@@ -349,6 +349,73 @@ fun AlertDialog(
                         ProvideContentColor(palette.onBackground, dismissButton)
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Compose's DialogLayout writes WRAP_CONTENT back onto the window after
+ * measure. Re-apply MATCH_PARENT on every pre-draw so the cancel group is
+ * laid out against the real screen, not the wrap height of the sheet.
+ */
+@Composable
+private fun MatchParentDialogWindow(composeView: View) {
+    DisposableEffect(composeView) {
+        fun apply() {
+            var parent = composeView.parent
+            while (parent != null) {
+                if (parent is DialogWindowProvider) {
+                    val window = parent.window
+                    val metrics = composeView.resources.displayMetrics
+                    val screenW = metrics.widthPixels
+                    val screenH = metrics.heightPixels
+                    val params = window.attributes
+                    val tooSmall =
+                        params.width == ViewGroup.LayoutParams.WRAP_CONTENT ||
+                            params.height == ViewGroup.LayoutParams.WRAP_CONTENT ||
+                            (params.width > 0 && params.width < screenW) ||
+                            (params.height > 0 && params.height < screenH) ||
+                            params.x != 0 ||
+                            params.y != 0
+                    if (tooSmall) {
+                        params.width = screenW
+                        params.height = screenH
+                        params.gravity = Gravity.TOP or Gravity.START
+                        params.x = 0
+                        params.y = 0
+                        params.horizontalMargin = 0f
+                        params.verticalMargin = 0f
+                        window.attributes = params
+                        window.setLayout(screenW, screenH)
+                    }
+                    window.decorView.setPadding(0, 0, 0, 0)
+                    window.setBackgroundDrawableResource(android.R.color.transparent)
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                    break
+                }
+                parent = parent.parent
+            }
+        }
+        apply()
+        val observer = composeView.viewTreeObserver
+        val layoutListener = ViewTreeObserver.OnGlobalLayoutListener { apply() }
+        val preDrawListener = ViewTreeObserver.OnPreDrawListener {
+            apply()
+            true
+        }
+        val attachListener = object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) = apply()
+            override fun onViewDetachedFromWindow(v: View) = Unit
+        }
+        observer.addOnGlobalLayoutListener(layoutListener)
+        observer.addOnPreDrawListener(preDrawListener)
+        composeView.addOnAttachStateChangeListener(attachListener)
+        onDispose {
+            composeView.removeOnAttachStateChangeListener(attachListener)
+            if (observer.isAlive) {
+                observer.removeOnGlobalLayoutListener(layoutListener)
+                observer.removeOnPreDrawListener(preDrawListener)
             }
         }
     }

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
@@ -92,4 +92,39 @@ class AlertDialogLayoutTest {
         assertEquals(0xFF, (AlertDialogLayout.DARK_SHEET_ARGB ushr 24) and 0xFF)
         assertEquals(0xFF, (AlertDialogLayout.LIGHT_SHEET_ARGB ushr 24) and 0xFF)
     }
+
+    @Test
+    fun wrapContentDialogWindowIsForcedToTheScreen() {
+        assertEquals(780f, AlertDialogLayout.dialogWindowHeightDp(780f, 220f), 0.001f)
+        assertEquals(780f, AlertDialogLayout.dialogWindowHeightDp(780f, 780f), 0.001f)
+        assertEquals(800f, AlertDialogLayout.dialogWindowHeightDp(780f, 800f), 0.001f)
+        assertEquals(360f, AlertDialogLayout.forcedWindowWidthDp(360f), 0.001f)
+        assertEquals(780f, AlertDialogLayout.forcedWindowHeightDp(780f), 0.001f)
+        assertEquals(1f, AlertDialogLayout.forcedWindowHeightDp(0f), 0.001f)
+    }
+
+    @Test
+    fun cancelGroupStaysAboveTheNavigationBarOnAPhone() {
+        val body = 180f
+        val nav = 48f
+        // Screenshot: wrap-content window ≈ sheet height, cancel sits in the nav bar.
+        assertFalse(
+            AlertDialogLayout.cancelGroupOnScreen(
+                screenHeightDp = 780f,
+                measuredWindowHeightDp = 220f,
+                bodyHeightDp = body,
+                hasDismiss = true,
+                navigationBarDp = nav,
+            ),
+        )
+        assertTrue(
+            AlertDialogLayout.cancelGroupOnScreen(
+                screenHeightDp = 780f,
+                measuredWindowHeightDp = 780f,
+                bodyHeightDp = body,
+                hasDismiss = true,
+                navigationBarDp = nav,
+            ),
+        )
+    }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -24,7 +24,7 @@ class SshTerminalHost(
     private val findConnection: suspend (String) -> Connection?,
 ) : TerminalHost {
 
-    private val lastRequest = LinkedHashMap<String, TerminalOpenRequest>()
+    private val lastTarget = LinkedHashMap<String, RememberedTarget>()
     @Suppress("unused")
     private val connectionLookup = findConnection
 
@@ -35,7 +35,7 @@ class SshTerminalHost(
             request.wipe()
             return TerminalOpenOutcome.Failed(UnavailableTerminalHost.TELNET_NO_SOCKET)
         }
-        lastRequest[request.sessionId] = copyRequest(request)
+        lastTarget[request.sessionId] = RememberedTarget(request.host, request.port)
         val route = SshRoute(listOf(RouteHop.Target(request.host, request.port)))
         val credential = credentialOf(request) ?: run {
             request.wipe()
@@ -79,7 +79,7 @@ class SshTerminalHost(
     }
 
     override suspend fun close(sessionId: String) {
-        lastRequest.remove(sessionId)
+        lastTarget.remove(sessionId)
         engine.disconnect(sessionId)
     }
 
@@ -92,8 +92,8 @@ class SshTerminalHost(
     override fun execStream(sessionId: String, command: String) = engine.execStream(sessionId, command)
 
     override suspend fun trustHostKey(sessionId: String) {
-        val remembered = lastRequest[sessionId] ?: return
-        engine.acceptHostKey(sessionId, remembered.host, remembered.port)
+        val remembered = lastTarget[sessionId]
+        engine.acceptHostKey(sessionId, remembered?.host.orEmpty(), remembered?.port ?: 0)
     }
 
     private fun credentialOf(request: TerminalOpenRequest): SshCredential? {
@@ -114,9 +114,5 @@ class SshTerminalHost(
         return copyOf()
     }
 
-    private fun copyRequest(request: TerminalOpenRequest): TerminalOpenRequest = request.copy(
-        password = request.password?.copyOf(),
-        privateKey = request.privateKey?.copyOf(),
-        passphrase = request.passphrase?.copyOf(),
-    )
+    private data class RememberedTarget(val host: String, val port: Int)
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
@@ -37,6 +37,50 @@ class SshTerminalHostTest {
     }
 
     @Test
+    fun trustHostKeyForwardsTheRememberedAddress() = runBlocking {
+        val engine = RecordingEngine()
+        val host = SshTerminalHost(engine) { null }
+        val outcome = host.open(
+            TerminalOpenRequest(
+                sessionId = "s1",
+                protocol = Protocol.SSH,
+                host = "103.240.198.233",
+                port = 22,
+                username = "root",
+                password = "secret".toCharArray(),
+            ),
+        )
+        assertTrue(outcome is TerminalOpenOutcome.Failed)
+        host.trustHostKey("s1")
+        assertEquals(1, engine.accepts)
+        assertEquals("s1", engine.acceptedSession)
+        assertEquals("103.240.198.233", engine.acceptedHost)
+        assertEquals(22, engine.acceptedPort)
+    }
+
+    @Test
+    fun trustHostKeyStillReachesTheEngineAfterTheRequestIsDropped() = runBlocking {
+        val engine = RecordingEngine()
+        val host = SshTerminalHost(engine) { null }
+        host.open(
+            TerminalOpenRequest(
+                sessionId = "s1",
+                protocol = Protocol.SSH,
+                host = "10.0.0.1",
+                port = 22,
+                username = "root",
+                password = "secret".toCharArray(),
+            ),
+        )
+        host.close("s1")
+        host.trustHostKey("s1")
+        assertEquals(1, engine.accepts)
+        assertEquals("s1", engine.acceptedSession)
+        assertEquals("", engine.acceptedHost)
+        assertEquals(0, engine.acceptedPort)
+    }
+
+    @Test
     fun telnetStaysOnTheUnavailablePath() = runBlocking {
         val engine = RecordingEngine()
         val host = SshTerminalHost(engine) { null }
@@ -57,6 +101,10 @@ class SshTerminalHostTest {
 
     private class RecordingEngine : SshEngine {
         var connects = 0
+        var accepts = 0
+        var acceptedSession: String? = null
+        var acceptedHost: String? = null
+        var acceptedPort: Int? = null
         override val isAvailable: Boolean = true
         override suspend fun connect(request: SshConnectRequest): SshConnectOutcome {
             connects += 1
@@ -68,7 +116,12 @@ class SshTerminalHostTest {
         override suspend fun send(sessionId: String, bytes: ByteArray) = Unit
         override suspend fun resize(sessionId: String, cols: Int, rows: Int, widthPx: Int, heightPx: Int) = Unit
         override suspend fun disconnect(sessionId: String) = Unit
-        override fun acceptHostKey(sessionId: String, host: String, port: Int) = Unit
+        override fun acceptHostKey(sessionId: String, host: String, port: Int) {
+            accepts += 1
+            acceptedSession = sessionId
+            acceptedHost = host
+            acceptedPort = port
+        }
         override suspend fun measureLatency(sessionId: String): Long? = null
         override suspend fun listDirectory(sessionId: String, path: String): Result<SftpDirectory> =
             Result.failure(IllegalStateException("unused"))

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -65,7 +65,7 @@ class SshjEngine internal constructor(
 
     private val sessions = ConcurrentHashMap<String, LiveSession>()
     private val closeEvents = ConcurrentHashMap<String, MutableSharedFlow<Throwable>>()
-    private val pending = ConcurrentHashMap<String, HostKey>()
+    private val pending = ConcurrentHashMap<String, PendingHostKey>()
     private val scope = CoroutineScope(SupervisorJob() + io)
 
     override val isAvailable: Boolean = true
@@ -97,9 +97,9 @@ class SshjEngine internal constructor(
             SshConnectOutcome.Connected(request.sessionId, "")
         } catch (error: Exception) {
             closeQuietly(client)
-            val presented = verifier.presented ?: pending[request.sessionId]
+            val presented = verifier.presented ?: pending[request.sessionId]?.key
             if (presented != null && !verifier.accepted) {
-                pending[request.sessionId] = presented
+                pending[request.sessionId] = PendingHostKey(target.host, target.port, presented)
                 return@withContext SshConnectOutcome.HostKeyDecisionRequired(presented, known = verifier.storedKey)
             }
             SshConnectOutcome.Failed(mapError(error, stage))
@@ -157,7 +157,8 @@ class SshjEngine internal constructor(
     override suspend fun disconnect(sessionId: String): Unit = withContext(io) {
         sessions.remove(sessionId)?.close()
         closeEvents.remove(sessionId)
-        pending.remove(sessionId)
+        // Pending trust is a user decision, not a live socket. Clearing it here is
+        // why "信任并继续" after a reconnect / host recreation wrote nothing.
         Unit
     }
 
@@ -501,8 +502,16 @@ class SshjEngine internal constructor(
     }
 
     override fun acceptHostKey(sessionId: String, host: String, port: Int) {
-        val key = pending.remove(sessionId) ?: return
-        knownHosts.put(host, port, key)
+        val presented = pending.remove(sessionId) ?: return
+        val storedHost = presented.host.ifBlank { host }
+        val storedPort = if (presented.port > 0) presented.port else port
+        if (storedHost.isBlank() || storedPort <= 0) return
+        knownHosts.put(storedHost, storedPort, presented.key)
+    }
+
+    /** Test seam: the first handshake stores the presented key before the user accepts it. */
+    internal fun rememberPendingForTest(sessionId: String, host: String, port: Int, key: HostKey) {
+        pending[sessionId] = PendingHostKey(host, port, key)
     }
 
     private fun authenticate(client: SSHClient, request: SshConnectRequest) {
@@ -578,6 +587,12 @@ class SshjEngine internal constructor(
         PTY("ssh_pty_failed", "SSH PTY 创建失败", true),
         SHELL("ssh_shell_failed", "SSH Shell 启动失败", true),
     }
+
+    private data class PendingHostKey(
+        val host: String,
+        val port: Int,
+        val key: HostKey,
+    )
 
     companion object {
         const val TRUST_FILE_NAME = "ssh_known_hosts.properties"

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngineHostKeyTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngineHostKeyTest.kt
@@ -1,0 +1,80 @@
+package one.zephyr.mobile.protocol.ssh
+
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Trust must survive the UI host being thrown away. The engine keeps the
+ * presented key (and the host/port it was seen on) so "信任并继续" still
+ * writes the book when [SshEngine.acceptHostKey] is called with blanks.
+ */
+class SshjEngineHostKeyTest {
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
+
+    @Test
+    fun acceptHostKeyUsesThePendingAddressWhenTheCallerForgotIt() {
+        val book = MemorySshKnownHostsBook()
+        val engine = SshjEngine(Dispatchers.Unconfined, book)
+        engine.rememberPendingForTest("s1", "103.240.198.233", 22, KEY_ED25519)
+
+        engine.acceptHostKey("s1", "", 0)
+
+        assertEquals(KEY_ED25519, book.find("103.240.198.233", 22))
+        assertNull(book.find("103.240.198.233", 2222))
+    }
+
+    @Test
+    fun disconnectDoesNotDropAPendingTrustDecision() {
+        val book = MemorySshKnownHostsBook()
+        val engine = SshjEngine(Dispatchers.Unconfined, book)
+        engine.rememberPendingForTest("s1", "10.0.0.5", 22, KEY_A)
+        runBlocking { engine.disconnect("s1") }
+
+        engine.acceptHostKey("s1", "", 0)
+
+        assertEquals(KEY_A, book.find("10.0.0.5", 22))
+    }
+
+    @Test
+    fun acceptHostKeyIsANoOpWithoutAPendingKey() {
+        val book = MemorySshKnownHostsBook()
+        val engine = SshjEngine(Dispatchers.Unconfined, book)
+
+        engine.acceptHostKey("missing", "10.0.0.5", 22)
+
+        assertNull(book.find("10.0.0.5", 22))
+    }
+
+    @Test
+    fun acceptedKeySurvivesANewEngineReadingTheSameFile() {
+        val file = File(tempDir.newFolder(), SshjEngine.TRUST_FILE_NAME)
+        val engine = SshjEngine(Dispatchers.Unconfined, FileSshKnownHostsBook(file))
+        engine.rememberPendingForTest("s1", "192.168.1.10", 22, KEY_A)
+
+        engine.acceptHostKey("s1", "ignored.example", 2222)
+
+        val reloaded = FileSshKnownHostsBook(file)
+        assertEquals(KEY_A, reloaded.find("192.168.1.10", 22))
+        assertNull(reloaded.find("ignored.example", 2222))
+    }
+
+    @Test
+    fun replacingAChangedKeyOverwritesTheFile() {
+        val file = File(tempDir.newFolder(), SshjEngine.TRUST_FILE_NAME)
+        val engine = SshjEngine(Dispatchers.Unconfined, FileSshKnownHostsBook(file))
+        engine.rememberPendingForTest("s1", "host-1", 22, KEY_A)
+        engine.acceptHostKey("s1", "host-1", 22)
+        engine.rememberPendingForTest("s1", "host-1", 22, KEY_B)
+        engine.acceptHostKey("s1", "host-1", 22)
+
+        assertEquals(KEY_B, FileSshKnownHostsBook(file).find("host-1", 22))
+    }
+}

--- a/zephyr_one/mobile/tests/alert-dialog-layout-replica.py
+++ b/zephyr_one/mobile/tests/alert-dialog-layout-replica.py
@@ -30,6 +30,32 @@ def sheet_fits(window_height_dp: float, body_height_dp: float, has_dismiss: bool
     return stacked <= available + 0.01 and stacked <= window_height_dp - EDGE_GUTTER_DP
 
 
+def dialog_window_height_dp(screen_height_dp: float, measured_height_dp: float) -> float:
+    return max(screen_height_dp, measured_height_dp)
+
+
+def forced_window_width_dp(screen_width_dp: float) -> float:
+    return max(screen_width_dp, 1.0)
+
+
+def forced_window_height_dp(screen_height_dp: float) -> float:
+    return max(screen_height_dp, 1.0)
+
+
+def cancel_group_on_screen(
+    screen_height_dp: float,
+    measured_window_height_dp: float,
+    body_height_dp: float,
+    has_dismiss: bool,
+    navigation_bar_dp: float,
+) -> bool:
+    if measured_window_height_dp + 0.01 < screen_height_dp:
+        return False
+    stacked = stacked_height_dp(body_height_dp, has_dismiss)
+    bottom_reserve = EDGE_GUTTER_DP + navigation_bar_dp
+    return stacked + bottom_reserve <= measured_window_height_dp + 0.01
+
+
 def _is_hex_digit(ch: str) -> bool:
     return ("0" <= ch <= "9") or ("A" <= ch <= "F") or ("a" <= ch <= "f")
 
@@ -63,6 +89,10 @@ def main() -> int:
     assert sheet_fits(780.0, body, True)
     assert not sheet_fits(220.0, body, True)
     assert stacked_height_dp(body, True) == body + 8.0 + 50.0 + 10.0
+    assert dialog_window_height_dp(780.0, 220.0) == 780.0
+    assert forced_window_height_dp(780.0) == 780.0
+    assert not cancel_group_on_screen(780.0, 220.0, body, True, 48.0)
+    assert cancel_group_on_screen(780.0, 780.0, body, True, 48.0)
 
     raw = "SHA256:QytVAAei+gY5ISAlZF3D6WfcZGOaTGY+ygTPRiDSbl0"
     wrapped = wrap_fingerprint(raw)

--- a/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
+++ b/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
@@ -24,10 +24,18 @@ test('alert dialog is bounded by the actual available window', () => {
   assert.match(alert, /AlertDialogLayout\.availableHeightDp\(windowHeightDp\)/);
   assert.match(alert, /\.heightIn\(max = availableHeight\)/);
   assert.match(alert, /\.navigationBarsPadding\(\)/);
-  assert.match(alert, /setLayout\(ViewGroup\.LayoutParams\.MATCH_PARENT, ViewGroup\.LayoutParams\.MATCH_PARENT\)/);
+  assert.match(alert, /window\.setLayout\(screenW, screenH\)/);
   assert.match(alert, /\.fillMaxSize\(\)/);
   assert.match(alert, /DialogWindowProvider/);
+  assert.match(alert, /OnPreDrawListener/);
+  assert.match(alert, /OnGlobalLayoutListener/);
+  assert.match(alert, /\.requiredWidth\(AlertDialogLayout\.forcedWindowWidthDp\(screenWidthDp\)\.dp\)/);
+  assert.match(alert, /\.requiredHeight\(AlertDialogLayout\.forcedWindowHeightDp\(screenHeightDp\)\.dp\)/);
+  assert.match(alert, /AlertDialogLayout\.dialogWindowHeightDp\(screenHeightDp, maxHeight\.value\)/);
+  assert.match(alert, /\.navigationBarsPadding\(\)[\s\S]*\.padding\(start = 10\.dp, end = 10\.dp, bottom = 10\.dp\)/);
   assert.match(layout, /fun availableHeightDp\(windowHeightDp: Float\)/);
+  assert.match(layout, /fun dialogWindowHeightDp/);
+  assert.match(layout, /fun cancelGroupOnScreen/);
   assert.doesNotMatch(alert, /val availableHeight = min\(maxHeight\.value - 20f, 640f\)/);
 });
 
@@ -100,6 +108,10 @@ test('window-height math keeps the cancel group on a phone', () => {
   assert.ok(stacked < availableHeightDp(780));
   const wrapContentDialog = 220;
   assert.ok(stacked > wrapContentDialog, 'old WRAP_CONTENT Dialog would clip cancel');
+  assert.equal(Math.max(780, 220), 780);
+  const nav = 48;
+  assert.ok(stacked + 10 + nav < 780);
+  assert.ok(!(stacked + 10 + nav < wrapContentDialog));
 });
 
 test('python replica of AlertDialogLayout stays in lockstep', async () => {

--- a/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
@@ -30,6 +30,8 @@ test('new connections start with a visible password field', () => {
 test('app wires SSHJ instead of the unavailable stub', () => {
   const root = read(ROOT_KT);
   assert.match(root, /SshTerminalHost\(/);
+  assert.match(root, /val terminalHost = remember\(account, sshEngine\)/);
+  assert.match(root, /host = terminalHost/);
   assert.match(root, /productionTerminalEmulator\(/);
   assert.doesNotMatch(root, /emulator = SimpleVtEmulator\(/);
   assert.match(root, /autoConnect = true/);
@@ -39,6 +41,14 @@ test('app wires SSHJ instead of the unavailable stub', () => {
   assert.match(read(ENGINE), /class SshjEngine/);
   assert.match(read(ENGINE), /TRUST_FILE_NAME = "ssh_known_hosts\.properties"/);
   assert.match(read(ENGINE), /FileSshKnownHostsBook/);
+  assert.match(read(ENGINE), /PendingHostKey/);
+  assert.match(read(ENGINE), /presented\.host\.ifBlank \{ host \}/);
+  const disconnect = read(ENGINE).match(/override suspend fun disconnect[\s\S]*?override suspend fun measureLatency/)?.[0] ?? '';
+  assert.match(disconnect, /Pending trust is a user decision/);
+  assert.doesNotMatch(disconnect, /pending\.remove\(sessionId\)/);
+  assert.match(read(HOST), /RememberedTarget/);
+  assert.match(read(HOST), /engine\.acceptHostKey\(sessionId, remembered\?\.host\.orEmpty\(\), remembered\?\.port \?: 0\)/);
+  assert.doesNotMatch(read(HOST), /lastRequest\[request\.sessionId\] = copyRequest/);
 });
 
 test('terminal uses the system IME by default', () => {


### PR DESCRIPTION
## 现象（pre24 仍在）

SSH 首次连接弹窗底部「取消」被系统导航栏裁掉；点「信任并继续」后杀进程再连，同一主机仍弹「首次连接该主机」。

## 根因

1. Compose `Dialog` 每次 measure 后把窗口写回 `WRAP_CONTENT`。PR #38 的一次性 `SideEffect { setLayout(MATCH_PARENT) }` 会被框架覆盖，取消组实际画在导航栏里。
2. `SshTerminalHost` 在 `ZephyrOneRoot` 里每次重组都 `new` 一份，`lastRequest` 丢了；`trustHostKey` 拿不到 host/port 就 `return`。引擎 `acceptHostKey` 没有 pending 也静默 return。`disconnect()` 还会把 pending 清掉。

## 修复

- `AlertDialog`：pre-draw / layout 把 Dialog 窗口钉到屏幕像素；内容用 `requiredWidth/requiredHeight` 按 configuration 铺满；`navigationBarsPadding` 在 gutter 之前。
- `SshjEngine`：pending 自带 host/port；`acceptHostKey` 即使调用方传空也能写盘；disconnect 不再清 pending。
- `SshTerminalHost` 用 `remember(account, sshEngine)` 跨重组存活；只记 host/port，不拷密码。

## 测试

- `AlertDialogLayoutTest`：wrap 窗口会裁取消组，全屏不会。
- `SshjEngineHostKeyTest`：pending 地址、disconnect 不丢、文件跨实例。
- `SshTerminalHostTest`：记住的地址会转发给引擎。
- 契约：`dialog-overflow-tools-add`、`ssh-editor-and-engine`、python replica。本地 `node --test` 相关套件 18/18。完整契约 362 pass / 10 fail，失败全是沙箱 PaX/Java + live server（与 main 基线同类）。
