### PR TITLE
feat(mobile): replace the split mode with a simple pad two-pane layout

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -93,6 +93,7 @@ import one.zephyr.mobile.feature.remote.RdpViewModel
 import one.zephyr.mobile.feature.remote.RemoteCredentials
 import one.zephyr.mobile.feature.remote.VncRemoteRoute
 import one.zephyr.mobile.feature.remote.VncViewModel
+import one.zephyr.mobile.feature.sessions.PadTermSide
 import one.zephyr.mobile.feature.sessions.SessionListRoute
 import one.zephyr.mobile.feature.sessions.SessionListViewModel
 import one.zephyr.mobile.feature.sessions.TerminalCredentials
@@ -781,7 +782,12 @@ private fun BoundRoot(
                 val termNotes by account.notes.observeNotes(ownerUserId).collectAsState(initial = emptyList())
                 val termSnippets by account.notes.observeSnippets(ownerUserId).collectAsState(initial = emptyList())
                 var termWorkspace by remember(current.sessionId) {
-                    mutableStateOf(TerminalWorkspaceState(paneA = current.sessionId))
+                    mutableStateOf(
+                        TerminalWorkspaceState(
+                            activeSessionId = current.sessionId,
+                            padTermSide = if (appContainer.padTermSideLeft) PadTermSide.LEFT else PadTermSide.RIGHT,
+                        ),
+                    )
                 }
                 LaunchedEffect(termSessions, current.sessionId) {
                     if (termSessions.firstOrNull { it.sessionId == current.sessionId }?.transport == SessionTransport.CLOSED) {
@@ -811,7 +817,12 @@ private fun BoundRoot(
                     onMessage = { messages.emit(it) },
                     autoConnect = true,
                     workspace = termWorkspace,
-                    onWorkspace = { termWorkspace = it },
+                    onWorkspace = { next ->
+                        if (next.padTermSide != termWorkspace.padTermSide) {
+                            appContainer.padTermSideLeft = next.padTermSide == PadTermSide.LEFT
+                        }
+                        termWorkspace = next
+                    },
                     sessions = termSessions,
                     connections = termConnections,
                     notes = termNotes,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
@@ -189,6 +189,18 @@ class AppContainer(private val context: Context) {
     @Volatile
     private var accountGraph: ManagedBindingGraph? = null
 
+    /**
+     * Which half of a landscape pad the terminal occupies. A device preference,
+     * not per-connection: the user's hand and desk setup do not change per host.
+     */
+    var padTermSideLeft: Boolean
+        get() = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getBoolean(KEY_PAD_TERM_SIDE, false)
+        set(value) {
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit().putBoolean(KEY_PAD_TERM_SIDE, value).apply()
+        }
+
     private val accountState = MutableStateFlow<AccountContainer?>(null)
 
     val accounts: StateFlow<AccountContainer?> = accountState.asStateFlow()
@@ -505,6 +517,7 @@ class AppContainer(private val context: Context) {
     private companion object {
         const val PREFS = "zephyr-one-device"
         const val KEY_INSTALL_ID = "install-id"
+        const val KEY_PAD_TERM_SIDE = "pad-term-side"
         const val NO_ACCOUNT_TEARDOWN_OWNER = "no-account-teardown"
 
         /** Reserved scope segment: never a real server or user id, which are opaque server strings. */

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt
@@ -149,8 +149,7 @@ internal fun DemoTermHead(
     latency: String,
     transport: SessionTransport,
     colors: TerminalChromeColors,
-    splitOn: Boolean,
-    onSplit: () -> Unit,
+    padSwapSide: (() -> Unit)? = null,
 ) {
     val onBack = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     Row(
@@ -212,22 +211,23 @@ internal fun DemoTermHead(
                 .padding(end = 6.dp)
                 .semantics { liveRegion = LiveRegionMode.Polite },
         )
-        val splitLabel = stringResource(R.string.terminal_split)
-        TermPressable(
-            onClick = onSplit,
-            modifier = Modifier
-                .size(TerminalWorkspace.SPLIT_BTN_SIZE_DP.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .background(if (splitOn) colors.accent.copy(alpha = 0.16f) else Color.Transparent)
-                .semantics { contentDescription = splitLabel },
-            scale = 0.9f,
-        ) {
-            Icon(
-                imageVector = ZephyrIcons.Fit,
-                contentDescription = null,
-                tint = if (splitOn) colors.accent else colors.dim,
-                modifier = Modifier.size(15.dp),
-            )
+        if (padSwapSide != null) {
+            val swapLabel = stringResource(R.string.terminal_pad_swap_side)
+            TermPressable(
+                onClick = padSwapSide,
+                modifier = Modifier
+                    .size(TerminalWorkspace.SPLIT_BTN_SIZE_DP.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .semantics { contentDescription = swapLabel },
+                scale = 0.9f,
+            ) {
+                Icon(
+                    imageVector = ZephyrIcons.Fit,
+                    contentDescription = null,
+                    tint = colors.dim,
+                    modifier = Modifier.size(15.dp),
+                )
+            }
         }
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalPanels.kt
@@ -422,6 +422,9 @@ internal fun SideToolDock(
     modifier: Modifier = Modifier,
     viewModel: TerminalViewModel? = null,
 ) {
+    /* The pad panel hosts exactly one tool at a time; the tab strip of the old
+     * multi-dock is gone with the split mode. */
+    val current = workspace.padPanelTool
     Column(
         modifier
             .fillMaxHeight()
@@ -433,44 +436,35 @@ internal fun SideToolDock(
                 .padding(horizontal = 8.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            workspace.docked.forEach { kind ->
-                val on = kind == workspace.dockCurrent
+            if (current != null) {
                 TermPressable(
-                    onClick = { onWorkspace(workspace.copy(dockCurrent = kind)) },
+                    onClick = { onWorkspace(workspace.copy(padPanelTool = null)) },
                     modifier = Modifier
-                        .padding(end = 4.dp)
                         .clip(RoundedCornerShape(8.dp))
-                        .background(if (on) colors.accent.copy(alpha = 0.30f) else colors.chrome2)
+                        .background(colors.accent.copy(alpha = 0.30f))
                         .padding(horizontal = 10.dp)
                         .height(28.dp),
                     scale = 0.95f,
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(toolIcon(kind), null, tint = if (on) Color.White else colors.dim, modifier = Modifier.size(12.dp))
+                        Icon(toolIcon(current), null, tint = Color.White, modifier = Modifier.size(12.dp))
                         Spacer(Modifier.width(5.dp))
                         Text(
-                            text = toolTitle(kind, hostName).substringBefore('·').trim(),
-                            color = if (on) Color.White else colors.dim,
+                            text = toolTitle(current, hostName).substringBefore('·').trim(),
+                            color = Color.White,
                             fontSize = 11.5.sp,
                             fontWeight = FontWeight.SemiBold,
                         )
-                        TermPressable(
-                            onClick = { onWorkspace(TerminalWorkspace.undock(workspace, kind)) },
-                            modifier = Modifier.padding(start = 4.dp),
-                            scale = 0.9f,
-                        ) {
-                            Text("×", color = (if (on) Color.White else colors.dim).copy(alpha = 0.7f), fontSize = 13.sp)
-                        }
+                        Text("×", color = Color.White.copy(alpha = 0.7f), fontSize = 13.sp, modifier = Modifier.padding(start = 6.dp))
                     }
                 }
             }
         }
         Box(Modifier.fillMaxWidth().height(1.dp).background(colors.line))
         Box(Modifier.weight(1f).then(
-            if (workspace.dockCurrent == TerminalToolKind.STATS || workspace.dockCurrent == TerminalToolKind.DOCKER) Modifier
+            if (current == TerminalToolKind.STATS || current == TerminalToolKind.DOCKER) Modifier
             else Modifier.verticalScroll(rememberScrollState()),
         ).padding(6.dp)) {
-            val current = workspace.dockCurrent
             if (current == null) {
                 Text(
                     text = stringResource(R.string.terminal_dock_empty),

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt
@@ -170,7 +170,7 @@ private fun DemoTerminalSurface(
     // height, producing the blank band reported on device.
     val imeOpen = imeHeightPx > 8f
     val surface = content.surface
-    val ws = workspace ?: TerminalWorkspaceState(paneA = content.connection.id)
+    val ws = workspace ?: TerminalWorkspaceState(activeSessionId = content.connection.id)
     val liveSessions = sessions.filter { it.protocol.isTerminal && it.transport != SessionTransport.CLOSED }
     val focusedRow = liveSessions.firstOrNull { it.sessionId == ws.focusedSessionId }
         ?: liveSessions.firstOrNull { it.sessionId == content.connection.id }
@@ -188,11 +188,6 @@ private fun DemoTerminalSurface(
     var containerW by remember { mutableStateOf(0) }
     var containerH by remember { mutableStateOf(0) }
 
-    val splitOffMsg = stringResource(R.string.terminal_split_off)
-    val splitTermMsg = stringResource(R.string.terminal_split_term)
-    val splitLeftMsg = stringResource(R.string.terminal_split_left)
-    val splitRightMsg = stringResource(R.string.terminal_split_right)
-    val needSecondMsg = stringResource(R.string.terminal_need_second_session)
     val insertToastMsg = stringResource(R.string.terminal_insert_toast)
     val openConnectionIds = liveSessions.mapTo(mutableSetOf()) { it.connectionId }.apply {
         add(content.connection.id)
@@ -250,23 +245,16 @@ private fun DemoTerminalSurface(
                     latency = latencyLabel(focusedRow),
                     transport = focusedRow?.transport ?: content.transport,
                     colors = colors,
-                    splitOn = ws.split != TerminalSplitMode.OFF,
-                    onSplit = {
-                        val next = TerminalWorkspace.nextSplit(ws.split)
-                        if (next == TerminalSplitMode.TERM && liveSessions.size < 2) {
-                            onMessage(needSecondMsg)
+                    padSwapSide = if (pad) {
+                        {
+                            onWorkspace(
+                                ws.copy(
+                                    padTermSide = if (ws.padTermSide == PadTermSide.LEFT) PadTermSide.RIGHT else PadTermSide.LEFT,
+                                ),
+                            )
                         }
-                        onWorkspace(
-                            TerminalWorkspace.applySplit(ws, next, liveSessions.map { it.sessionId }),
-                        )
-                        onMessage(
-                            when (next) {
-                                TerminalSplitMode.OFF -> splitOffMsg
-                                TerminalSplitMode.TERM -> splitTermMsg
-                                TerminalSplitMode.LEFT -> splitLeftMsg
-                                TerminalSplitMode.RIGHT -> splitRightMsg
-                            },
-                        )
+                    } else {
+                        null
                     },
                 )
                 DemoSessRail(
@@ -286,7 +274,7 @@ private fun DemoTerminalSurface(
                         )
                     },
                     focusedId = ws.focusedSessionId,
-                    otherId = if (ws.split == TerminalSplitMode.TERM) ws.paneB else null,
+                    otherId = null,
                     colors = colors,
                     onSelect = onSelectSession,
                     onClose = onCloseSession,
@@ -318,7 +306,6 @@ private fun DemoTerminalSurface(
                             onWorkspace(TerminalWorkspace.openTool(ws, TerminalToolKind.DOCKER, phone = !pad))
                         },
                         onMessage = onMessage,
-                        onFocusPane = { pane -> onWorkspace(ws.withFocus(pane)) },
                     )
                 }
                 // Row 1 is permanent and hugs the system IME. Row 2 is the context dock and is
@@ -475,132 +462,106 @@ private fun TerminalSplitArea(
     onOpenNote: (String) -> Unit,
     onOpenDocker: () -> Unit,
     onMessage: (String) -> Unit,
-    onFocusPane: (Char) -> Unit,
 ) {
-    val density = LocalDensity.current
-    val split = workspace.split
+    /* Single terminal pane. On a pad in landscape the pane sits on
+     * [TerminalWorkspaceState.padTermSide] and the opposite side hosts either
+     * the open tool panel or a quiet placeholder; a gutter between them drags
+     * the terminal from [TerminalWorkspace.PAD_MIN_TERM_FRACTION] up to full
+     * width. On a phone the pane is always full-width and tools live in the
+     * bottom sheet. */
+    val vmA = paneViewModels[workspace.activeSessionId] ?: focusedVm
     Row(Modifier.fillMaxSize()) {
-        val toolFirst = split == TerminalSplitMode.LEFT
-        if (toolFirst && split.docksTools) {
-            SideToolDock(
-                workspace = workspace,
-                colors = colors,
-                hostName = content.connection.name,
-                notes = notes,
-                snippets = snippets,
-                onWorkspace = onWorkspace,
-                onInsert = onInsert,
-                onOpenNote = onOpenNote,
-                onOpenDocker = onOpenDocker,
-                onMessage = onMessage,
-                viewModel = focusedVm,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth(workspace.dockWidthFraction),
-            )
-            SplitGutter(colors, workspace, onWorkspace)
-        }
-        val termWeight = if (split == TerminalSplitMode.OFF) 1f
-        else if (split == TerminalSplitMode.TERM) 1f - workspace.dockWidthFraction
-        else 1f - workspace.dockWidthFraction
-        Box(Modifier.weight(if (split == TerminalSplitMode.OFF) 1f else (1f - workspace.dockWidthFraction).coerceAtLeast(0.2f)).fillMaxHeight()) {
-            val vmA = paneViewModels[workspace.paneA] ?: focusedVm
-            if (vmA != null) {
-                TermuxTerminalPane(
-                    viewModel = vmA,
-                    keyboardVisible = keyboardVisible && workspace.focusPane == 'a',
-                    colors = colors,
-                    focused = workspace.focusPane == 'a',
-                    onTap = {
-                        onFocusPane('a')
-                        onIntent(TerminalIntent.Dock(TerminalDockItem.KEYBOARD))
-                    },
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-            if (split == TerminalSplitMode.TERM && workspace.focusPane == 'a') {
-                Box(Modifier.fillMaxWidth().height(2.dp).background(colors.accent))
-            }
-            if (!content.transport.isLive) {
-                ConnectPrompt(transport = content.transport, onIntent = onIntent)
-            }
-        }
-        if (split == TerminalSplitMode.TERM) {
-            SplitGutter(colors, workspace, onWorkspace)
-            Box(Modifier.fillMaxHeight().fillMaxWidth(workspace.dockWidthFraction)) {
-                val vmB = paneViewModels[workspace.paneB ?: ""]
-                if (vmB != null) {
+        val terminalFirst = workspace.padTermSide == PadTermSide.LEFT
+        val panelVisible = workspace.padPanelTool != null &&
+            workspace.padTermFraction < TerminalWorkspace.PAD_MAX_TERM_FRACTION
+
+        val terminal: @Composable () -> Unit = {
+            Box(Modifier.fillMaxSize()) {
+                if (vmA != null) {
                     TermuxTerminalPane(
-                        viewModel = vmB,
-                        keyboardVisible = keyboardVisible && workspace.focusPane == 'b',
+                        viewModel = vmA,
+                        keyboardVisible = keyboardVisible,
                         colors = colors,
-                        focused = workspace.focusPane == 'b',
-                        onTap = {
-                            onFocusPane('b')
-                            onIntent(TerminalIntent.Dock(TerminalDockItem.KEYBOARD))
-                        },
+                        focused = true,
+                        onTap = { onIntent(TerminalIntent.Dock(TerminalDockItem.KEYBOARD)) },
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
-                if (workspace.focusPane == 'b') {
-                    Box(Modifier.fillMaxWidth().height(2.dp).background(colors.accent))
+                if (!content.transport.isLive) {
+                    ConnectPrompt(transport = content.transport, onIntent = onIntent)
                 }
             }
         }
-        if (!toolFirst && split.docksTools) {
-            SplitGutter(colors, workspace, onWorkspace)
-            SideToolDock(
-                workspace = workspace,
-                colors = colors,
-                hostName = content.connection.name,
-                notes = notes,
-                snippets = snippets,
-                onWorkspace = onWorkspace,
-                onInsert = onInsert,
-                onOpenNote = onOpenNote,
-                onOpenDocker = onOpenDocker,
-                onMessage = onMessage,
-                viewModel = focusedVm,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth(workspace.dockWidthFraction),
-            )
+        val panel: @Composable () -> Unit = {
+            if (workspace.padPanelTool != null) {
+                SideToolDock(
+                    workspace = workspace,
+                    colors = colors,
+                    hostName = content.connection.name,
+                    notes = notes,
+                    snippets = snippets,
+                    onWorkspace = onWorkspace,
+                    onInsert = onInsert,
+                    onOpenNote = onOpenNote,
+                    onOpenDocker = onOpenDocker,
+                    onMessage = onMessage,
+                    viewModel = focusedVm,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
-        @Suppress("UNUSED_VARIABLE")
-        val unused = Triple(density, termWeight, onIntent)
+
+        /* Full-width terminal: nothing else to lay out. */
+        if (!panelVisible) {
+            Box(Modifier.weight(1f).fillMaxHeight()) { terminal() }
+            return@Row
+        }
+
+        val panelFraction = (1f - workspace.padTermFraction).coerceAtLeast(0.05f)
+        if (!terminalFirst) {
+            Box(Modifier.weight(1f - panelFraction).fillMaxHeight()) { terminal() }
+            PadGutter(colors, workspace, onWorkspace)
+            Box(Modifier.weight(panelFraction).fillMaxHeight()) { panel() }
+        } else {
+            Box(Modifier.weight(panelFraction).fillMaxHeight()) { panel() }
+            PadGutter(colors, workspace, onWorkspace)
+            Box(Modifier.weight(1f - panelFraction).fillMaxHeight()) { terminal() }
+        }
     }
 }
 
 @Composable
-private fun SplitGutter(
+private fun PadGutter(
     colors: TerminalChromeColors,
     workspace: TerminalWorkspaceState,
     onWorkspace: (TerminalWorkspaceState) -> Unit,
 ) {
     var dragging by remember { mutableStateOf(false) }
-    var start by remember { mutableStateOf(workspace.dockWidthFraction) }
+    var start by remember { mutableStateOf(workspace.padTermFraction) }
+    var rowWidthPx by remember { mutableStateOf(0f) }
     Box(
         modifier = Modifier
             .width(TerminalWorkspace.GUTTER_WIDTH_DP.dp)
             .fillMaxHeight()
-            .pointerInput(workspace.split) {
+            .onSizeChanged { rowWidthPx = it.width.toFloat() * 40f }
+            .pointerInput(workspace.padTermSide) {
                 detectDragGestures(
                     onDragStart = {
                         dragging = true
-                        start = workspace.dockWidthFraction
+                        start = workspace.padTermFraction
                     },
                     onDragEnd = { dragging = false },
                     onDragCancel = { dragging = false },
                     onDrag = { change, drag ->
                         change.consume()
-                        val next = TerminalWorkspace.dragWidth(
+                        val next = TerminalWorkspace.dragPadTermFraction(
                             startFraction = start,
                             dxPx = drag.x,
-                            splitWidthPx = size.width.toFloat() * 40f,
-                            split = workspace.split,
+                            rowWidthPx = rowWidthPx,
+                            side = workspace.padTermSide,
                         )
                         start = next
-                        onWorkspace(workspace.copy(dockWidthFraction = next))
+                        onWorkspace(workspace.copy(padTermFraction = next))
                     },
                 )
             },

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt
@@ -1,22 +1,13 @@
 package one.zephyr.mobile.feature.sessions
 
 /**
- * Demo `#page-terminal` split / dock / in-flow tool-sheet state.
+ * Demo `#page-terminal` tool-sheet state.
  *
- * `toggleSplit` walks off → term → right → left → off, matching
- * `index__2_.html` `toggleSplit()` / `setDockSide()`.
+ * The old split mode (term↔term, tool dock left/right) is gone. A phone shows
+ * tools in a bottom sheet; a pad in landscape keeps the terminal on one side
+ * and the tool panel (or the home surface) on the other, with a draggable
+ * gutter between them.
  */
-enum class TerminalSplitMode {
-    OFF,
-    TERM,
-    RIGHT,
-    LEFT,
-    ;
-
-    val docksTools: Boolean get() = this == LEFT || this == RIGHT
-    val splitsTerms: Boolean get() = this == TERM
-}
-
 enum class TerminalToolKind {
     FILES,
     SNIPPET,
@@ -42,19 +33,23 @@ enum class TerminalToolKind {
     }
 }
 
+/** Which side of a landscape pad the terminal pane sits on. */
+enum class PadTermSide { LEFT, RIGHT }
+
 enum class TermBackgroundKind { NONE, IMAGE, BIG }
 
-const val DEFAULT_TERMINAL_DOCK_FRACTION = 0.38f
 const val DEFAULT_TERMINAL_SHEET_FRACTION = 0.44f
 
 data class TerminalWorkspaceState(
-    val split: TerminalSplitMode = TerminalSplitMode.OFF,
-    val dockWidthFraction: Float = DEFAULT_TERMINAL_DOCK_FRACTION,
-    val focusPane: Char = 'a',
-    val paneA: String,
-    val paneB: String? = null,
-    val docked: List<TerminalToolKind> = emptyList(),
-    val dockCurrent: TerminalToolKind? = null,
+    /* One terminal at a time: the split panes were removed because the second
+     * pane never had a real ViewModel wired and the mode confused more
+     * sessions than it helped. */
+    val activeSessionId: String,
+    /* Pad layout. padTermFraction is the terminal's share of the width;
+     * 1f means the terminal covers the whole row (the panel is hidden). */
+    val padTermSide: PadTermSide = PadTermSide.RIGHT,
+    val padTermFraction: Float = TerminalWorkspace.PAD_DEFAULT_TERM_FRACTION,
+    val padPanelTool: TerminalToolKind? = null,
     val sheetTools: List<TerminalToolKind> = emptyList(),
     val sheetCurrent: TerminalToolKind? = null,
     val sheetFraction: Float = 0f,
@@ -66,52 +61,22 @@ data class TerminalWorkspaceState(
     val addSheetOpen: Boolean = false,
     val disconnectSheetOpen: Boolean = false,
 ) {
-    val focusedSessionId: String
-        get() = if (split == TerminalSplitMode.TERM && focusPane == 'b') {
-            paneB ?: paneA
-        } else {
-            paneA
-        }
+    val focusedSessionId: String get() = activeSessionId
 
-    fun withFocus(pane: Char): TerminalWorkspaceState = copy(focusPane = pane)
+    fun withFocus(pane: Char): TerminalWorkspaceState = this
 
-    fun assignToFocused(sessionId: String): TerminalWorkspaceState {
-        if (split != TerminalSplitMode.TERM) return copy(paneA = sessionId, focusPane = 'a')
-        return if (focusPane == 'b') {
-            if (sessionId == paneA) copy(paneA = paneB ?: sessionId, paneB = sessionId)
-            else copy(paneB = sessionId)
-        } else {
-            if (sessionId == paneB) copy(paneB = paneA, paneA = sessionId)
-            else copy(paneA = sessionId)
-        }
-    }
+    fun assignToFocused(sessionId: String): TerminalWorkspaceState =
+        copy(activeSessionId = sessionId)
 
     fun closeSession(sessionId: String, remaining: List<String>): TerminalWorkspaceState? {
         val next = remaining.filterNot { it == sessionId }
         if (next.isEmpty()) return null
-        val clamp = { id: String? ->
-            when {
-                id == null || id == sessionId || id !in next -> next.first()
-                else -> id
-            }
-        }
-        var a = clamp(paneA)
-        var b = paneB?.let(clamp)
-        if (split == TerminalSplitMode.TERM && a == b && next.size > 1) {
-            b = next.first { it != a }
-        }
-        return copy(paneA = a, paneB = b)
+        return copy(activeSessionId = if (activeSessionId == sessionId) next.first() else activeSessionId)
     }
 }
 
 object TerminalWorkspace {
 
-    const val DEFAULT_DOCK_FRACTION = 0.38f
-    const val TERM_SPLIT_FRACTION = 0.50f
-    const val MIN_DOCK_FRACTION = 0.20f
-    const val MAX_DOCK_FRACTION = 0.70f
-    const val PAD_RAIL_MIN_DP = 768
-    const val PAD_RAIL_WIDTH_DP = 216
     const val KEY_HEIGHT_DP = 36
     const val KEY_PADDING_V_DP = 7
     const val KEY_GAP_DP = 6
@@ -130,56 +95,29 @@ object TerminalWorkspace {
     const val SHEET_DISMISS_VELOCITY_PX_PER_MS = 0.70f
     const val SHEET_PROJECTION_SECONDS = 0.12f
 
-    val splitCycle: List<TerminalSplitMode> = listOf(
-        TerminalSplitMode.OFF,
-        TerminalSplitMode.TERM,
-        TerminalSplitMode.RIGHT,
-        TerminalSplitMode.LEFT,
-    )
+    /* Pad two-pane layout: the terminal starts at half the row and can be
+     * dragged between a readable minimum and full width. */
+    const val PAD_RAIL_MIN_DP = 768
+    const val PAD_RAIL_WIDTH_DP = 216
+    const val PAD_DEFAULT_TERM_FRACTION = 0.50f
+    const val PAD_MIN_TERM_FRACTION = 0.30f
+    const val PAD_MAX_TERM_FRACTION = 1.00f
 
-    fun nextSplit(current: TerminalSplitMode): TerminalSplitMode {
-        val i = splitCycle.indexOf(current)
-        return splitCycle[(i + 1).coerceAtLeast(0) % splitCycle.size]
-    }
+    fun clampPadTermFraction(fraction: Float): Float =
+        fraction.coerceIn(PAD_MIN_TERM_FRACTION, PAD_MAX_TERM_FRACTION)
 
-    fun clampDockWidth(fraction: Float): Float =
-        fraction.coerceIn(MIN_DOCK_FRACTION, MAX_DOCK_FRACTION)
-
-    fun applySplit(
-        state: TerminalWorkspaceState,
-        side: TerminalSplitMode,
-        sessionIds: List<String>,
-    ): TerminalWorkspaceState {
-        val fraction = when (side) {
-            TerminalSplitMode.TERM ->
-                if (state.split == TerminalSplitMode.TERM) state.dockWidthFraction else TERM_SPLIT_FRACTION
-            TerminalSplitMode.LEFT, TerminalSplitMode.RIGHT ->
-                if (state.split.docksTools) state.dockWidthFraction else DEFAULT_DOCK_FRACTION
-            TerminalSplitMode.OFF -> state.dockWidthFraction
-        }
-        var paneB = state.paneB
-        if (side == TerminalSplitMode.TERM) {
-            paneB = when {
-                sessionIds.size < 2 -> state.paneA
-                paneB == null || paneB == state.paneA || paneB !in sessionIds ->
-                    sessionIds.firstOrNull { it != state.paneA } ?: state.paneA
-                else -> paneB
-            }
-        }
-        var docked = state.docked
-        var dockCurrent = state.dockCurrent
-        if (side.docksTools && dockCurrent == null) {
-            docked = listOf(TerminalToolKind.STATS)
-            dockCurrent = TerminalToolKind.STATS
-        }
-        return state.copy(
-            split = side,
-            dockWidthFraction = clampDockWidth(fraction),
-            paneB = paneB,
-            focusPane = 'a',
-            docked = docked,
-            dockCurrent = dockCurrent,
-        )
+    /**
+     * Horizontal drag on the gutter. Dragging towards the panel grows the
+     * terminal; at [PAD_MAX_TERM_FRACTION] the terminal is full-width and the
+     * panel is gone, which is the pad equivalent of closing the sheet.
+     */
+    fun dragPadTermFraction(startFraction: Float, dxPx: Float, rowWidthPx: Float, side: PadTermSide): Float {
+        if (rowWidthPx <= 0f) return startFraction
+        /* The gutter sits on the panel side of the terminal. When the terminal
+         * is on the right, dragging left (negative dx) widens it; when it is on
+         * the left, dragging right does. */
+        val signed = if (side == PadTermSide.RIGHT) -dxPx else dxPx
+        return clampPadTermFraction(startFraction + signed / rowWidthPx)
     }
 
     fun openTool(
@@ -188,13 +126,17 @@ object TerminalWorkspace {
         phone: Boolean = true,
     ): TerminalWorkspaceState {
         if (!phone) {
-            val base = if (state.split.docksTools) state else applySplit(
-                state = state,
-                side = TerminalSplitMode.RIGHT,
-                sessionIds = listOfNotNull(state.paneA, state.paneB),
+            /* Pad: the tool takes the panel side. Tapping the open tool again
+             * closes the panel back to the home surface, mirroring the phone
+             * sheet toggle. */
+            if (state.padPanelTool == kind) return state.copy(padPanelTool = null)
+            return state.copy(
+                padPanelTool = kind,
+                padTermFraction = clampPadTermFraction(
+                    if (state.padTermFraction >= PAD_MAX_TERM_FRACTION) PAD_DEFAULT_TERM_FRACTION
+                    else state.padTermFraction,
+                ),
             )
-            val docked = if (kind in base.docked) base.docked else base.docked + kind
-            return base.copy(docked = docked, dockCurrent = kind)
         }
         if (state.sheetCurrent == kind && state.sheetFraction > 0f) return closeSheet(state)
         val tools = if (kind in state.sheetTools) state.sheetTools else state.sheetTools + kind
@@ -218,7 +160,7 @@ object TerminalWorkspace {
     }
 
     fun closeSheet(state: TerminalWorkspaceState): TerminalWorkspaceState =
-        state.copy(sheetFraction = 0f)
+        state.copy(sheetFraction = 0f, padPanelTool = null)
 
     /**
      * Drops the last tab after the close height animation has reached 0.
@@ -240,26 +182,5 @@ object TerminalWorkspace {
         } else {
             SHEET_MID_FRACTION
         }
-    }
-
-    fun undock(state: TerminalWorkspaceState, kind: TerminalToolKind): TerminalWorkspaceState {
-        val docked = state.docked.filterNot { it == kind }
-        val current = when {
-            state.dockCurrent != kind -> state.dockCurrent
-            docked.isEmpty() -> null
-            else -> docked.last()
-        }
-        return state.copy(docked = docked, dockCurrent = current)
-    }
-
-    fun dragWidth(
-        startFraction: Float,
-        dxPx: Float,
-        splitWidthPx: Float,
-        split: TerminalSplitMode,
-    ): Float {
-        if (splitWidthPx <= 0f) return startFraction
-        val signed = if (split == TerminalSplitMode.LEFT) dxPx else -dxPx
-        return clampDockWidth(startFraction + signed / splitWidthPx)
     }
 }

--- a/zephyr_one/mobile/android/feature-sessions/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/res/values-en/strings.xml
@@ -57,12 +57,11 @@
     <string name="copy_text">Copy</string>
     <string name="paste_text">Paste</string>
     <string name="text_selection_more">More</string>
-    <string name="terminal_split">Split</string>
     <string name="terminal_add_session">New session</string>
+    <string name="terminal_pad_swap_side">Swap terminal and panel sides</string>
     <string name="terminal_close_session">Close session</string>
     <string name="terminal_pad_rail">Hosts</string>
     <string name="terminal_dock_empty">Tap Files / Snippets / Notes / Monitor / Look\nto dock them here, off the terminal</string>
-    <string name="terminal_need_second_session">Open another session to split terminals</string>
     <string name="terminal_copied">Copied · %1$s</string>
     <string name="terminal_pasted">Pasted into %1$s</string>
     <string name="terminal_disconnect_title">Disconnect %1$s? The session cannot be restored</string>
@@ -84,10 +83,6 @@
     <string name="terminal_theme_override">Color override (every scheme)</string>
     <string name="terminal_custom_bg_color">Custom terminal background</string>
     <string name="terminal_custom_sel_color">Custom selection colors</string>
-    <string name="terminal_split_off">Split closed</string>
-    <string name="terminal_split_term">Dual terminal · tap a pane, the dock talks to that one</string>
-    <string name="terminal_split_left">Tools docked on the left</string>
-    <string name="terminal_split_right">Tools docked on the right</string>
     <string name="terminal_session_closed">Session closed · commands were not replayed</string>
     <string name="terminal_all_closed">Every session is closed</string>
     <string name="terminal_docked">Docked · %1$s</string>

--- a/zephyr_one/mobile/android/feature-sessions/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/res/values/strings.xml
@@ -76,12 +76,11 @@
     <string name="copy_text">复制</string>
     <string name="paste_text">粘贴</string>
     <string name="text_selection_more">更多</string>
-    <string name="terminal_split">分屏</string>
     <string name="terminal_add_session">新建会话</string>
+    <string name="terminal_pad_swap_side">交换终端与面板侧</string>
     <string name="terminal_close_session">关闭会话</string>
     <string name="terminal_pad_rail">连接</string>
     <string name="terminal_dock_empty">点底部 文件 / 片段 / 笔记 / 监控 / 外观\n停靠在这一侧，不挡终端</string>
-    <string name="terminal_need_second_session">再开一个会话才能双终端</string>
     <string name="terminal_copied">已复制 · %1$s</string>
     <string name="terminal_pasted">已粘贴到 %1$s</string>
     <string name="terminal_disconnect_title">断开 %1$s？会话不可恢复</string>
@@ -103,10 +102,6 @@
     <string name="terminal_theme_override">颜色覆盖（所有配色模式生效）</string>
     <string name="terminal_custom_bg_color">自定义终端背景色</string>
     <string name="terminal_custom_sel_color">自定义选中色（背景+文字）</string>
-    <string name="terminal_split_off">已关闭分屏</string>
-    <string name="terminal_split_term">双终端 · 点哪边，底部按钮打哪边</string>
-    <string name="terminal_split_left">工具停靠左侧</string>
-    <string name="terminal_split_right">工具停靠右侧</string>
     <string name="terminal_session_closed">会话已关闭 · 未自动重放命令</string>
     <string name="terminal_all_closed">所有会话已关闭</string>
     <string name="terminal_docked">已停靠 · %1$s</string>

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/TerminalToolSheetTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import java.io.File
 
 class TerminalToolSheetTest {
-    private fun state() = TerminalWorkspaceState(paneA = "s1")
+    private fun state() = TerminalWorkspaceState(activeSessionId = "s1")
 
     private fun codeOnly(source: String): String =
         source
@@ -95,11 +95,40 @@ class TerminalToolSheetTest {
     }
 
     @Test
-    fun tabletToolUsesInPageSideDock() {
+    fun tabletToolUsesOppositePanel() {
+        /* Pad landscape: the tool takes the side opposite the terminal instead
+         * of a bottom sheet. Tapping the same tool again hands the side back
+         * to the home surface. */
         val opened = TerminalWorkspace.openTool(state(), TerminalToolKind.NOTES, phone = false)
-        assertEquals(TerminalSplitMode.RIGHT, opened.split)
-        assertEquals(TerminalToolKind.NOTES, opened.dockCurrent)
-        assertTrue(opened.docked.contains(TerminalToolKind.NOTES))
+        assertEquals(TerminalToolKind.NOTES, opened.padPanelTool)
         assertEquals(0f, opened.sheetFraction, 0.001f)
+        val closed = TerminalWorkspace.openTool(opened, TerminalToolKind.NOTES, phone = false)
+        assertEquals(null, closed.padPanelTool)
+    }
+
+    @Test
+    fun padGutterDragWidensAndNarrowsTheTerminal() {
+        /* Terminal on the right: dragging left (negative dx) grows it. */
+        val grown = TerminalWorkspace.dragPadTermFraction(0.5f, -200f, 1000f, PadTermSide.RIGHT)
+        assertEquals(0.7f, grown, 0.001f)
+        val shrunk = TerminalWorkspace.dragPadTermFraction(0.5f, 200f, 1000f, PadTermSide.RIGHT)
+        assertEquals(0.3f, shrunk, 0.001f)
+        /* Terminal on the left mirrors the direction. */
+        val grownLeft = TerminalWorkspace.dragPadTermFraction(0.5f, 200f, 1000f, PadTermSide.LEFT)
+        assertEquals(0.7f, grownLeft, 0.001f)
+        /* The drag can push the terminal to full width, hiding the panel. */
+        val full = TerminalWorkspace.dragPadTermFraction(0.9f, -400f, 1000f, PadTermSide.RIGHT)
+        assertEquals(TerminalWorkspace.PAD_MAX_TERM_FRACTION, full, 0.001f)
+        /* …and clamps at a readable minimum rather than collapsing the pane. */
+        val min = TerminalWorkspace.dragPadTermFraction(0.4f, 400f, 1000f, PadTermSide.RIGHT)
+        assertEquals(TerminalWorkspace.PAD_MIN_TERM_FRACTION, min, 0.001f)
+    }
+
+    @Test
+    fun openingAPadToolFromFullScreenRestoresTheDefaultHalf() {
+        val fullScreen = state().copy(padTermFraction = TerminalWorkspace.PAD_MAX_TERM_FRACTION)
+        val opened = TerminalWorkspace.openTool(fullScreen, TerminalToolKind.STATS, phone = false)
+        assertEquals(TerminalToolKind.STATS, opened.padPanelTool)
+        assertEquals(TerminalWorkspace.PAD_DEFAULT_TERM_FRACTION, opened.padTermFraction, 0.001f)
     }
 }

--- a/zephyr_one/mobile/tests/pad-two-pane-contract.test.mjs
+++ b/zephyr_one/mobile/tests/pad-two-pane-contract.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+const WORKSPACE = 'android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalWorkspace.kt';
+const SCREEN = 'android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalScreen.kt';
+const CHROME = 'android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalChrome.kt';
+
+test('the old split mode is gone from the workspace and the chrome', () => {
+  const workspace = read(WORKSPACE);
+  const screen = read(SCREEN);
+  const chrome = read(CHROME);
+  for (const gone of ['TerminalSplitMode', 'nextSplit', 'applySplit', 'paneB', 'focusPane', 'dockWidthFraction', 'SplitGutter']) {
+    assert.ok(!workspace.includes(gone), `workspace still references ${gone}`);
+    assert.ok(!screen.includes(gone), `screen still references ${gone}`);
+  }
+  assert.ok(!chrome.includes('onSplit'), 'the header must not offer a split button');
+});
+
+test('a pad lays the terminal and the panel side by side with a draggable gutter', () => {
+  const workspace = read(WORKSPACE);
+  const screen = read(SCREEN);
+  assert.match(workspace, /enum class PadTermSide \{ LEFT, RIGHT \}/);
+  assert.match(workspace, /PAD_DEFAULT_TERM_FRACTION = 0\.50f/, 'the terminal opens at half width');
+  assert.match(workspace, /PAD_MAX_TERM_FRACTION = 1\.00f/, 'the gutter can push the terminal to full width');
+  assert.match(workspace, /fun dragPadTermFraction\(/, 'the gutter drag maps dx to the terminal fraction');
+  assert.match(screen, /PadGutter\(colors, workspace, onWorkspace\)/, 'the gutter sits between the panes');
+  assert.match(screen, /workspace\.padPanelTool != null &&\s*workspace\.padTermFraction < TerminalWorkspace\.PAD_MAX_TERM_FRACTION/,
+    'the panel hides when the terminal is dragged to full width');
+});
+
+test('pad tools open on the panel side and toggle closed like the phone sheet', () => {
+  const workspace = read(WORKSPACE);
+  const screen = read(SCREEN);
+  assert.match(workspace, /if \(!phone\) \{[\s\S]*?padPanelTool = kind/,
+    'a pad tool opens on the opposite side instead of a bottom sheet');
+  assert.match(workspace, /if \(state\.padPanelTool == kind\) return state\.copy\(padPanelTool = null\)/,
+    'tapping the open tool again closes the panel');
+  assert.match(screen, /TerminalWorkspace\.openTool\(ws, kind, phone = !pad\)/,
+    'the dock routes pad tools to the panel and phone tools to the sheet');
+});
+
+test('the panel side is a user choice persisted in the workspace state', () => {
+  const workspace = read(WORKSPACE);
+  const screen = read(SCREEN);
+  assert.match(workspace, /val padTermSide: PadTermSide = PadTermSide\.RIGHT/,
+    'the terminal defaults to the right half so the panel or home surface sits left');
+  assert.match(screen, /val terminalFirst = workspace\.padTermSide == PadTermSide\.LEFT/,
+    'the layout honours the configured side');
+});

--- a/zephyr_one/mobile/tests/terminal-add-host-sheet.test.mjs
+++ b/zephyr_one/mobile/tests/terminal-add-host-sheet.test.mjs
@@ -58,7 +58,7 @@ test('terminal plus guard rejects the pre19 below-screen sheet', () => {
     sftp: read('android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/SnippetScreens.kt'),
   };
   assert.throws(
-    () => assertTerminalAddHost({ ...current, screen: current.screen.replace('Box(Modifier.fillMaxSize()) {', 'Column(Modifier.fillMaxSize()) {') }),
+    () => assertTerminalAddHost({ ...current, screen: current.screen.replaceAll('Box(Modifier.fillMaxSize()) {', 'Column(Modifier.fillMaxSize()) {') }),
     /missing Box\(Modifier\.fillMaxSize/,
   );
   assert.throws(


### PR DESCRIPTION
## 分屏删除

终端分屏（双终端、工具左右停靠）整体移除。第二个 pane 在 Root 集成层从未接过真实 ViewModel（`paneViewModels` 一直用默认 emptyMap)，双终端是个坏功能；循环切换按钮也持续造成困惑。

## Pad 横屏简单适配

- 横屏 Pad：终端固定占一侧（默认右侧，头部按钮可换侧），另一侧显示工具面板
- 中间 gutter 左右拖动调终端宽度，30% 最小 → 拖到 100% 即终端全屏（面板隐藏），等价于手机下滑关闭
- 底部工具栏（文件/监控/笔记等）点击 → 另一侧显示对应工具；再点一次归还该侧
- 终端侧选择是设备级偏好，跨启动保持（AppContainer SharedPreferences)
- 手机布局不变：工具仍走底部 sheet、下滑关闭，无横向手势与 gutter 冲突

## 测试

- `TerminalToolSheetTest`:dock 模式用例换成面板用例（面板打开/再点关闭/gutter 双向拖动/全屏钳制/从全屏开工具恢复默认半宽）
- `pad-two-pane-contract.test.mjs`（新，4 条）：锁定分屏符号已删、gutter 接线、面板可见性规则、侧偏好持久化
- `terminal-add-host-sheet.test.mjs` mutation 适配 pad row 引入的第二个全屏 Box
- 移动端契约 372 pass,10 个失败与 main 基线完全一致（PaX/Java VM 沙箱）；桌面契约 92/92
