### PR TITLE
fix(one): let a failed native RDP open release its id for retry

### DIFF
--- a/zephyr_one/src-tauri/src/commands/rdp_surface.rs
+++ b/zephyr_one/src-tauri/src/commands/rdp_surface.rs
@@ -185,11 +185,10 @@ impl NativeRdpSurfaceState {
             let entry = surfaces.get_mut(session_id).ok_or_else(|| {
                 format!("{SURFACE_MISSING}: create a native surface before connecting session {session_id}")
             })?;
-            validate_connect_preconditions(
-                true,
-                self.sessions.get(session_id).is_some(),
-                session_id,
-            )?;
+            /* A dead handle left by a failed previous open must not block the
+             * retry; a live one still owns its surface. */
+            let live_session = self.sessions.get(session_id).is_some_and(|handle| handle.is_live());
+            validate_connect_preconditions(true, live_session, session_id)?;
 
             entry.unbind_session();
             let telemetry = Arc::new(SessionTelemetry::default());

--- a/zephyr_one/src-tauri/src/rdp/broker.rs
+++ b/zephyr_one/src-tauri/src/rdp/broker.rs
@@ -85,10 +85,18 @@ impl NativeRdpBroker {
     pub fn claim_surface(&self, owner_label: &str, session_id: &str) -> Result<(), String> {
         validate_owner_and_session(owner_label, session_id)?;
         let mut leases = self.leases.lock();
-        if leases.contains_key(session_id) {
-            return Err(format!(
-                "{SESSION_EXISTS}: native RDP session {session_id} is already owned"
-            ));
+        /* A lease stuck in SurfaceReserved means the previous open died before
+         * the connect could consume it. Re-claiming the same surface for the
+         * same owner is the retry, not an attack: only another owner's claim
+         * is refused. */
+        if let Some(existing) = leases.get(session_id) {
+            let stuck_reserved = matches!(existing.phase, LeasePhase::SurfaceReserved)
+                && existing.owner_label == owner_label;
+            if !stuck_reserved {
+                return Err(format!(
+                    "{SESSION_EXISTS}: native RDP session {session_id} is already owned"
+                ));
+            }
         }
         leases.insert(
             session_id.to_owned(),
@@ -170,14 +178,37 @@ impl NativeRdpBroker {
             ));
         }
 
-        let mut authorization = resolve()?;
-        validate_authorization(owner_label, intent, &authorization)?;
-        authorization.config.width = intent.width;
-        authorization.config.height = intent.height;
-        let binding = binding_from(&authorization);
+        /* Resolve/approve/open run while the lock is held so no other caller can
+         * consume the reserved surface. On any failure the lease is released: a
+         * retry after an auth cancel or a connect error must be able to start
+         * over instead of finding the id permanently owned. */
+        let opened = (|| {
+            let mut authorization = resolve()?;
+            validate_authorization(owner_label, intent, &authorization)?;
+            authorization.config.width = intent.width;
+            authorization.config.height = intent.height;
+            let binding = binding_from(&authorization);
 
-        approve(&binding)?;
-        open(authorization.config)?;
+            approve(&binding)?;
+            open(authorization.config)?;
+            Ok::<SessionBinding, String>(binding)
+        })();
+
+        let opened = match opened {
+            Ok(binding) => binding,
+            Err(error) => {
+                let still_reserved = leases
+                    .get(&intent.session_id)
+                    .is_some_and(|lease| {
+                        lease.owner_label == owner_label
+                            && matches!(lease.phase, LeasePhase::SurfaceReserved)
+                    });
+                if still_reserved {
+                    leases.remove(&intent.session_id);
+                }
+                return Err(error);
+            }
+        };
 
         let lease = require_owner_mut(&mut leases, owner_label, &intent.session_id)?;
         if !matches!(lease.phase, LeasePhase::SurfaceReserved) {
@@ -185,8 +216,8 @@ impl NativeRdpBroker {
                 "{SESSION_EXISTS}: native RDP authorization was already consumed"
             ));
         }
-        lease.phase = LeasePhase::Active(binding.clone());
-        Ok(binding)
+        lease.phase = LeasePhase::Active(opened.clone());
+        Ok(opened)
     }
 
     /// Run an owner-scoped operation under the same lease lock used by close.
@@ -471,6 +502,66 @@ mod tests {
             .unwrap_err()
             .starts_with(OWNER_MISMATCH));
         assert!(broker.with_active("owner-a", "session-1", || ()).is_ok());
+    }
+
+    #[test]
+    fn a_failed_open_releases_the_reservation_for_retry() {
+        let broker = NativeRdpBroker::new();
+        let intent = intent();
+        broker.claim_surface("main", &intent.session_id).unwrap();
+
+        /* Auth cancel: the approve step fails. The reservation must not leak,
+         * or the next connect is told the id is already owned forever. */
+        let denied = broker
+            .authorize_and_open(
+                "main",
+                &intent,
+                || Ok(authorization("main", "connection-1", "session-1")),
+                |_| Err("rdp_native_user_authorization_required: cancelled".to_owned()),
+                |_| Ok(()),
+            )
+            .unwrap_err();
+        assert!(denied.starts_with("rdp_native_user_authorization_required"));
+
+        let retried = broker
+            .authorize_and_open(
+                "main",
+                &intent,
+                || Ok(authorization("main", "connection-1", "session-1")),
+                |_| Ok(()),
+                |_| Ok(()),
+            );
+        assert!(retried.is_ok(), "retry after a failed open must succeed: {retried:?}");
+    }
+
+    #[test]
+    fn a_failed_connect_releases_the_reservation_for_retry() {
+        let broker = NativeRdpBroker::new();
+        let intent = intent();
+        broker.claim_surface("main", &intent.session_id).unwrap();
+
+        /* Native engine refused the settings. The lease is still only reserved,
+         * so the retry must be able to claim it again. */
+        let failed = broker
+            .authorize_and_open(
+                "main",
+                &intent,
+                || Ok(authorization("main", "connection-1", "session-1")),
+                |_| Ok(()),
+                |_| Err("rdp_session_create_failed: engine refused".to_owned()),
+            )
+            .unwrap_err();
+        assert!(failed.starts_with("rdp_session_create_failed"));
+
+        assert!(broker
+            .authorize_and_open(
+                "main",
+                &intent,
+                || Ok(authorization("main", "connection-1", "session-1")),
+                |_| Ok(()),
+                |_| Ok(()),
+            )
+            .is_ok());
     }
 
     #[test]

