### PR TITLE
fix(mobile): host-key sheet in-window; persist trust as lines

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt
@@ -99,7 +99,7 @@ class ManagedSshSessionPool(
                     if (promptState.value === prompt) promptState.value = null
                 }
                 if (!accepted) error("已取消主机指纹确认")
-                engine.acceptHostKey(sessionId, connection.host, connection.port)
+                engine.acceptHostKey(sessionId, connection.host, connection.port, outcome.presented)
                 outcome = engine.connect(request)
             }
             require(outcome is SshConnectOutcome.Connected) {

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayout.kt
@@ -17,6 +17,8 @@ object AlertDialogLayout {
     const val BODY_VERTICAL_PAD_DP = 8f
     const val FINGERPRINT_GROUP = 4
     const val FINGERPRINT_GROUPS_PER_LINE = 6
+    /** Above terminal chrome so the cancel group is never under Extra Keys. */
+    const val OVERLAY_Z = 40f
 
     /** Dark-scheme floating sheet, forced opaque so Extra Keys cannot bleed through. */
     val DARK_SHEET_ARGB: Int = 0xFF1A1E25.toInt()

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Overlays.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,15 +18,11 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -36,20 +31,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
-import android.view.Gravity
-import android.view.View
-import android.view.ViewGroup
-import android.view.ViewTreeObserver
-import android.view.WindowManager
+import androidx.compose.ui.zIndex
+import androidx.activity.compose.BackHandler
 import kotlinx.coroutines.delay
 import one.zephyr.mobile.ui.theme.ProvideContentColor
 import one.zephyr.mobile.ui.theme.ZephyrMotionTokens
@@ -243,11 +230,11 @@ class ZephyrToastHostState {
  * Confirmation that looks like the demo action sheet, not a Material dialog.
  * Kept as `AlertDialog` so existing call sites only change the import.
  *
- * Compose Dialog reverts [Window.setLayout] to WRAP_CONTENT after every
- * measure. A one-shot SideEffect therefore still leaves the cancel group
- * sitting in the system navigation bar. The window is pinned MATCH_PARENT
- * on every pre-draw, and the content is [requiredWidth]/[requiredHeight]
- * to the configuration screen so even a wrap window is screen-sized.
+ * This is an in-window overlay on the Activity, the same surface ActionSheet
+ * uses. Compose Dialog / PopupWindow are WRAP_CONTENT windows; pinning them
+ * MATCH_PARENT still left the cancel group in the system navigation bar on
+ * device (pre24 / pre26). Drawn here, [navigationBarsPadding] is the real
+ * Activity inset.
  */
 @Composable
 fun AlertDialog(
@@ -260,162 +247,79 @@ fun AlertDialog(
 ) {
     val palette = ZephyrTheme.palette
     val sheetColor = Color(AlertDialogLayout.sheetArgb(palette.dark))
-    Dialog(
-        onDismissRequest = onDismissRequest,
-        properties = DialogProperties(
-            usePlatformDefaultWidth = false,
-            decorFitsSystemWindows = false,
-        ),
+    BackHandler(onBack = onDismissRequest)
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxSize()
+            .zIndex(AlertDialogLayout.OVERLAY_Z)
+            .background(palette.surfaces.scrim)
+            .imePadding()
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onDismissRequest,
+            ),
+        contentAlignment = Alignment.BottomCenter,
     ) {
-        val composeView = LocalView.current
-        val configuration = LocalConfiguration.current
-        val screenWidthDp = configuration.screenWidthDp.toFloat()
-        val screenHeightDp = configuration.screenHeightDp.toFloat()
-        MatchParentDialogWindow(composeView)
-        // requiredWidth/requiredHeight pin the wrap-content Dialog to the
-        // configuration screen so the cancel group is measured against it.
-        BoxWithConstraints(
-            modifier = modifier
-                .requiredWidth(AlertDialogLayout.forcedWindowWidthDp(screenWidthDp).dp)
-                .requiredHeight(AlertDialogLayout.forcedWindowHeightDp(screenHeightDp).dp)
-                .fillMaxSize()
-                .background(palette.surfaces.scrim)
-                .imePadding()
-                .clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                    onClick = onDismissRequest,
-                ),
-            contentAlignment = Alignment.BottomCenter,
+        val availableHeight = AlertDialogLayout.availableHeightDp(maxHeight.value).dp
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .heightIn(max = availableHeight)
+                .navigationBarsPadding()
+                .padding(start = 10.dp, end = 10.dp, bottom = 10.dp)
+                .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) {},
         ) {
-            val windowHeightDp = AlertDialogLayout.dialogWindowHeightDp(screenHeightDp, maxHeight.value)
-            val availableHeight = AlertDialogLayout.availableHeightDp(windowHeightDp).dp
             Column(
                 Modifier
                     .fillMaxWidth()
-                    .heightIn(max = availableHeight)
-                    .navigationBarsPadding()
-                    .padding(start = 10.dp, end = 10.dp, bottom = 10.dp)
-                    .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) {},
+                    .weight(1f, fill = false)
+                    .clip(RoundedCornerShape(ZephyrRadius.lg))
+                    .background(sheetColor),
             ) {
-                Column(
+                if (title != null) {
+                    Box(
+                        Modifier.fillMaxWidth().padding(top = 16.dp, start = 20.dp, end = 20.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        ProvideContentColor(palette.onBackground, title)
+                    }
+                }
+                if (text != null) {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .weight(1f, fill = false)
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = 20.dp, vertical = 8.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        ProvideContentColor(palette.onFloatingMuted, text)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                Box(
                     Modifier
                         .fillMaxWidth()
-                        .weight(1f, fill = false)
-                        .clip(RoundedCornerShape(ZephyrRadius.lg))
-                        .background(sheetColor),
+                        .heightIn(min = 50.dp)
+                        .clickable(role = Role.Button) { /* confirm button owns the click */ },
+                    contentAlignment = Alignment.Center,
                 ) {
-                    if (title != null) {
-                        Box(
-                            Modifier.fillMaxWidth().padding(top = 16.dp, start = 20.dp, end = 20.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            ProvideContentColor(palette.onBackground, title)
-                        }
-                    }
-                    if (text != null) {
-                        Box(
-                            Modifier
-                                .fillMaxWidth()
-                                .weight(1f, fill = false)
-                                .verticalScroll(rememberScrollState())
-                                .padding(horizontal = 20.dp, vertical = 8.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            ProvideContentColor(palette.onFloatingMuted, text)
-                        }
-                    }
-                    Spacer(Modifier.height(8.dp))
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 50.dp)
-                            .clickable(role = Role.Button) { /* confirm button owns the click */ },
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        ProvideContentColor(palette.status.error, confirmButton)
-                    }
-                }
-                if (dismissButton != null) {
-                    Spacer(Modifier.height(8.dp))
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(ZephyrRadius.lg))
-                            .background(sheetColor)
-                            .heightIn(min = 50.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        ProvideContentColor(palette.onBackground, dismissButton)
-                    }
+                    ProvideContentColor(palette.status.error, confirmButton)
                 }
             }
-        }
-    }
-}
-
-/**
- * Compose's DialogLayout writes WRAP_CONTENT back onto the window after
- * measure. Re-apply MATCH_PARENT on every pre-draw so the cancel group is
- * laid out against the real screen, not the wrap height of the sheet.
- */
-@Composable
-private fun MatchParentDialogWindow(composeView: View) {
-    DisposableEffect(composeView) {
-        fun apply() {
-            var parent = composeView.parent
-            while (parent != null) {
-                if (parent is DialogWindowProvider) {
-                    val window = parent.window
-                    val metrics = composeView.resources.displayMetrics
-                    val screenW = metrics.widthPixels
-                    val screenH = metrics.heightPixels
-                    val params = window.attributes
-                    val tooSmall =
-                        params.width == ViewGroup.LayoutParams.WRAP_CONTENT ||
-                            params.height == ViewGroup.LayoutParams.WRAP_CONTENT ||
-                            (params.width > 0 && params.width < screenW) ||
-                            (params.height > 0 && params.height < screenH) ||
-                            params.x != 0 ||
-                            params.y != 0
-                    if (tooSmall) {
-                        params.width = screenW
-                        params.height = screenH
-                        params.gravity = Gravity.TOP or Gravity.START
-                        params.x = 0
-                        params.y = 0
-                        params.horizontalMargin = 0f
-                        params.verticalMargin = 0f
-                        window.attributes = params
-                        window.setLayout(screenW, screenH)
-                    }
-                    window.decorView.setPadding(0, 0, 0, 0)
-                    window.setBackgroundDrawableResource(android.R.color.transparent)
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-                    break
+            if (dismissButton != null) {
+                Spacer(Modifier.height(8.dp))
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(ZephyrRadius.lg))
+                        .background(sheetColor)
+                        .heightIn(min = 50.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    ProvideContentColor(palette.onBackground, dismissButton)
                 }
-                parent = parent.parent
-            }
-        }
-        apply()
-        val observer = composeView.viewTreeObserver
-        val layoutListener = ViewTreeObserver.OnGlobalLayoutListener { apply() }
-        val preDrawListener = ViewTreeObserver.OnPreDrawListener {
-            apply()
-            true
-        }
-        val attachListener = object : View.OnAttachStateChangeListener {
-            override fun onViewAttachedToWindow(v: View) = apply()
-            override fun onViewDetachedFromWindow(v: View) = Unit
-        }
-        observer.addOnGlobalLayoutListener(layoutListener)
-        observer.addOnPreDrawListener(preDrawListener)
-        composeView.addOnAttachStateChangeListener(attachListener)
-        onDispose {
-            composeView.removeOnAttachStateChangeListener(attachListener)
-            if (observer.isAlive) {
-                observer.removeOnGlobalLayoutListener(layoutListener)
-                observer.removeOnPreDrawListener(preDrawListener)
             }
         }
     }

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/component/AlertDialogLayoutTest.kt
@@ -94,6 +94,11 @@ class AlertDialogLayoutTest {
     }
 
     @Test
+    fun overlaySitsAboveTerminalChrome() {
+        assertTrue(AlertDialogLayout.OVERLAY_Z > 1f)
+    }
+
+    @Test
     fun wrapContentDialogWindowIsForcedToTheScreen() {
         assertEquals(780f, AlertDialogLayout.dialogWindowHeightDp(780f, 220f), 0.001f)
         assertEquals(780f, AlertDialogLayout.dialogWindowHeightDp(780f, 780f), 0.001f)

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -93,8 +93,9 @@ fun ConnectionEditorScreen(
 ) {
     var confirmDiscard by remember { mutableStateOf(false) }
 
+    Box(modifier.fillMaxSize()) {
     Column(
-        modifier
+        Modifier
             .fillMaxSize()
             .background(ZephyrTheme.palette.surfaces.background),
     ) {
@@ -167,6 +168,7 @@ fun ConnectionEditorScreen(
                 }
             },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt
@@ -98,7 +98,8 @@ fun ConnectionListScreen(
 ) {
     var pendingDelete by remember { mutableStateOf<Connection?>(null) }
 
-    Column(modifier.fillMaxSize()) {
+    Box(modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize()) {
         DashboardHeader(
             query = filter.query,
             syncStatus = syncStatus,
@@ -166,6 +167,7 @@ fun ConnectionListScreen(
                 }
             },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/NoteScreens.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/NoteScreens.kt
@@ -223,6 +223,7 @@ fun NoteListRoute(
     val filter by viewModel.filter.collectAsState()
     var pendingTrash by remember { mutableStateOf<Note?>(null) }
 
+    Box(Modifier.fillMaxSize()) {
     Column(Modifier.fillMaxSize()) {
         PushedPageHeader(title = stringResource(R.string.notes_title), onBack = onBack) {
             HeaderAddButton(stringResource(R.string.notes_create), onCreate)
@@ -312,6 +313,7 @@ fun NoteListRoute(
             },
             dismissButton = { TextButton(onClick = { pendingTrash = null }) { Text(stringResource(R.string.notes_cancel)) } },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt
@@ -197,6 +197,7 @@ fun SnippetListRoute(
     val rows by viewModel.snippets.collectAsState()
     var pending by remember { mutableStateOf<Snippet?>(null) }
 
+    Box(Modifier.fillMaxSize()) {
     Column(Modifier.fillMaxSize()) {
         PushedPageHeader(title = stringResource(R.string.snippets_title), onBack = onBack) {
             HeaderAddButton(stringResource(R.string.snippets_create), onCreate)
@@ -266,6 +267,7 @@ fun SnippetListRoute(
             },
             dismissButton = { TextButton(onClick = { pending = null }) { Text("取消") } },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionListScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionListScreen.kt
@@ -84,6 +84,7 @@ fun SessionListScreen(
     var confirmingBulkClose by remember { mutableStateOf(false) }
 
     PageStateScaffold(state = state, modifier = modifier) { content ->
+        Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {
             ListHeader(
                 selectionCount = selection.size,
@@ -154,6 +155,7 @@ fun SessionListScreen(
                     }
                 },
             )
+        }
         }
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -35,7 +35,7 @@ class SshTerminalHost(
             request.wipe()
             return TerminalOpenOutcome.Failed(UnavailableTerminalHost.TELNET_NO_SOCKET)
         }
-        lastTarget[request.sessionId] = RememberedTarget(request.host, request.port)
+        lastTarget[request.sessionId] = RememberedTarget(request.host, request.port, presented = null)
         val route = SshRoute(listOf(RouteHop.Target(request.host, request.port)))
         val credential = credentialOf(request) ?: run {
             request.wipe()
@@ -57,10 +57,17 @@ class SshTerminalHost(
         request.wipe()
         return when (outcome) {
             is SshConnectOutcome.Connected -> TerminalOpenOutcome.Opened(outcome.sessionId, outcome.serverBanner)
-            is SshConnectOutcome.HostKeyDecisionRequired -> TerminalOpenOutcome.HostKeyDecision(
-                fingerprint = outcome.presented.sha256Fingerprint,
-                changed = outcome.known != null,
-            )
+            is SshConnectOutcome.HostKeyDecisionRequired -> {
+                lastTarget[request.sessionId] = RememberedTarget(
+                    host = request.host,
+                    port = request.port,
+                    presented = outcome.presented,
+                )
+                TerminalOpenOutcome.HostKeyDecision(
+                    fingerprint = outcome.presented.sha256Fingerprint,
+                    changed = outcome.known != null,
+                )
+            }
             is SshConnectOutcome.Failed -> TerminalOpenOutcome.Failed(outcome.error)
         }
     }
@@ -93,7 +100,12 @@ class SshTerminalHost(
 
     override suspend fun trustHostKey(sessionId: String) {
         val remembered = lastTarget[sessionId]
-        engine.acceptHostKey(sessionId, remembered?.host.orEmpty(), remembered?.port ?: 0)
+        engine.acceptHostKey(
+            sessionId,
+            remembered?.host.orEmpty(),
+            remembered?.port ?: 0,
+            remembered?.presented,
+        )
     }
 
     private fun credentialOf(request: TerminalOpenRequest): SshCredential? {
@@ -114,5 +126,9 @@ class SshTerminalHost(
         return copyOf()
     }
 
-    private data class RememberedTarget(val host: String, val port: Int)
+    private data class RememberedTarget(
+        val host: String,
+        val port: Int,
+        val presented: one.zephyr.mobile.protocol.ssh.HostKey?,
+    )
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
@@ -117,6 +117,14 @@ class SshTerminalHostTest {
         override suspend fun resize(sessionId: String, cols: Int, rows: Int, widthPx: Int, heightPx: Int) = Unit
         override suspend fun disconnect(sessionId: String) = Unit
         override fun acceptHostKey(sessionId: String, host: String, port: Int) {
+            acceptHostKey(sessionId, host, port, null)
+        }
+        override fun acceptHostKey(
+            sessionId: String,
+            host: String,
+            port: Int,
+            key: one.zephyr.mobile.protocol.ssh.HostKey?,
+        ) {
             accepts += 1
             acceptedSession = sessionId
             acceptedHost = host

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/BatchExecutionScreen.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/BatchExecutionScreen.kt
@@ -81,6 +81,7 @@ fun BatchExecutionScreen(
     modifier: Modifier = Modifier,
 ) {
     PageStateScaffold(state = state, onRetry = onRetry, modifier = modifier.fillMaxSize()) { content ->
+        var confirmCancel by remember { mutableStateOf(false) }
         Box(Modifier.fillMaxSize()) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -189,7 +190,9 @@ fun BatchExecutionScreen(
             }
             PushedPageActionBar(Modifier.align(Alignment.BottomCenter)) {
                 PrimaryButton(
-                    onClick = { onIntent(if (content.isRunning) BatchIntent.CancelRun else BatchIntent.ClearSelection) },
+                    onClick = {
+                        if (content.isRunning) confirmCancel = true else onIntent(BatchIntent.ClearSelection)
+                    },
                     modifier = Modifier.weight(1f),
                     ghost = true,
                 ) { Text("取消") }
@@ -198,6 +201,24 @@ fun BatchExecutionScreen(
                     modifier = Modifier.weight(1.4f),
                     enabled = content.canRun,
                 ) { Text("执行") }
+            }
+            if (confirmCancel) {
+                AlertDialog(
+                    onDismissRequest = { confirmCancel = false },
+                    title = { Text(stringResource(R.string.tools_batch_cancel_title)) },
+                    text = { Text(stringResource(R.string.tools_batch_cancel_message)) },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            confirmCancel = false
+                            onIntent(BatchIntent.CancelRun)
+                        }) { Text(stringResource(R.string.tools_batch_cancel_confirm)) }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { confirmCancel = false }) {
+                            Text(stringResource(R.string.tools_dialog_cancel))
+                        }
+                    },
+                )
             }
         }
     }
@@ -381,7 +402,6 @@ private fun TargetPickerRow(
 
 @Composable
 private fun RunActions(content: BatchContent, onIntent: (BatchIntent) -> Unit) {
-    var confirmCancel by remember { mutableStateOf(false) }
     FlowRow(
         modifier = Modifier.fillMaxWidth().padding(vertical = ZephyrSpacing.sm),
         horizontalArrangement = Arrangement.spacedBy(ZephyrSpacing.sm),
@@ -392,13 +412,6 @@ private fun RunActions(content: BatchContent, onIntent: (BatchIntent) -> Unit) {
             modifier = Modifier.sizeIn(minHeight = 48.dp),
         ) { Text(stringResource(R.string.tools_batch_run)) }
 
-        if (content.isRunning) {
-            OutlinedButton(
-                onClick = { confirmCancel = true },
-                modifier = Modifier.sizeIn(minHeight = 48.dp),
-            ) { Text(stringResource(R.string.tools_batch_cancel_run)) }
-        }
-
         if (content.run?.isComplete == true) {
             OutlinedButton(
                 onClick = { onIntent(BatchIntent.Export) },
@@ -406,31 +419,11 @@ private fun RunActions(content: BatchContent, onIntent: (BatchIntent) -> Unit) {
             ) { Text(stringResource(R.string.tools_batch_export)) }
         }
     }
-    // The disabled reason is shown rather than implied, so a greyed-out 执行 is never unexplained.
     (content.runGate as? ActionGate.Disabled)?.let { disabled ->
         Text(
             text = disabled.reason,
             style = ZephyrTheme.typography.caption,
             color = ZephyrTheme.palette.onFloatingMuted,
-        )
-    }
-
-    if (confirmCancel) {
-        AlertDialog(
-            onDismissRequest = { confirmCancel = false },
-            title = { Text(stringResource(R.string.tools_batch_cancel_title)) },
-            text = { Text(stringResource(R.string.tools_batch_cancel_message)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    confirmCancel = false
-                    onIntent(BatchIntent.CancelRun)
-                }) { Text(stringResource(R.string.tools_batch_cancel_confirm)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { confirmCancel = false }) {
-                    Text(stringResource(R.string.tools_dialog_cancel))
-                }
-            },
         )
     }
 }

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ConnectedScreens.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ConnectedScreens.kt
@@ -191,6 +191,7 @@ fun ClientTokenLiveRoute(
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboardManager.current
 
+    Box(Modifier.fillMaxSize()) {
     Column(Modifier.fillMaxSize()) {
         PushedPageHeader(title = "Client Token", onBack = onBack) {
             HeaderAddButton("新增 Token") {
@@ -203,8 +204,7 @@ fun ClientTokenLiveRoute(
                 modifier = Modifier.padding(ZephyrSpacing.lg),
                 color = ZephyrTheme.palette.onFloatingMuted,
             )
-            return
-        }
+        } else {
         val liveRows = rows.filter { it.deletedAt == null }
         LazyColumn(contentPadding = androidx.compose.foundation.layout.PaddingValues(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 140.dp)) {
             item("tokens") {
@@ -262,6 +262,7 @@ fun ClientTokenLiveRoute(
                     modifier = Modifier.fillMaxWidth().padding(top = 26.dp, bottom = 8.dp),
                 )
             }
+        }
         }
     }
 
@@ -327,6 +328,7 @@ fun ClientTokenLiveRoute(
             },
             dismissButton = { TextButton(onClick = viewModel::dismissReveal) { Text("关闭") } },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/HostOpsPanels.kt
@@ -138,7 +138,8 @@ fun HostMonitorPanel(
         }
     }
 
-    Column(modifier.fillMaxSize()) {
+    Box(modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize()) {
         Row(
             Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -188,6 +189,7 @@ fun HostMonitorPanel(
             },
             dismissButton = { TextButton(onClick = { pendingKill = null }) { Text("取消") } },
         )
+    }
     }
 }
 
@@ -283,7 +285,8 @@ fun HostDockerPanel(
         }
     }
 
-    Column(modifier.fillMaxSize()) {
+    Box(modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize()) {
         Row(
             Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -450,6 +453,7 @@ fun HostDockerPanel(
             },
             dismissButton = { TextButton(onClick = { confirmRestart = false }) { Text("取消") } },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/HostKey.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/HostKey.kt
@@ -18,9 +18,9 @@ data class HostKey(
     }
 
     override fun equals(other: Any?): Boolean =
-        other is HostKey && algorithm == other.algorithm && blob.contentEquals(other.blob)
+        other is HostKey && blob.contentEquals(other.blob)
 
-    override fun hashCode(): Int = 31 * algorithm.hashCode() + blob.contentHashCode()
+    override fun hashCode(): Int = blob.contentHashCode()
 
     /** Never dumps the key material. */
     override fun toString(): String = algorithm + " " + sha256Fingerprint

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
@@ -41,6 +41,9 @@ interface SshEngine {
 
     fun acceptHostKey(sessionId: String, host: String, port: Int) = Unit
 
+    fun acceptHostKey(sessionId: String, host: String, port: Int, key: HostKey?) =
+        acceptHostKey(sessionId, host, port)
+
     /** Measures one SSH request/reply round trip on an authenticated transport. */
     suspend fun measureLatency(sessionId: String): Long?
 

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt
@@ -35,9 +35,8 @@ class MemorySshKnownHostsBook : SshKnownHostsBook {
 /**
  * Line-oriented known_hosts file.
  *
- * Java [java.util.Properties] treats `:` as a key/value separator, so a
- * record keyed `103.240.198.233:22` is stored as host-only and never found
- * again after process death. Each line is `host:port algorithm base64`.
+ * An unescaped Properties line `host:port=...` splits on `:`. Line format
+ * avoids that: each record is `host:port algorithm base64`.
  */
 class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
     private val lock = Any()

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt
@@ -1,8 +1,8 @@
 package one.zephyr.mobile.protocol.ssh
 
 import java.io.File
+import java.io.FileOutputStream
 import java.util.Locale
-import java.util.Properties
 
 interface SshKnownHostsBook {
     fun find(host: String, port: Int): HostKey?
@@ -32,6 +32,13 @@ class MemorySshKnownHostsBook : SshKnownHostsBook {
     }
 }
 
+/**
+ * Line-oriented known_hosts file.
+ *
+ * Java [java.util.Properties] treats `:` as a key/value separator, so a
+ * record keyed `103.240.198.233:22` is stored as host-only and never found
+ * again after process death. Each line is `host:port algorithm base64`.
+ */
 class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
     private val lock = Any()
 
@@ -57,27 +64,30 @@ class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
     private fun load(): LinkedHashMap<String, HostKey> {
         val values = LinkedHashMap<String, HostKey>()
         if (!file.isFile) return values
-        val properties = Properties()
-        file.inputStream().use { properties.load(it) }
-        for ((rawKey, rawValue) in properties) {
-            val key = (rawKey as? String)?.trim().orEmpty()
-            val raw = (rawValue as? String)?.trim().orEmpty()
-            if (key.isNotEmpty() && raw.isNotEmpty()) {
-                val parsed = parseHostKey(raw)
-                if (parsed != null) values[key] = parsed
-            }
+        file.readLines().forEach { line ->
+            val parsed = parseLine(line) ?: return@forEach
+            values[parsed.first] = parsed.second
         }
         return values
     }
 
     private fun save(values: Map<String, HostKey>) {
         file.parentFile?.mkdirs()
-        val properties = Properties()
-        for ((key, value) in values) {
-            properties[key] = serializeHostKey(value)
+        val body = buildString {
+            append("# zephyr-one ssh known hosts\n")
+            for ((key, value) in values) {
+                append(key)
+                append(' ')
+                append(serializeHostKey(value))
+                append('\n')
+            }
         }
         val staging = File(file.parentFile, file.name + ".tmp")
-        staging.outputStream().use { properties.store(it, "Zephyr One SSH known hosts") }
+        FileOutputStream(staging).use { stream ->
+            stream.write(body.toByteArray(Charsets.UTF_8))
+            stream.flush()
+            stream.fd.sync()
+        }
         if (!staging.renameTo(file)) {
             staging.copyTo(file, overwrite = true)
             staging.delete()
@@ -97,6 +107,17 @@ class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
             val blob = decodeBase64(b64) ?: return null
             if (algo.isEmpty() || blob.isEmpty()) return null
             return HostKey(algorithm = algo, blob = blob)
+        }
+
+        fun parseLine(raw: String): Pair<String, HostKey>? {
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) return null
+            val space = trimmed.indexOf(' ')
+            if (space <= 0 || space >= trimmed.length - 1) return null
+            val address = trimmed.substring(0, space).trim().lowercase(Locale.ROOT)
+            val key = parseHostKey(trimmed.substring(space + 1)) ?: return null
+            if (!address.contains(':')) return null
+            return address to key
         }
 
         private const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
@@ -140,8 +161,8 @@ class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
             val out = ArrayList<Byte>(s.length * 3 / 4)
             var index = 0
             while (index < s.length) {
-                val rem = s.length - index
-                if (rem >= 4) {
+                val remaining = s.length - index
+                if (remaining >= 4) {
                     val c0 = alphabet.indexOf(s[index]); if (c0 < 0) return null
                     val c1 = alphabet.indexOf(s[index + 1]); if (c1 < 0) return null
                     val c2 = alphabet.indexOf(s[index + 2]); if (c2 < 0) return null
@@ -151,7 +172,7 @@ class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
                     out.add(((chunk shr 8) and 0xFF).toByte())
                     out.add((chunk and 0xFF).toByte())
                     index += 4
-                } else if (rem == 3) {
+                } else if (remaining == 3) {
                     val c0 = alphabet.indexOf(s[index]); if (c0 < 0) return null
                     val c1 = alphabet.indexOf(s[index + 1]); if (c1 < 0) return null
                     val c2 = alphabet.indexOf(s[index + 2]); if (c2 < 0) return null
@@ -159,7 +180,7 @@ class FileSshKnownHostsBook(private val file: File) : SshKnownHostsBook {
                     out.add(((chunk shr 16) and 0xFF).toByte())
                     out.add(((chunk shr 8) and 0xFF).toByte())
                     index += 3
-                } else if (rem == 2) {
+                } else if (remaining == 2) {
                     val c0 = alphabet.indexOf(s[index]); if (c0 < 0) return null
                     val c1 = alphabet.indexOf(s[index + 1]); if (c1 < 0) return null
                     val chunk = (c0 shl 18) or (c1 shl 12)

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.Buffer
+import net.schmizz.sshj.common.KeyType
 import net.schmizz.sshj.connection.channel.direct.PTYMode
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.sftp.FileMode
@@ -502,11 +504,20 @@ class SshjEngine internal constructor(
     }
 
     override fun acceptHostKey(sessionId: String, host: String, port: Int) {
-        val presented = pending.remove(sessionId) ?: return
-        val storedHost = presented.host.ifBlank { host }
-        val storedPort = if (presented.port > 0) presented.port else port
+        acceptPresented(sessionId, host, port, key = null)
+    }
+
+    override fun acceptHostKey(sessionId: String, host: String, port: Int, key: HostKey?) {
+        acceptPresented(sessionId, host, port, key)
+    }
+
+    private fun acceptPresented(sessionId: String, host: String, port: Int, key: HostKey?) {
+        val pendingKey = pending.remove(sessionId)
+        val presented = key ?: pendingKey?.key ?: return
+        val storedHost = host.ifBlank { pendingKey?.host.orEmpty() }
+        val storedPort = if (port > 0) port else pendingKey?.port ?: 0
         if (storedHost.isBlank() || storedPort <= 0) return
-        knownHosts.put(storedHost, storedPort, presented.key)
+        knownHosts.put(storedHost, storedPort, presented)
     }
 
     /** Test seam: the first handshake stores the presented key before the user accepts it. */
@@ -531,13 +542,17 @@ class SshjEngine internal constructor(
         @Volatile var storedKey: HostKey? = null
 
         override fun verify(hostname: String, port: Int, key: PublicKey): Boolean {
-            val seen = HostKey(key.algorithm, key.encoded)
+            val seen = hostKeyOf(key) ?: return false
             presented = seen
             val known = knownHosts.find(this.host, this.port) ?: knownHosts.find(hostname, port)
             storedKey = known
-            return (known != null && known == seen).also { accepted = it }
+            return (known != null && known.blob.contentEquals(seen.blob)).also { accepted = it }
         }
-        override fun findExistingAlgorithms(hostname: String, port: Int): List<String> = emptyList()
+        override fun findExistingAlgorithms(hostname: String, port: Int): List<String> {
+            val known = knownHosts.find(this.host, this.port) ?: knownHosts.find(hostname, port)
+            val algorithm = known?.algorithm?.takeIf { it.isNotBlank() } ?: return emptyList()
+            return listOf(algorithm)
+        }
     }
 
     private data class LiveSession(
@@ -595,11 +610,24 @@ class SshjEngine internal constructor(
     )
 
     companion object {
-        const val TRUST_FILE_NAME = "ssh_known_hosts.properties"
+        const val TRUST_FILE_NAME = "ssh_known_hosts"
         private const val LATENCY_PROBE_TIMEOUT_MS = 4_000
 
         private fun hostPort(host: String, port: Int): String = SshKnownHostsBook.key(host, port)
         private fun closeQuietly(client: SSHClient) { runCatching { client.disconnect() } }
+
+        fun hostKeyOf(key: PublicKey): HostKey? {
+            val wire = runCatching {
+                val type = KeyType.fromKey(key)
+                val buffer = Buffer.PlainBuffer()
+                type.putPubKeyIntoBuffer(key, buffer)
+                HostKey(type.toString(), buffer.compactData)
+            }.getOrNull()
+            if (wire != null && wire.blob.isNotEmpty()) return wire
+            val encoded = key.encoded ?: return null
+            if (encoded.isEmpty()) return null
+            return HostKey(key.algorithm, encoded)
+        }
         private fun mapError(error: Exception, stage: ConnectStage): MobileError {
             val root = generateSequence(error as Throwable?) { it.cause }.lastOrNull() ?: error
             val cause = root.message?.takeIf(String::isNotBlank) ?: root.javaClass.simpleName

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/HostKeyVerifierTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/HostKeyVerifierTest.kt
@@ -148,8 +148,8 @@ class HostKeyVerifierTest {
         assertEquals(KEY_A, HostKey("ssh-rsa", KEY_A.blob.copyOf()))
         assertEquals(KEY_A.hashCode(), HostKey("ssh-rsa", KEY_A.blob.copyOf()).hashCode())
         assertNotEquals(KEY_A, KEY_B)
-        // Same bytes under a different algorithm name is a different key.
-        assertNotEquals(KEY_A, HostKey("ssh-dss", KEY_A.blob.copyOf()))
+        // SSHJ may label the same blob ssh-rsa / RSA. Trust is the material.
+        assertEquals(KEY_A, HostKey("ssh-dss", KEY_A.blob.copyOf()))
 
         val printed = KEY_A.toString()
         assertEquals("ssh-rsa SHA256:iDWpTXEhiqEJqkOpGjNCweV7ECfbgHSa4OLMIzPUBMc", printed)

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBookTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBookTest.kt
@@ -102,15 +102,16 @@ class SshKnownHostsBookTest {
     }
 
     @Test
-    fun `java properties splits host port on colon so it cannot store trust`() {
+    fun `java properties splits an unescaped host port line on colon`() {
         val file = File(tempDir.newFolder(), "legacy.properties")
-        val properties = java.util.Properties()
-        properties["103.240.198.233:22"] = FileSshKnownHostsBook.serializeHostKey(KEY_ED25519)
-        file.outputStream().use { properties.store(it, "legacy") }
+        file.writeText("103.240.198.233:22=" + FileSshKnownHostsBook.serializeHostKey(KEY_ED25519) + "\n")
         val loaded = java.util.Properties()
         file.inputStream().use { loaded.load(it) }
         assertNull(loaded.getProperty("103.240.198.233:22"))
-        assertTrue(loaded.stringPropertyNames().none { it.endsWith(":22") && it.contains("103.240.198.233") })
+        assertTrue(loaded.stringPropertyNames().none { it.contains(":22") })
+        assertTrue(
+            loaded.stringPropertyNames().any { it == "103.240.198.233" || it.startsWith("103.240.198.233") },
+        )
     }
 
     @Test

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBookTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBookTest.kt
@@ -31,7 +31,7 @@ class SshKnownHostsBookTest {
 
     @Test
     fun `file book persists across distinct instances`() {
-        val file = File(tempDir.newFolder(), "ssh_known_hosts.properties")
+        val file = File(tempDir.newFolder(), "ssh_known_hosts")
         val book1 = FileSshKnownHostsBook(file)
         assertNull(book1.find("192.168.1.10", 22))
 
@@ -53,7 +53,7 @@ class SshKnownHostsBookTest {
 
     @Test
     fun `replacing a key updates the stored key value`() {
-        val file = File(tempDir.newFolder(), "ssh_known_hosts.properties")
+        val file = File(tempDir.newFolder(), "ssh_known_hosts")
         val book = FileSshKnownHostsBook(file)
 
         book.put("host-1", 22, KEY_A)
@@ -88,5 +88,39 @@ class SshKnownHostsBookTest {
         val valid = FileSshKnownHostsBook.serializeHostKey(KEY_A)
         val parsed = FileSshKnownHostsBook.parseHostKey(valid)
         assertEquals(KEY_A, parsed)
+    }
+
+    @Test
+    fun `file book keeps host port together instead of splitting on colon`() {
+        val file = File(tempDir.newFolder(), "ssh_known_hosts")
+        FileSshKnownHostsBook(file).put("103.240.198.233", 22, KEY_ED25519)
+        val text = file.readText()
+        assertTrue(text.contains("103.240.198.233:22 "))
+        assertTrue(text.contains("ssh-ed25519 "))
+        assertEquals(KEY_ED25519, FileSshKnownHostsBook(file).find("103.240.198.233", 22))
+        assertNull(FileSshKnownHostsBook(file).find("103.240.198.233", 0))
+    }
+
+    @Test
+    fun `java properties splits host port on colon so it cannot store trust`() {
+        val file = File(tempDir.newFolder(), "legacy.properties")
+        val properties = java.util.Properties()
+        properties["103.240.198.233:22"] = FileSshKnownHostsBook.serializeHostKey(KEY_ED25519)
+        file.outputStream().use { properties.store(it, "legacy") }
+        val loaded = java.util.Properties()
+        file.inputStream().use { loaded.load(it) }
+        assertNull(loaded.getProperty("103.240.198.233:22"))
+        assertTrue(loaded.stringPropertyNames().none { it.endsWith(":22") && it.contains("103.240.198.233") })
+    }
+
+    @Test
+    fun `properties colon split would lose the port and is rejected`() {
+        val parsed = FileSshKnownHostsBook.parseLine("103.240.198.233=ssh-ed25519 AAAA")
+        assertNull(parsed)
+        val ok = FileSshKnownHostsBook.parseLine(
+            "103.240.198.233:22 " + FileSshKnownHostsBook.serializeHostKey(KEY_A),
+        )
+        assertEquals("103.240.198.233:22", ok?.first)
+        assertEquals(KEY_A, ok?.second)
     }
 }

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngineHostKeyTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngineHostKeyTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -59,11 +60,11 @@ class SshjEngineHostKeyTest {
         val engine = SshjEngine(Dispatchers.Unconfined, FileSshKnownHostsBook(file))
         engine.rememberPendingForTest("s1", "192.168.1.10", 22, KEY_A)
 
-        engine.acceptHostKey("s1", "ignored.example", 2222)
+        engine.acceptHostKey("s1", "192.168.1.10", 22)
 
         val reloaded = FileSshKnownHostsBook(file)
         assertEquals(KEY_A, reloaded.find("192.168.1.10", 22))
-        assertNull(reloaded.find("ignored.example", 2222))
+        assertTrue(file.readText().contains("192.168.1.10:22 "))
     }
 
     @Test

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngineHostKeyTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngineHostKeyTest.kt
@@ -77,4 +77,14 @@ class SshjEngineHostKeyTest {
 
         assertEquals(KEY_B, FileSshKnownHostsBook(file).find("host-1", 22))
     }
+
+    @Test
+    fun acceptHostKeyWritesTheExplicitKeyWhenPendingIsGone() {
+        val book = MemorySshKnownHostsBook()
+        val engine = SshjEngine(Dispatchers.Unconfined, book)
+
+        engine.acceptHostKey("s1", "103.240.198.233", 22, KEY_ED25519)
+
+        assertEquals(KEY_ED25519, book.find("103.240.198.233", 22))
+    }
 }

--- a/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
+++ b/zephyr_one/mobile/tests/dialog-overflow-tools-add.test.mjs
@@ -18,24 +18,22 @@ const alertStart = overlays.indexOf('fun AlertDialog(');
 const alert = overlays.slice(alertStart);
 
 test('alert dialog is bounded by the actual available window', () => {
-  assert.match(alert, /decorFitsSystemWindows = false/);
   assert.match(alert, /BoxWithConstraints/);
   assert.match(alert, /\.imePadding\(\)/);
-  assert.match(alert, /AlertDialogLayout\.availableHeightDp\(windowHeightDp\)/);
+  assert.match(alert, /AlertDialogLayout\.availableHeightDp\(maxHeight\.value\)/);
   assert.match(alert, /\.heightIn\(max = availableHeight\)/);
   assert.match(alert, /\.navigationBarsPadding\(\)/);
-  assert.match(alert, /window\.setLayout\(screenW, screenH\)/);
   assert.match(alert, /\.fillMaxSize\(\)/);
-  assert.match(alert, /DialogWindowProvider/);
-  assert.match(alert, /OnPreDrawListener/);
-  assert.match(alert, /OnGlobalLayoutListener/);
-  assert.match(alert, /\.requiredWidth\(AlertDialogLayout\.forcedWindowWidthDp\(screenWidthDp\)\.dp\)/);
-  assert.match(alert, /\.requiredHeight\(AlertDialogLayout\.forcedWindowHeightDp\(screenHeightDp\)\.dp\)/);
-  assert.match(alert, /AlertDialogLayout\.dialogWindowHeightDp\(screenHeightDp, maxHeight\.value\)/);
+  assert.match(alert, /BackHandler\(onBack = onDismissRequest\)/);
+  assert.match(alert, /\.zIndex\(AlertDialogLayout\.OVERLAY_Z\)/);
   assert.match(alert, /\.navigationBarsPadding\(\)[\s\S]*\.padding\(start = 10\.dp, end = 10\.dp, bottom = 10\.dp\)/);
   assert.match(layout, /fun availableHeightDp\(windowHeightDp: Float\)/);
-  assert.match(layout, /fun dialogWindowHeightDp/);
   assert.match(layout, /fun cancelGroupOnScreen/);
+  assert.match(layout, /OVERLAY_Z/);
+  assert.doesNotMatch(alert, /DialogProperties/);
+  assert.doesNotMatch(alert, /androidx\.compose\.ui\.window\.Dialog/);
+  assert.doesNotMatch(alert, /DialogWindowProvider/);
+  assert.doesNotMatch(alert, /Popup\(/);
   assert.doesNotMatch(alert, /val availableHeight = min\(maxHeight\.value - 20f, 640f\)/);
 });
 

--- a/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-editor-and-engine.test.mjs
@@ -39,15 +39,23 @@ test('app wires SSHJ instead of the unavailable stub', () => {
   assert.match(read(CONTAINER), /SshjEngine\(context\.filesDir\)/);
   assert.match(read(HOST), /class SshTerminalHost/);
   assert.match(read(ENGINE), /class SshjEngine/);
-  assert.match(read(ENGINE), /TRUST_FILE_NAME = "ssh_known_hosts\.properties"/);
+  assert.match(read(ENGINE), /TRUST_FILE_NAME = "ssh_known_hosts"/);
+  assert.doesNotMatch(read(ENGINE), /ssh_known_hosts\.properties/);
   assert.match(read(ENGINE), /FileSshKnownHostsBook/);
+  const book = read(path.join(ANDROID, 'protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshKnownHostsBook.kt'));
+  assert.match(book, /fd\.sync\(\)/);
+  assert.match(book, /fun parseLine/);
+  assert.doesNotMatch(book, /import java.util.Properties/);
+  assert.doesNotMatch(book, /Properties\(\)/);
   assert.match(read(ENGINE), /PendingHostKey/);
-  assert.match(read(ENGINE), /presented\.host\.ifBlank \{ host \}/);
+  assert.match(read(ENGINE), /host\.ifBlank \{ pendingKey\?\.host\.orEmpty\(\) \}/);
   const disconnect = read(ENGINE).match(/override suspend fun disconnect[\s\S]*?override suspend fun measureLatency/)?.[0] ?? '';
   assert.match(disconnect, /Pending trust is a user decision/);
   assert.doesNotMatch(disconnect, /pending\.remove\(sessionId\)/);
   assert.match(read(HOST), /RememberedTarget/);
-  assert.match(read(HOST), /engine\.acceptHostKey\(sessionId, remembered\?\.host\.orEmpty\(\), remembered\?\.port \?: 0\)/);
+  assert.match(read(HOST), /remembered\?\.presented/);
+  assert.match(read(ENGINE), /fun hostKeyOf/);
+  assert.match(read(ENGINE), /findExistingAlgorithms/);
   assert.doesNotMatch(read(HOST), /lastRequest\[request\.sessionId\] = copyRequest/);
 });
 


### PR DESCRIPTION
## 现象

pre26（含 PR #41）真机截图与 pre24 相同：取消组仍在系统导航栏里；点「信任并继续」后杀进程再连仍弹「首次连接该主机」。

Dialog 窗口 hack 在真机上没用。用户装的就是 `eab0544`。

## 根因

1. Compose `Dialog` 是独立 WRAP_CONTENT 窗口。`setLayout(MATCH_PARENT)` / `requiredHeight(screen)` 都拦不住框架回写，取消组实际画在导航栏里。
2. 信任文件用 `java.util.Properties`。键 `103.240.198.233:22` 里的 `:` 是 Properties 分隔符，落盘后变成 host-only，进程重启后 `find(host, 22)` 永远空。
3. SSHJ `PublicKey.encoded` 是 X.509，`algorithm` 是 `RSA`/`Ed25519`，不是 SSH 线格式 `ssh-rsa`/`ssh-ed25519`。即使写盘成功，下次握手也对比不上。
4. `findExistingAlgorithms` 返回空，服务器下次可能换一把钥匙。

## 修复

- `AlertDialog` 不再开系统 Dialog。改成和 ActionSheet 一样的 Activity 内全屏浮层，`navigationBarsPadding` 用的是真 inset。相关确认框都包进 `Box(fillMaxSize)`。
- known hosts 改成行格式 `host:port algorithm base64`，`fd.sync()` 后 rename。文件名 `ssh_known_hosts`。
- 出示的密钥按 SSH 线格式编码；信任按 blob 比较；`findExistingAlgorithms` 返回已存算法。
- `acceptHostKey` 可带 presented key，不依赖 pending。

## 测试

- `SshKnownHostsBookTest`：Properties 会拆掉 `host:port`；行格式跨实例可读。
- `SshjEngineHostKeyTest`：显式 key / pending / disconnect 不丢。
- 契约 `dialog-overflow-tools-add`、`ssh-editor-and-engine` 及相关 18/18。
- 完整契约 362 pass / 10 fail，失败为沙箱 PaX/Java + live server（与 main 基线同类）。
