### PR TITLE
fix(mobile): dial the configured SSH jump chain instead of refusing it

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AiWorkspaceHost.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AiWorkspaceHost.kt
@@ -44,6 +44,7 @@ internal fun BoundAiWorkspace(
             engine = account.appContainer().sshEngine,
             connectionProvider = account.connections::find,
             credentialsProvider = account::terminalCredentials,
+            routePlanner = accountRoutePlanner(account),
         )
         val exec = LiveSshExecPort(account.appContainer().sshEngine, account.sessions, managed)
         val host = AndroidAiPlatformHost(account, exec, account.localAiWorkspace)

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt
@@ -36,7 +36,12 @@ class ManagedSshSessionPool(
     private val engine: SshEngine,
     private val connectionProvider: suspend (String) -> Connection?,
     private val credentialsProvider: suspend (Connection) -> TerminalCredentials,
+    private val routePlanner: RoutePlanner = RoutePlanner { null },
 ) {
+    fun interface RoutePlanner {
+        suspend fun plan(connection: Connection): SshRoute?
+    }
+
     private data class Live(val sessionId: String, var references: Int)
 
     private val locks = ConcurrentHashMap<String, Mutex>()
@@ -73,9 +78,15 @@ class ManagedSshSessionPool(
                     SshCredential.Password(password.copyOf())
                 else -> error("连接没有可用的 SSH 凭据")
             }
+            /* Route resolution is a configuration check, not a dial: a proxy or
+             * jump chain that does not resolve is a fixable setup error, and the
+             * planner names which field to fix. Only after it succeeds does a
+             * socket open. */
+            val route = routePlanner.plan(connection)
+                ?: SshRoute(listOf(RouteHop.Target(connection.host, connection.port)))
             val request = SshConnectRequest(
                 sessionId = sessionId,
-                route = SshRoute(listOf(RouteHop.Target(connection.host, connection.port))),
+                route = route,
                 username = connection.username,
                 credential = credential,
                 hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
@@ -15,8 +15,17 @@ import one.zephyr.mobile.protocol.ssh.SshCredential
 import one.zephyr.mobile.protocol.ssh.SshEngine
 import one.zephyr.mobile.protocol.ssh.SshRoute
 
-/** One-shot direct SSH test used by the connection editor. Never creates a terminal tab. */
-internal class DirectSshConnectionTester(private val engine: SshEngine) : ConnectionTester {
+/** One-shot SSH test used by the connection editor. Never creates a terminal tab.
+ *
+ * The stored route is dialled, not just the target's TCP port: a proxy or jump
+ * chain is part of the connection's reachability, and testing past it would
+ * report a working connection the real dialer cannot make. */
+internal class DirectSshConnectionTester(
+    private val engine: SshEngine,
+    private val routePlanner: suspend (Connection) -> SshRoute = {
+        SshRoute(listOf(RouteHop.Target(it.host, it.port)))
+    },
+) : ConnectionTester {
     override suspend fun test(
         connection: Connection,
         credentials: ConnectionTestCredentials,
@@ -44,11 +53,20 @@ internal class DirectSshConnectionTester(private val engine: SshEngine) : Connec
         }
         val sessionId = "test-" + UUID.randomUUID()
         var outcome: SshConnectOutcome
+        val route = try {
+            routePlanner(connection)
+        } catch (error: Exception) {
+            /* A route that does not resolve is a configuration error, not a
+             * network failure: say which field is wrong instead of timing out. */
+            return ConnectionTestResult.Failed(
+                MobileError.local("route_invalid", error.message ?: "路由配置无效", false),
+            )
+        }
         val elapsedNanos = measureNanoTime {
             outcome = engine.connect(
                 SshConnectRequest(
                     sessionId = sessionId,
-                    route = SshRoute(listOf(RouteHop.Target(connection.host, connection.port))),
+                    route = route,
                     username = connection.username,
                     credential = credential,
                     hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -122,6 +122,8 @@ import one.zephyr.mobile.model.SecretPresence
 import one.zephyr.mobile.model.SyncStatus
 import one.zephyr.mobile.model.SyncState
 import one.zephyr.mobile.model.Snippet
+import one.zephyr.mobile.protocol.ssh.RoutePlanResult
+import one.zephyr.mobile.protocol.ssh.SshRoutePlanner
 import one.zephyr.mobile.security.AuthResult
 import one.zephyr.mobile.security.UnlockPresentation
 import one.zephyr.mobile.data.session.SessionExecution
@@ -421,6 +423,7 @@ private fun BoundRoot(
             engine = sshEngine,
             connectionProvider = account.connections::find,
             credentialsProvider = account::terminalCredentials,
+            routePlanner = accountRoutePlanner(account),
         )
     }
     val terminalHost = remember(account, sshEngine) {
@@ -560,7 +563,10 @@ private fun BoundRoot(
                         initialProtocol = current.protocol,
                         newIdFactory = { UUID.randomUUID().toString() },
                         tester = ProtocolConnectionTester(
-                            ssh = DirectSshConnectionTester(appContainer.sshEngine),
+                            ssh = DirectSshConnectionTester(
+                                engine = appContainer.sshEngine,
+                                routePlanner = { connection -> accountRoutePlanner(account).plan(connection) },
+                            ),
                             fallback = TcpReachabilityTester(),
                         ),
                         testCredentials = { connection, draft -> account.connectionTestCredentials(connection, draft) },
@@ -1651,6 +1657,42 @@ private fun BatchExecutionViewModel.dispatch(intent: BatchIntent) {
  * Prefers the ref the mirror recorded and falls back to the conventional field ref, because a row
  * written before the ref was persisted still has its secret under the derived name.
  */
+/**
+ * Resolves the stored proxy/jump settings of a connection into the route the
+ * dialer will actually take.
+ *
+ * Mirrors the main end's resolveRoutePlan: a jumpHostIds entry that names a
+ * jumpHost resource follows its connectionId, and one that names no resource
+ * is itself a connection id. Rejections are configuration errors the user can
+ * fix, never a connect timeout.
+ */
+internal fun accountRoutePlanner(account: AccountContainer): ManagedSshSessionPool.RoutePlanner =
+    ManagedSshSessionPool.RoutePlanner { connection ->
+        when (val result = SshRoutePlanner.plan(
+            connection = connection,
+            proxies = buildMap {
+                connection.proxyId?.let { id ->
+                    account.resources.findProxy(id)?.let { put(id, it) }
+                }
+            },
+            jumpHosts = buildMap {
+                connection.jumpHostIds.forEach { id ->
+                    account.resources.findJumpHost(id)?.let { put(id, it) }
+                }
+            },
+            connections = buildMap {
+                connection.jumpHostIds.forEach { id ->
+                    val resource = account.resources.findJumpHost(id)
+                    val viaId = resource?.connectionId ?: id
+                    account.connections.find(viaId)?.let { put(viaId, it) }
+                }
+            },
+        )) {
+            is RoutePlanResult.Planned -> result.route
+            is RoutePlanResult.Rejected -> error(result.code + ": " + result.detail)
+        }
+    }
+
 internal fun AccountContainer.passwordChars(connection: Connection): CharArray? {
     val ref = secretRefForPresence(
         presence = connection.password,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -122,7 +122,9 @@ import one.zephyr.mobile.model.SecretPresence
 import one.zephyr.mobile.model.SyncStatus
 import one.zephyr.mobile.model.SyncState
 import one.zephyr.mobile.model.Snippet
+import one.zephyr.mobile.protocol.ssh.RouteHop
 import one.zephyr.mobile.protocol.ssh.RoutePlanResult
+import one.zephyr.mobile.protocol.ssh.SshRoute
 import one.zephyr.mobile.protocol.ssh.SshRoutePlanner
 import one.zephyr.mobile.security.AuthResult
 import one.zephyr.mobile.security.UnlockPresentation
@@ -565,7 +567,14 @@ private fun BoundRoot(
                         tester = ProtocolConnectionTester(
                             ssh = DirectSshConnectionTester(
                                 engine = appContainer.sshEngine,
-                                routePlanner = { connection -> accountRoutePlanner(account).plan(connection) },
+                                routePlanner = { connection ->
+                                    /* A null plan means no routing rule applies
+                                     * to this connection: fall back to direct
+                                     * so reachability matches what the real
+                                     * dialer would do. */
+                                    accountRoutePlanner(account).plan(connection)
+                                        ?: SshRoute(listOf(RouteHop.Target(connection.host, connection.port)))
+                                },
                             ),
                             fallback = TcpReachabilityTester(),
                         ),

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRoute.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRoute.kt
@@ -3,6 +3,7 @@ package one.zephyr.mobile.protocol.ssh
 import one.zephyr.mobile.model.Connection
 import one.zephyr.mobile.model.ConnectionMode
 import one.zephyr.mobile.model.JumpHost
+import one.zephyr.mobile.model.Protocol
 import one.zephyr.mobile.model.Proxy
 import one.zephyr.mobile.model.ProxyType
 
@@ -93,15 +94,25 @@ object SshRoutePlanner {
                 // socket budget is gone, so the whole chain is checked for repeats up front.
                 val seen = mutableSetOf(connection.id)
                 for (jumpId in connection.jumpHostIds) {
+                    /* Main-end resolveRoutePlan semantics: a stored jump id names a jumpHost
+                     * resource whose connectionId is the hop; when no such resource exists the
+                     * id *is* the connection id. Rejecting a bare connection id here is what made
+                     * every jump route configured on the server read as "not configured" on
+                     * mobile. */
                     val jump = jumpHosts[jumpId]
-                        ?: return RoutePlanResult.Rejected("dependency_missing", "Jump host " + jumpId + " is unavailable")
-                    val via = connections[jump.connectionId]
+                    val via = connections[jump?.connectionId ?: jumpId]
                         ?: return RoutePlanResult.Rejected(
                             "dependency_missing",
                             "Jump host " + jumpId + " points at a missing connection",
                         )
                     if (!seen.add(via.id)) {
                         return RoutePlanResult.Rejected("jump_cycle", "Jump chain revisits " + via.id)
+                    }
+                    if (via.protocol != Protocol.SSH) {
+                        return RoutePlanResult.Rejected(
+                            "jump_protocol_unsupported",
+                            "Jump host " + (via.name.ifBlank { via.host }) + " is not SSH",
+                        )
                     }
                     if (via.host.isBlank()) {
                         return RoutePlanResult.Rejected("invalid_host", "Jump host " + jumpId + " has no host")

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -73,19 +73,74 @@ class SshjEngine internal constructor(
     override val isAvailable: Boolean = true
 
     override suspend fun connect(request: SshConnectRequest): SshConnectOutcome = withContext(io) {
-        if (request.route.hops.any { it !is RouteHop.Target }) {
+        sessions.remove(request.sessionId)?.close()
+        val jumps = request.route.hops.filterIsInstance<RouteHop.SshJump>()
+        if (request.route.hops.any { it !is RouteHop.Target && it !is RouteHop.SshJump }) {
             return@withContext SshConnectOutcome.Failed(
-                MobileError.local("route_unsupported", "当前 SSHJ 引擎尚未接入代理或跳板链", false),
+                MobileError.local("route_unsupported", "当前 SSHJ 引擎尚未接入代理链", false),
             )
         }
-        sessions.remove(request.sessionId)?.close()
         val target = request.route.target
-        val client = SSHClient()
-        val verifier = RecordingVerifier(target.host, target.port)
-        client.addHostKeyVerifier(verifier)
+        val chain = mutableListOf<SSHClient>()
         var stage = ConnectStage.TRANSPORT
+        /* Set by whichever hop presented an untrusted key before connect threw;
+         * keyed by hop so a jump fingerprint is never shown as the target's. */
+        var firstUntrusted: Pair<PendingHostKey, HostKey?>? = null
+        /* Declared here, not inside try, so the failure path can close the
+         * half-open target client after a jump error: the loop's chain holds
+         * only the hops, and a leaked target transport would sit on the last
+         * jump's direct-tcpip channel. */
+        val client = SSHClient()
         try {
-            client.connect(target.host, target.port)
+            /* Jump chain, main-end createRoutedSSHConnection semantics: hop 1 is
+             * dialed directly; each next hop is reached through a direct-tcpip
+             * channel on the previous client. Every hop authenticates with the
+             * connection's own credential and presents its own host key, keyed by
+             * the hop's host:port — approving one hop must never trust another. */
+            var upstream: SSHClient? = null
+            for (jump in jumps) {
+                val hopClient = SSHClient()
+                chain += hopClient
+                val hopVerifier = RecordingVerifier(jump.host, jump.port)
+                hopClient.addHostKeyVerifier(hopVerifier)
+                val from = upstream
+                try {
+                    if (from == null) {
+                        hopClient.connect(jump.host, jump.port)
+                    } else {
+                        /* SSHJ's jump-host transport: the direct-tcpip channel on the
+                         * previous client carries this hop's handshake. connectVia is
+                         * the SocketClient entry point that accepts a DirectConnection. */
+                        hopClient.connectVia(from.newDirectConnection(jump.host, jump.port))
+                    }
+                } catch (error: Exception) {
+                    val key = hopVerifier.presented
+                    if (key != null && !hopVerifier.accepted && firstUntrusted == null) {
+                        firstUntrusted = PendingHostKey(jump.host, jump.port, key) to hopVerifier.storedKey
+                    }
+                    throw error
+                }
+                stage = ConnectStage.AUTHENTICATION
+                authenticate(hopClient, request)
+                stage = ConnectStage.TRANSPORT
+                upstream = hopClient
+            }
+            val verifier = RecordingVerifier(target.host, target.port)
+            client.addHostKeyVerifier(verifier)
+            val from = upstream
+            try {
+                if (from == null) {
+                    client.connect(target.host, target.port)
+                } else {
+                    client.connectVia(from.newDirectConnection(target.host, target.port))
+                }
+            } catch (error: Exception) {
+                val key = verifier.presented
+                if (key != null && !verifier.accepted && firstUntrusted == null) {
+                    firstUntrusted = PendingHostKey(target.host, target.port, key) to verifier.storedKey
+                }
+                throw error
+            }
             stage = ConnectStage.AUTHENTICATION
             authenticate(client, request)
             stage = ConnectStage.PTY
@@ -93,16 +148,22 @@ class SshjEngine internal constructor(
             terminalSession.allocatePTY("xterm-256color", request.cols, request.rows, 0, 0, emptyMap<PTYMode, Int>())
             stage = ConnectStage.SHELL
             val shell = terminalSession.startShell()
-            sessions[request.sessionId] = LiveSession(client, terminalSession, shell)
+            sessions[request.sessionId] = LiveSession(client, terminalSession, shell, chain.toList())
             closeEvents[request.sessionId] = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
             pending.remove(request.sessionId)
             SshConnectOutcome.Connected(request.sessionId, "")
         } catch (error: Exception) {
-            closeQuietly(client)
-            val presented = verifier.presented ?: pending[request.sessionId]?.key
-            if (presented != null && !verifier.accepted) {
-                pending[request.sessionId] = PendingHostKey(target.host, target.port, presented)
-                return@withContext SshConnectOutcome.HostKeyDecisionRequired(presented, known = verifier.storedKey)
+            chain.forEach(::closeQuietly)
+            /* `client` is still a local here: sessions[...] is only set after a
+             * fully successful open, so a failed attempt must close it directly. */
+            runCatching { client.disconnect() }
+            val untrusted = firstUntrusted
+            if (untrusted != null) {
+                pending[request.sessionId] = untrusted.first
+                return@withContext SshConnectOutcome.HostKeyDecisionRequired(
+                    untrusted.first.key,
+                    known = untrusted.second,
+                )
             }
             SshConnectOutcome.Failed(mapError(error, stage))
         }
@@ -559,6 +620,10 @@ class SshjEngine internal constructor(
         val client: SSHClient,
         val session: Session,
         val shell: Session.Shell,
+        /* Every hop above the target's own client. Closing the target alone
+         * would leave the jump transports (and their direct-tcpip channels)
+         * open on the network. */
+        val chain: List<SSHClient> = emptyList(),
         @Volatile var closed: Boolean = false,
     ) {
         @Volatile private var sftpClient: SFTPClient? = null
@@ -589,6 +654,9 @@ class SshjEngine internal constructor(
             runCatching { shell.close() }
             runCatching { session.close() }
             closeQuietly(client)
+            /* The jumps' transports live on their own sockets; the target's
+             * direct-tcpip channel dies with them, not before. */
+            chain.forEach(::closeQuietly)
         }
     }
 

--- a/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRoutePlannerTest.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/test/kotlin/one/zephyr/mobile/protocol/ssh/SshRoutePlannerTest.kt
@@ -235,6 +235,38 @@ class SshRoutePlannerTest {
     }
 
     @Test
+    fun `a bare connection id resolves as a jump hop like the main end`() {
+        /* Main-end resolveRoutePlan: jumpHostIds entries that name no jumpHost
+         * resource are treated as connection ids directly. Mobile used to reject
+         * every such entry as dependency_missing, which is why a route saved on
+         * the server read as "not configured" on the phone. */
+        val via = connection(id = "bastion", host = "bastion.corp", port = 2222, username = "ops")
+        val route = (plan(
+            connection(mode = ConnectionMode.JUMP, jumpHostIds = listOf("bastion")),
+            connections = mapOf("bastion" to via),
+        ) as RoutePlanResult.Planned).route
+
+        assertEquals(
+            listOf(
+                RouteHop.SshJump("bastion.corp", 2222, "ops", "bastion"),
+                RouteHop.Target("10.0.0.5", 22),
+            ),
+            route.hops,
+        )
+    }
+
+    @Test
+    fun `a non-SSH connection cannot be a jump hop`() {
+        val via = connection(id = "desktop", host = "rdp.corp").copy(protocol = one.zephyr.mobile.model.Protocol.RDP)
+        val rejected = plan(
+            connection(mode = ConnectionMode.JUMP, jumpHostIds = listOf("desktop")),
+            connections = mapOf("desktop" to via),
+        ) as RoutePlanResult.Rejected
+
+        assertEquals("jump_protocol_unsupported", rejected.code)
+    }
+
+    @Test
     fun `the target is always the final hop`() {
         val (ids, jumps, vias) = jumpChain(3)
         val jumped = (

--- a/zephyr_one/mobile/tests/android-ssh-provider-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/android-ssh-provider-runtime.test.mjs
@@ -75,7 +75,9 @@ test('mutation guards catch provider collision and generic diagnostics', () => {
   assert.throws(
     () => assertRuntimeGuards({
       ...current,
-      engineSrc: engine.replace('stage = ConnectStage.AUTHENTICATION', '// stage lost'),
+      /* Every hop in a jump chain runs the auth stage, so the marker exists
+       * more than once. Removing them all must be caught. */
+      engineSrc: engine.replaceAll('stage = ConnectStage.AUTHENTICATION', '// stage lost'),
     }),
     /AUTHENTICATION/,
   );

--- a/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = path.resolve(ROOT, '..');
+const read = (file) => fs.readFileSync(path.join(ROOT, file), 'utf8');
+
+test('jump planner treats a bare connection id as a hop like the main end', () => {
+  const planner = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRoute.kt');
+  /* Main-end resolveRoutePlan: jumpHostIds entries that name no jumpHost
+   * resource are themselves connection ids. The old mobile planner rejected
+   * them as dependency_missing, which made every jump route saved on the
+   * server read as "not configured" on the phone. */
+  assert.match(planner, /jumpHosts\[jumpId\][\s\S]*connections\[jump\?\.connectionId \?: jumpId\]/);
+  assert.match(planner, /Protocol\.SSH/);
+});
+
+test('the SSH engine dials the resolved chain instead of refusing routed sessions', () => {
+  const engine = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+  /* The old engine answered route_unsupported for anything but a direct hop.
+   * The fix connects each hop through connectVia on the previous client's
+   * direct-tcpip channel, the same shape as the main end's forwardOut loop. */
+  assert.match(engine, /connectVia\(from\.newDirectConnection/);
+  assert.doesNotMatch(engine, /route_unsupported[\s\S]*跳板链/);
+  assert.match(engine, /RouteHop\.SshJump/);
+});
+
+test('every hop gets its own host-key decision keyed by the hop address', () => {
+  const engine = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+  /* A jump fingerprint must never be shown (or trusted) as the target's. Each
+   * hop carries its own RecordingVerifier bound to the hop's host:port, and the
+   * first untrusted hop is the one the user is asked about. */
+  const connect = engine.slice(engine.indexOf('override suspend fun connect'), engine.indexOf('override fun output'));
+  assert.match(connect, /RecordingVerifier\(jump\.host, jump\.port\)/);
+  assert.match(connect, /RecordingVerifier\(target\.host, target\.port\)/);
+  assert.match(connect, /PendingHostKey\(jump\.host, jump\.port, key\)/);
+});
+
+test('a closed jump session closes the whole chain', () => {
+  const engine = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+  /* Closing only the target client would leave the jump transports (and their
+   * direct-tcpip channels) open on the network. */
+  const close = engine.slice(engine.indexOf('fun close()'), engine.indexOf('private enum class ConnectStage'));
+  assert.match(close, /chain\.forEach\(::closeQuietly\)/);
+});
+
+test('dialers resolve the stored route rather than always dialling direct', () => {
+  const root = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+  const pool = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt');
+  const tester = read('android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt');
+
+  /* The regression: every dialer hard-coded SshRoute([Target]) and the planner
+   * was dead code, so a configured jump/proxy chain was silently ignored and
+   * the unreachable direct target read as "not configured / unusable". */
+  assert.match(root, /accountRoutePlanner\(account\)/);
+  assert.match(pool, /routePlanner\.plan\(connection\)/);
+  assert.doesNotMatch(pool, /route = SshRoute\(listOf\(RouteHop\.Target\(connection\.host, connection\.port\)\)\)/);
+  assert.match(tester, /routePlanner\(connection\)/);
+});
+
+test('main-end jump resolution semantics are pinned in one place', () => {
+  const server = fs.readFileSync(path.join(REPO, '..', 'server.js'), 'utf8');
+  const resolver = server.slice(server.indexOf('const jumpHostIds = normalizeJumpHostIds'), server.indexOf('async function createRoutedSSHConnection'));
+  /* The mobile planner follows this exact rule: a jumpHostConfig's connectionId
+   * wins, otherwise the raw id is itself the connection id. */
+  assert.match(resolver, /jumpHostConfig\?\.connectionId \|\| rawJumpHostId/);
+  assert.match(resolver, /跳板机必须是 SSH 连接/);
+});


### PR DESCRIPTION
主端保存的带跳板机的连接在移动端不可用，显示"未正确配置"。

## 根因（三层叠加）

1. **SshRoutePlanner 拒绝裸连接 id** — `jumpHostIds` 中没有对应 jumpHost 资源时被当成 `dependency_missing`。主端 `resolveRoutePlan` 的规则是 `jumpHostConfig?.connectionId || rawJumpHostId` —— 裸 id 本身就是连接 id。

2. **SshjEngine 拒绝一切路由会话** — `route_unsupported`,根本没实现跳板链。

3. **所有拨号点绕过 planner** — `ManagedSshSessionPool` / `DirectSshConnectionTester` / `AiWorkspaceHost` 全部硬编码 `SshRoute([Target(host,port)])`,planner 是死代码。

## 修复（与主端 `createRoutedSSHConnection` 语义对齐）

- planner:`jumpHostConfig?.connectionId ?: rawId` 回退 + 非 SSH 跳板拒绝
- SshjEngine：第一跳直连，后续每跳经 `connectVia(from.newDirectConnection(...))` 走 direct-tcpip；**每跳独立 host key 决策，按跳的 host:port 记录**，跳板指纹永远不会被当成目标信任；失败关整条链
- 三个拨号点全部改走 `accountRoutePlanner`(jumpHost 资源优先，裸连接 id 回退)

## 测试

- `SshRoutePlannerTest` 新增：裸连接 id 解析、非 SSH 跳板拒绝
- `ssh-jump-route-contract.test.mjs`(6 条）：锁定 planner 规则、connectVia 链、逐跳 host key、链清理、拨号点接线、主端 resolver 语义
- `android-ssh-provider-runtime.test.mjs` 的 mutation 适配跳板链多处 AUTHENTICATION stage
- 移动端契约 368 pass,10 个失败与 main 基线完全一致（PaX/Java VM 环境）
