### PR TITLE
fix(one): wire RDPGFX into the GDI pipeline so frames actually arrive

### DIFF
--- a/zephyr_one/native/freerdp-core/zephyr_rdp.c
+++ b/zephyr_one/native/freerdp-core/zephyr_rdp.c
@@ -713,6 +713,16 @@ static void on_channel_connected(void* context, Z_EVENT_CONST ChannelConnectedEv
         bind_cliprdr(s, (CliprdrClientContext*)e->pInterface);
     } else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0) {
         s->disp = (DispClientContext*)e->pInterface;
+    } else {
+        /* The common client's fallback is what wires RDPGFX into the GDI
+         * pipeline (gdi_graphics_pipeline_init on rdpgfx). Without it the
+         * channel negotiates up, the server sends every frame as GFX PDUs,
+         * and the GDI primary buffer never receives a single pixel: connect
+         * succeeds, EndPaint sees ninvalid == 0 forever, and the host times
+         * out waiting for the first frame. Every official client (SDL, X11,
+         * iOS) ends its handler with this exact fallback for the channels it
+         * does not claim itself. */
+        freerdp_client_OnChannelConnectedEventHandler(context, e);
     }
     /* rdpdr/drive needs no client-side context: the drive addin services IRPs
      * against the mapped path on its own thread once the channel is up. */
@@ -728,6 +738,11 @@ static void on_channel_disconnected(void* context, Z_EVENT_CONST ChannelDisconne
         s->cliprdr_ready = FALSE;
     } else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0) {
         s->disp = NULL;
+    } else {
+        /* Symmetric with the connect path: the common fallback uninitializes
+         * the GFX pipeline (gdi_graphics_pipeline_uninit) so a reconnect does
+         * not double-register the surface-update callbacks. */
+        freerdp_client_OnChannelDisconnectedEventHandler(context, e);
     }
 }
 

--- a/zephyr_one/tests/native-rdp-connect-contract.test.mjs
+++ b/zephyr_one/tests/native-rdp-connect-contract.test.mjs
@@ -93,6 +93,29 @@ test('a dead session handle does not block the retry', () => {
   assert.match(start, /Error::SessionExists/);
 });
 
+test('the GFX channel is wired into the GDI pipeline through the common fallback', () => {
+  const shim = read('native/freerdp-core/zephyr_rdp.c');
+
+  /* The regression this locks: the shim claimed cliprdr and disp and dropped
+   * every other channel on the floor. With RDPGFX negotiated (the default
+   * gfx=true policy), that meant the server sent frames as GFX PDUs that
+   * nothing decoded into the GDI primary buffer — connect succeeded and the
+   * host then timed out waiting for a first frame that could never exist.
+   * Every shipped FreeRDP client ends its handler with the common fallback,
+   * which is where gdi_graphics_pipeline_init lives. */
+  const connected = shim.slice(
+    shim.indexOf('static void on_channel_connected'),
+    shim.indexOf('static void on_channel_disconnected'),
+  );
+  assert.match(connected, /freerdp_client_OnChannelConnectedEventHandler\(context, e\)/);
+
+  const disconnected = shim.slice(
+    shim.indexOf('static void on_channel_disconnected'),
+    shim.indexOf('/* ── instance callbacks'),
+  );
+  assert.match(disconnected, /freerdp_client_OnChannelDisconnectedEventHandler\(context, e\)/);
+});
+
 test('broker denial is logged with enough detail to distinguish ACL from transport', () => {
   const broker = fs.readFileSync(path.join(ROOT, '..', 'zephyr-one-rdp-native-broker.js'), 'utf8');
   assert.match(broker, /authorization denied/);


### PR DESCRIPTION
用户报 `code=remote_first_frame_timeout`,桌面/移动 RDP 连接成功但永远无帧。

## 根因(对照 FreeRDP 3.20 SDL/X11/iOS 客户端源码确认)

1. `gfx=true` 是默认策略,服务器协商 RDPGFX 动态通道后,**所有屏幕更新走 GFX PDU**。
2. GFX PDU 只有在通道的 `RdpgfxClientContext` 经 `gdi_graphics_pipeline_init()` 注册后才会解码进 GDI primary buffer。
3. 这个注册在 `freerdp_client_OnChannelConnectedEventHandler` 里 —— 官方客户端(SDL `sdl_channels.cpp:55`、X11 `xf_channels.c:83`、iOS)对未自己认领的通道**统一走这个 common fallback**。
4. Zephyr shim 只认领 cliprdr 和 disp,**其他通道全部丢弃** → rdpgfx 从未注册 → primary buffer 永远无像素 → EndPaint `ninvalid == 0` → 零帧 → 首帧超时。

桌面 Windows surface 和移动端 JNI 共用这条 shim,所以两端一起"不可用"。

## 修复

两个 channel handler 末尾都加 common fallback,与官方客户端一致:
- connected → fallback 注册 GFX 管线
- disconnected → fallback 反注册,防止重连双重注册

## 验证

- shim 用 pinned FreeRDP 3 头 `-Wall -Wextra -Werror` 编译干净
- `freerdp_client_OnChannel{Connected,Disconnected}EventHandler` 符号确认为 `libfreerdp-client3.a` 的 text 定义
- 契约 `native-rdp-connect-contract` 新增一条:两个 handler 必须以防兜底结尾,防回归
- 桌面契约全绿