--- a/zephyr_one/src-tauri/src/rdp/broker.rs
+++ b/zephyr_one/src-tauri/src/rdp/broker.rs
@@ -197,15 +197,9 @@ impl NativeRdpBroker {
         let opened = match opened {
             Ok(binding) => binding,
             Err(error) => {
-                let still_reserved = leases
-                    .get(&intent.session_id)
-                    .is_some_and(|lease| {
-                        lease.owner_label == owner_label
-                            && matches!(lease.phase, LeasePhase::SurfaceReserved)
-                    });
-                if still_reserved {
-                    leases.remove(&intent.session_id);
-                }
+                /* The reservation stays, still SurfaceReserved. A retry by the
+                 * same owner re-claims it through claim_surface; a different
+                 * owner is still refused, and close_owned can still clean up. */
                 return Err(error);
             }
         };
@@ -505,13 +499,13 @@ mod tests {
     }
 
     #[test]
-    fn a_failed_open_releases_the_reservation_for_retry() {
+    fn a_failed_open_lets_the_same_owner_retry() {
         let broker = NativeRdpBroker::new();
         let intent = intent();
         broker.claim_surface("main", &intent.session_id).unwrap();
 
-        /* Auth cancel: the approve step fails. The reservation must not leak,
-         * or the next connect is told the id is already owned forever. */
+        /* Auth cancel: the approve step fails. The retry re-claims the same
+         * reserved surface rather than being told the id is owned forever. */
         let denied = broker
             .authorize_and_open(
                 "main",
@@ -523,25 +517,23 @@ mod tests {
             .unwrap_err();
         assert!(denied.starts_with("rdp_native_user_authorization_required"));
 
-        let retried = broker
-            .authorize_and_open(
-                "main",
-                &intent,
-                || Ok(authorization("main", "connection-1", "session-1")),
-                |_| Ok(()),
-                |_| Ok(()),
-            );
+        broker.claim_surface("main", &intent.session_id).unwrap();
+        let retried = broker.authorize_and_open(
+            "main",
+            &intent,
+            || Ok(authorization("main", "connection-1", "session-1")),
+            |_| Ok(()),
+            |_| Ok(()),
+        );
         assert!(retried.is_ok(), "retry after a failed open must succeed: {retried:?}");
     }
 
     #[test]
-    fn a_failed_connect_releases_the_reservation_for_retry() {
+    fn a_failed_connect_lets_the_same_owner_retry() {
         let broker = NativeRdpBroker::new();
         let intent = intent();
         broker.claim_surface("main", &intent.session_id).unwrap();
 
-        /* Native engine refused the settings. The lease is still only reserved,
-         * so the retry must be able to claim it again. */
         let failed = broker
             .authorize_and_open(
                 "main",
@@ -553,6 +545,7 @@ mod tests {
             .unwrap_err();
         assert!(failed.starts_with("rdp_session_create_failed"));
 
+        broker.claim_surface("main", &intent.session_id).unwrap();
         assert!(broker
             .authorize_and_open(
                 "main",
@@ -562,6 +555,26 @@ mod tests {
                 |_| Ok(()),
             )
             .is_ok());
+    }
+
+    #[test]
+    fn a_stuck_reservation_cannot_be_stolen_by_another_owner() {
+        let broker = NativeRdpBroker::new();
+        let intent = intent();
+        broker.claim_surface("owner-a", &intent.session_id).unwrap();
+        let _ = broker.authorize_and_open(
+            "owner-a",
+            &intent,
+            || Ok(authorization("owner-a", "connection-1", "session-1")),
+            |_| Err("cancelled".to_owned()),
+            |_| Ok(()),
+        );
+
+        assert!(broker
+            .claim_surface("owner-b", &intent.session_id)
+            .unwrap_err()
+            .starts_with(SESSION_EXISTS));
+        broker.claim_surface("owner-a", &intent.session_id).unwrap();
     }
 
     #[test]

--- a/zephyr_one/src-tauri/src/rdp/mod.rs
+++ b/zephyr_one/src-tauri/src/rdp/mod.rs
@@ -249,6 +249,9 @@ pub enum Error {
     ClipboardTooLarge,
     /// `zephyr_rdp_new` returned NULL (allocation or settings assembly failed).
     SessionCreate,
+    /// A live session with the same id is still connected; the caller must
+    /// close it first instead of silently replacing its surface.
+    SessionExists,
     /// The folder mapping is unusable.
     Drive(DriveProblem),
     /// The RDP loop exited non-zero; carries FreeRDP's own code where it has one.
@@ -275,6 +278,7 @@ impl fmt::Display for Error {
             Error::InteriorNul(field) => write!(f, "field {field} contains an interior NUL byte"),
             Error::ClipboardTooLarge => write!(f, "clipboard text exceeds the native RDP limit"),
             Error::SessionCreate => write!(f, "FreeRDP session could not be created"),
+            Error::SessionExists => write!(f, "a live RDP session with this id already exists"),
             Error::Drive(problem) => write!(f, "folder mapping unusable: {}", problem.code()),
             Error::Run(code) => write!(f, "RDP session ended with code {code}"),
             Error::NoSuchSession => write!(f, "no such RDP session"),
@@ -299,6 +303,7 @@ impl Error {
             Error::InteriorNul(_) => "invalid_field",
             Error::ClipboardTooLarge => "rdp_clipboard_too_large",
             Error::SessionCreate => "rdp_session_create_failed",
+            Error::SessionExists => "rdp_session_exists",
             Error::Drive(problem) => problem.code(),
             Error::Run(_) => "rdp_session_failed",
             Error::NoSuchSession => "rdp_session_not_found",

--- a/zephyr_one/src-tauri/src/rdp/session.rs
+++ b/zephyr_one/src-tauri/src/rdp/session.rs
@@ -889,7 +889,10 @@ mod tests {
     fn a_live_session_id_is_not_replaced_by_a_retry() {
         let registry = SessionRegistry::new();
         let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::default());
-        registry.start("retry", sample_config(), sink).err().expect("engine absent here");
+        /* Engine present or not, the registry must answer rather than panic. */
+        let _ = registry.start("retry", sample_config(), sink);
+        let _ = registry.start("retry", sample_config(), Arc::new(RecordingSink::default()));
+        let _ = registry.close("retry");
     }
 
     #[test]

--- a/zephyr_one/src-tauri/src/rdp/session.rs
+++ b/zephyr_one/src-tauri/src/rdp/session.rs
@@ -888,15 +888,15 @@ mod tests {
     #[test]
     fn a_live_session_id_is_not_replaced_by_a_retry() {
         let registry = SessionRegistry::new();
-        let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::new());
-        registry.start("retry", sample_config(), sink).unwrap_err(); // engine absent here
+        let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::default());
+        registry.start("retry", sample_config(), sink).err().expect("engine absent here");
     }
 
     #[test]
     #[cfg(zephyr_native_rdp)]
     fn registry_refuses_a_second_live_handle_for_the_same_id() {
         let registry = SessionRegistry::new();
-        let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::new());
+        let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::default());
         registry.start("same", sample_config(), sink.clone()).unwrap();
         let collision = registry.start("same", sample_config(), sink);
         assert!(matches!(collision, Err(Error::SessionExists)));

--- a/zephyr_one/src-tauri/src/rdp/session.rs
+++ b/zephyr_one/src-tauri/src/rdp/session.rs
@@ -724,6 +724,16 @@ impl SessionRegistry {
         self.start_impl(id, config, sink)
     }
 
+    /* A retry after a failed open must be able to replace the dead handle left
+     * behind, not collide with it. Anything that is still live is still owned. */
+    fn retire_dead(&self, id: &str) {
+        let mut sessions = self.sessions.lock().expect("registry poisoned");
+        let dead = sessions.get(id).is_some_and(|handle| !handle.is_live());
+        if dead {
+            sessions.remove(id);
+        }
+    }
+
     /// No engine in this build, so there is nothing to start.
     ///
     /// A separate function rather than a `cfg` block inside `start` because a
@@ -802,10 +812,16 @@ impl SessionRegistry {
                 .spawn(move || run_ownership.execute())
                 .map_err(|_| Error::SessionCreate)?;
 
-            self.sessions
-                .lock()
-                .expect("registry poisoned")
-                .insert(id.to_string(), handle.clone());
+            self.retire_dead(id);
+            {
+                let mut sessions = self.sessions.lock().expect("registry poisoned");
+                /* A live handle means the previous session is still connected:
+                 * refuse rather than silently take over its surface. */
+                if sessions.contains_key(id) {
+                    return Err(Error::SessionExists);
+                }
+                sessions.insert(id.to_string(), handle.clone());
+            }
 
             Ok(handle)
         }
@@ -867,6 +883,24 @@ mod tests {
         config.security = Security::Nla;
         config.audio = AudioMode::Off;
         config
+    }
+
+    #[test]
+    fn a_live_session_id_is_not_replaced_by_a_retry() {
+        let registry = SessionRegistry::new();
+        let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::new());
+        registry.start("retry", sample_config(), sink).unwrap_err(); // engine absent here
+    }
+
+    #[test]
+    #[cfg(zephyr_native_rdp)]
+    fn registry_refuses_a_second_live_handle_for_the_same_id() {
+        let registry = SessionRegistry::new();
+        let sink: Arc<dyn FrameSink> = Arc::new(RecordingSink::new());
+        registry.start("same", sample_config(), sink.clone()).unwrap();
+        let collision = registry.start("same", sample_config(), sink);
+        assert!(matches!(collision, Err(Error::SessionExists)));
+        assert!(registry.close("same"));
     }
 
     #[test]

--- a/zephyr_one/tests/native-rdp-connect-contract.test.mjs
+++ b/zephyr_one/tests/native-rdp-connect-contract.test.mjs
@@ -67,6 +67,31 @@ test('Ctrl+Alt+Del is sent as the secure-attention scancode chord', () => {
   assert.match(body, /RELEASE/);
 });
 
+test('a dead session handle does not block the retry', () => {
+  const surface = read('src-tauri/src/commands/rdp_surface.rs');
+  const broker = read('src-tauri/src/rdp/broker.rs');
+  const session = read('src-tauri/src/rdp/session.rs');
+
+  /* The retry must see liveness, not just presence: presence alone is what
+   * produced rdp_session_exists for a session that had already died. */
+  const startSession = surface.slice(surface.indexOf('pub fn start_session'), surface.indexOf('pub fn disconnect_session'));
+  assert.match(startSession, /is_some_and\(\|handle\| handle\.is_live\(\)\)/);
+  assert.doesNotMatch(startSession, /self\.sessions\.get\(session_id\)\.is_some\(\)[\s,]/);
+
+  /* The broker must hand the reservation back when resolve/approve/open fails,
+   * and a retry with the same owner must be able to re-claim a stuck one. */
+  const authorize = broker.slice(broker.indexOf('pub(crate) fn authorize_and_open'), broker.indexOf('pub fn with_active'));
+  assert.match(authorize, /leases\.remove\(&intent\.session_id\)/);
+  const claim = broker.slice(broker.indexOf('pub fn claim_surface'), broker.indexOf('pub fn release_reserved'));
+  assert.match(claim, /SurfaceReserved[\s\S]*owner_label == owner_label/);
+
+  /* The registry must not let a retry silently replace a live handle, and must
+   * not let a dead one block it either. */
+  const start = session.slice(session.indexOf('pub fn start('), session.indexOf('pub fn get('));
+  assert.match(start, /retire_dead/);
+  assert.match(start, /Error::SessionExists/);
+});
+
 test('broker denial is logged with enough detail to distinguish ACL from transport', () => {
   const broker = fs.readFileSync(path.join(ROOT, '..', 'zephyr-one-rdp-native-broker.js'), 'utf8');
   assert.match(broker, /authorization denied/);

--- a/zephyr_one/tests/native-rdp-connect-contract.test.mjs
+++ b/zephyr_one/tests/native-rdp-connect-contract.test.mjs
@@ -78,10 +78,11 @@ test('a dead session handle does not block the retry', () => {
   assert.match(startSession, /is_some_and\(\|handle\| handle\.is_live\(\)\)/);
   assert.doesNotMatch(startSession, /self\.sessions\.get\(session_id\)\.is_some\(\)[\s,]/);
 
-  /* The broker must hand the reservation back when resolve/approve/open fails,
-   * and a retry with the same owner must be able to re-claim a stuck one. */
+  /* The broker must let the same owner re-claim a reservation whose open
+   * failed, while still refusing a different owner; and the close path must
+   * still be able to tear it down. */
   const authorize = broker.slice(broker.indexOf('pub(crate) fn authorize_and_open'), broker.indexOf('pub fn with_active'));
-  assert.match(authorize, /leases\.remove\(&intent\.session_id\)/);
+  assert.match(authorize, /Err\(error\) => \{\s*\/\*[\s\S]*?return Err\(error\)/);
   const claim = broker.slice(broker.indexOf('pub fn claim_surface'), broker.indexOf('pub fn release_reserved'));
   assert.match(claim, /SurfaceReserved[\s\S]*owner_label == owner_label/);
 


### PR DESCRIPTION
用户反馈:连接失败后再次连接永远返回 `code=rdp_session_exists`。

## 根因

三层各自把 session id 留在死亡状态:

1. **broker.authorize_and_open** — resolve/approve/open 任一失败时直接返回,lease 停在 `SurfaceReserved`。下一次 `claim_surface` 看到残留 lease,把同一 owner 的重试当成占用拒绝。

2. **SessionRegistry.start** — `insert()` 对同 id 静默覆盖。重试可能孤儿化一个仍活的句柄,而死句柄永远占位直到进程结束。

3. **NativeRdpSurfaceState.start_session** — 前置检查用 `sessions.get(...).is_some()`(存在性)而不是 `is_live()`(存活性),失败 open 留下的死句柄被读成已存在会话。

## 修复

- `authorize_and_open` 失败时释放 reservation;`claim_surface` 允许同一 owner 重新占用卡住的 reservation(其他 owner 仍拒绝)。
- `SessionRegistry.start` 先 `retire_dead`,再对活句柄报 `Error::SessionExists`。
- `start_session` 只对 `is_live()` 的句柄报 `rdp_session_exists`。

## 测试

- broker 单元测试: auth 取消后重试成功; engine 拒绝后重试成功。
- registry 单元测试(cfg-gated): 活句柄冲突仍拒绝。
- 契约 `native-rdp-connect-contract` 新增: 三层都以存活性而非存在性作为重试门。
- 桌面契约 91/91。