### PR TITLE
fix(mobile): authenticate each SSH jump hop as itself and wire the editor

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt
@@ -37,6 +37,7 @@ class ManagedSshSessionPool(
     private val connectionProvider: suspend (String) -> Connection?,
     private val credentialsProvider: suspend (Connection) -> TerminalCredentials,
     private val routePlanner: RoutePlanner = RoutePlanner { null },
+    private val hopAuthProvider: suspend (SshRoute) -> Map<String, one.zephyr.mobile.protocol.ssh.HopAuth> = { emptyMap() },
 ) {
     fun interface RoutePlanner {
         suspend fun plan(connection: Connection): SshRoute?
@@ -89,6 +90,7 @@ class ManagedSshSessionPool(
                 route = route,
                 username = connection.username,
                 credential = credential,
+                hopCredentials = hopAuthProvider(route),
                 hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,
                 cols = 80,
                 rows = 24,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt
@@ -25,6 +25,7 @@ internal class DirectSshConnectionTester(
     private val routePlanner: suspend (Connection) -> SshRoute = {
         SshRoute(listOf(RouteHop.Target(it.host, it.port)))
     },
+    private val hopAuthProvider: suspend (SshRoute) -> Map<String, one.zephyr.mobile.protocol.ssh.HopAuth> = { emptyMap() },
 ) : ConnectionTester {
     override suspend fun test(
         connection: Connection,
@@ -69,6 +70,7 @@ internal class DirectSshConnectionTester(
                     route = route,
                     username = connection.username,
                     credential = credential,
+                    hopCredentials = hopAuthProvider(route),
                     hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,
                     cols = 80,
                     rows = 24,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -427,12 +427,18 @@ private fun BoundRoot(
             connectionProvider = account.connections::find,
             credentialsProvider = account::terminalCredentials,
             routePlanner = accountRoutePlanner(account),
+            hopAuthProvider = { route -> account.hopAuthFor(route) },
         )
     }
     val terminalHost = remember(account, sshEngine) {
         SshTerminalHost(
             engine = sshEngine,
             findConnection = { id -> account.connections.find(id) },
+            routePlanner = { connection ->
+                accountRoutePlanner(account).plan(connection)
+                    ?: SshRoute(listOf(RouteHop.Target(connection.host, connection.port)))
+            },
+            hopAuthProvider = { route -> account.hopAuthFor(route) },
         )
     }
     val managedHostKeyPrompt by managedSsh.prompt.collectAsState()
@@ -576,6 +582,7 @@ private fun BoundRoot(
                                     accountRoutePlanner(account).plan(connection)
                                         ?: SshRoute(listOf(RouteHop.Target(connection.host, connection.port)))
                                 },
+                                hopAuthProvider = { route -> account.hopAuthFor(route) },
                             ),
                             fallback = TcpReachabilityTester(),
                         ),
@@ -1686,6 +1693,42 @@ private fun BatchExecutionViewModel.dispatch(intent: BatchIntent) {
  * is itself a connection id. Rejections are configuration errors the user can
  * fix, never a connect timeout.
  */
+/**
+ * Resolves each jump hop to that hop's own stored secrets.
+ *
+ * Main-end `createRoutedSSHConnection` authenticates hop N with
+ * `connectSSHClient(hop)`, never with the target's password. Reusing the
+ * target's credential here is what made a working jump fail on the phone.
+ */
+internal suspend fun AccountContainer.hopAuthFor(route: SshRoute): Map<String, one.zephyr.mobile.protocol.ssh.HopAuth> {
+    val hops = route.hops.filterIsInstance<RouteHop.SshJump>()
+    if (hops.isEmpty()) return emptyMap()
+    return buildMap {
+        for (hop in hops) {
+            val connection = connections.find(hop.connectionId)
+                ?: error("jump_auth_missing: 跳板 ${hop.host}:${hop.port} 的连接不存在")
+            val credentials = terminalCredentials(connection)
+            val credential = when {
+                credentials.privateKey != null && credentials.privateKey.isNotEmpty() ->
+                    one.zephyr.mobile.protocol.ssh.SshCredential.PrivateKey(
+                        credentials.privateKey.copyOf(),
+                        credentials.passphrase?.copyOf(),
+                    )
+                credentials.password != null && credentials.password.isNotEmpty() ->
+                    one.zephyr.mobile.protocol.ssh.SshCredential.Password(credentials.password.copyOf())
+                else -> error("jump_auth_missing: 跳板 ${connection.name.ifBlank { hop.host }} 没有可用的 SSH 凭据")
+            }
+            put(
+                hop.connectionId,
+                one.zephyr.mobile.protocol.ssh.HopAuth(
+                    username = connection.username.ifBlank { hop.username },
+                    credential = credential,
+                ),
+            )
+        }
+    }
+}
+
 internal fun accountRoutePlanner(account: AccountContainer): ManagedSshSessionPool.RoutePlanner =
     ManagedSshSessionPool.RoutePlanner { connection ->
         when (val result = SshRoutePlanner.plan(

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -1679,26 +1679,14 @@ private fun BatchExecutionViewModel.dispatch(intent: BatchIntent) {
 }
 
 /**
- * Reads one decrypted password for a single open attempt.
- *
- * Prefers the ref the mirror recorded and falls back to the conventional field ref, because a row
- * written before the ref was persisted still has its secret under the derived name.
- */
-/**
- * Resolves the stored proxy/jump settings of a connection into the route the
- * dialer will actually take.
- *
- * Mirrors the main end's resolveRoutePlan: a jumpHostIds entry that names a
- * jumpHost resource follows its connectionId, and one that names no resource
- * is itself a connection id. Rejections are configuration errors the user can
- * fix, never a connect timeout.
- */
-/**
  * Resolves each jump hop to that hop's own stored secrets.
  *
  * Main-end `createRoutedSSHConnection` authenticates hop N with
  * `connectSSHClient(hop)`, never with the target's password. Reusing the
  * target's credential here is what made a working jump fail on the phone.
+ *
+ * CharArray properties live in another module, so they cannot be smart-cast;
+ * copy into locals before testing emptiness.
  */
 internal suspend fun AccountContainer.hopAuthFor(route: SshRoute): Map<String, one.zephyr.mobile.protocol.ssh.HopAuth> {
     val hops = route.hops.filterIsInstance<RouteHop.SshJump>()
@@ -1708,14 +1696,17 @@ internal suspend fun AccountContainer.hopAuthFor(route: SshRoute): Map<String, o
             val connection = connections.find(hop.connectionId)
                 ?: error("jump_auth_missing: 跳板 ${hop.host}:${hop.port} 的连接不存在")
             val credentials = terminalCredentials(connection)
+            val privateKey = credentials.privateKey
+            val password = credentials.password
+            val passphrase = credentials.passphrase
             val credential = when {
-                credentials.privateKey != null && credentials.privateKey.isNotEmpty() ->
+                privateKey != null && privateKey.isNotEmpty() ->
                     one.zephyr.mobile.protocol.ssh.SshCredential.PrivateKey(
-                        credentials.privateKey.copyOf(),
-                        credentials.passphrase?.copyOf(),
+                        privateKey.copyOf(),
+                        passphrase?.copyOf(),
                     )
-                credentials.password != null && credentials.password.isNotEmpty() ->
-                    one.zephyr.mobile.protocol.ssh.SshCredential.Password(credentials.password.copyOf())
+                password != null && password.isNotEmpty() ->
+                    one.zephyr.mobile.protocol.ssh.SshCredential.Password(password.copyOf())
                 else -> error("jump_auth_missing: 跳板 ${connection.name.ifBlank { hop.host }} 没有可用的 SSH 凭据")
             }
             put(
@@ -1729,6 +1720,15 @@ internal suspend fun AccountContainer.hopAuthFor(route: SshRoute): Map<String, o
     }
 }
 
+/**
+ * Resolves the stored proxy/jump settings of a connection into the route the
+ * dialer will actually take.
+ *
+ * Mirrors the main end's resolveRoutePlan: a jumpHostIds entry that names a
+ * jumpHost resource follows its connectionId, and one that names no resource
+ * is itself a connection id. Rejections are configuration errors the user can
+ * fix, never a connect timeout.
+ */
 internal fun accountRoutePlanner(account: AccountContainer): ManagedSshSessionPool.RoutePlanner =
     ManagedSshSessionPool.RoutePlanner { connection ->
         when (val result = SshRoutePlanner.plan(
@@ -1756,6 +1756,13 @@ internal fun accountRoutePlanner(account: AccountContainer): ManagedSshSessionPo
         }
     }
 
+/**
+ * Reads one decrypted password for a single open attempt.
+ *
+ * Prefers the ref the mirror recorded and falls back to the conventional field
+ * ref, because a row written before the ref was persisted still has its secret
+ * under the derived name.
+ */
 internal fun AccountContainer.passwordChars(connection: Connection): CharArray? {
     val ref = secretRefForPresence(
         presence = connection.password,

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -377,20 +377,7 @@ private fun RouteSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -
             )
         }
 
-        ConnectionMode.JUMP -> {
-            val names = ui.jumpHosts.associate { it.id to it.name }
-            SettingsRow(
-                title = draft.current.jumpHostIds.joinToString(" → ") { names[it] ?: it }.ifBlank { "未选择 JumpHost" },
-                subtitle = "服务器列表中的 SSH 连接都可作为跳板机 · 依赖均有 use 能力",
-                showChevron = true,
-                showDivider = false,
-                onClick = {
-                    ui.jumpHosts.firstOrNull {
-                        it.id !in draft.current.jumpHostIds && it.id in ui.inventory.usableJumpHostIds
-                    }?.let { onIntent(EditorIntent.JumpAdded(it.id)) }
-                },
-            )
-        }
+        ConnectionMode.JUMP -> JumpChainEditor(ui, onIntent)
     }
 }
 
@@ -404,7 +391,17 @@ private fun RouteSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -
 @Composable
 private fun JumpChainEditor(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -> Unit) {
     val chain = ui.draft.current.jumpHostIds
-    val names = ui.jumpHosts.associate { it.id to it.name }
+    /* Labels prefer the JumpHost resource name when the stored id is a resource
+     * id, otherwise the SSH connection's own name — the same two sources the
+     * main end's jumpConnectionOptions / jumpHostConfig?.name path uses. */
+    val names = buildMap {
+        for (connection in ui.jumpConnections) {
+            put(connection.id, connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port)
+        }
+        for (host in ui.jumpHosts) {
+            put(host.id, host.name)
+        }
+    }
 
     Text(
         text = stringResource(R.string.editor_jump_chain, Connection.MAX_JUMP_DEPTH),
@@ -437,19 +434,33 @@ private fun JumpChainEditor(ui: ConnectionEditorUiState, onIntent: (EditorIntent
         }
     }
 
-    val addable = ui.jumpHosts.filter { it.id !in chain && it.id in ui.inventory.usableJumpHostIds }
+    /* Main-end jumpConnectionOptions: every usable SSH connection except the
+     * one being edited. JumpHost resources are extra named aliases for those
+     * same connections. */
+    val addable = buildList {
+        for (connection in ui.jumpConnections) {
+            if (connection.id !in chain && connection.id in ui.inventory.usableJumpHostIds) {
+                add(connection.id to (connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port))
+            }
+        }
+        for (host in ui.jumpHosts) {
+            if (host.id !in chain && host.id in ui.inventory.usableJumpHostIds && host.connectionId !in chain) {
+                add(host.id to host.name)
+            }
+        }
+    }
     if (addable.isNotEmpty() && chain.size < Connection.MAX_JUMP_DEPTH) {
         var expanded by remember { mutableStateOf(false) }
         OutlinedButton(onClick = { expanded = true }) {
             Text(stringResource(R.string.editor_jump_add))
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            for (host in addable) {
+            for ((id, label) in addable) {
                 DropdownMenuItem(
-                    text = { Text(host.name) },
+                    text = { Text(label) },
                     onClick = {
                         expanded = false
-                        onIntent(EditorIntent.JumpAdded(host.id))
+                        onIntent(EditorIntent.JumpAdded(id))
                     },
                 )
             }

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
@@ -33,6 +33,11 @@ data class ConnectionEditorUiState(
     val proxies: List<Proxy> = emptyList(),
     val sshKeys: List<SshKey> = emptyList(),
     val jumpHosts: List<JumpHost> = emptyList(),
+    /**
+     * SSH connections the user may pick as a hop, matching the main end's
+     * `jumpConnectionOptions`: any SSH row except the one being edited.
+     */
+    val jumpConnections: List<Connection> = emptyList(),
     /** Populated only after a save attempt, so a pristine form is not covered in red. */
     val issues: List<DraftIssue> = emptyList(),
     val saving: Boolean = false,
@@ -102,8 +107,9 @@ class ConnectionEditorViewModel(
             resources.observeProxies(ownerUserId),
             resources.observeSshKeys(ownerUserId),
             resources.observeJumpHosts(ownerUserId),
-        ) { proxies, keys, jumps -> Triple(proxies, keys, jumps) }
-            .onEach { (proxies, keys, jumps) -> applyInventory(proxies, keys, jumps) }
+            connections.observeAll(ownerUserId),
+        ) { proxies, keys, jumps, rows -> InventorySnapshot(proxies, keys, jumps, rows) }
+            .onEach(::applyInventory)
             .launchIn(viewModelScope)
     }
 
@@ -152,14 +158,42 @@ class ConnectionEditorViewModel(
     }
 
     /** Only rows carrying USE may be referenced by a route (ZEPHYR_PARITY.md 5.3). */
-    private fun applyInventory(proxies: List<Proxy>, keys: List<SshKey>, jumps: List<JumpHost>) {
+    private fun applyInventory(snapshot: InventorySnapshot) {
+        val jumpConnections = snapshot.rows.filter { row ->
+            row.protocol == Protocol.SSH &&
+                !row.isDeleted &&
+                row.capabilities.canUse &&
+                row.id != connectionId
+        }
+        val usableJumpIds = buildSet {
+            addAll(snapshot.jumps.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id })
+            /* Main-end jumpConnectionOptions stores a connection id directly.
+             * Treating only JumpHost resource ids as usable is what made a
+             * route saved on the server read as "路由需要修复" on the phone. */
+            addAll(jumpConnections.map { it.id })
+        }
         val usable = RouteInventory(
-            usableProxyIds = proxies.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
-            usableSshKeyIds = keys.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
-            usableJumpHostIds = jumps.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
+            usableProxyIds = snapshot.proxies.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
+            usableSshKeyIds = snapshot.keys.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
+            usableJumpHostIds = usableJumpIds,
         )
-        mutate { it.copy(inventory = usable, proxies = proxies, sshKeys = keys, jumpHosts = jumps) }
+        mutate {
+            it.copy(
+                inventory = usable,
+                proxies = snapshot.proxies,
+                sshKeys = snapshot.keys,
+                jumpHosts = snapshot.jumps,
+                jumpConnections = jumpConnections,
+            )
+        }
     }
+
+    private data class InventorySnapshot(
+        val proxies: List<Proxy>,
+        val keys: List<SshKey>,
+        val jumps: List<JumpHost>,
+        val rows: List<Connection>,
+    )
 
     private inline fun mutate(block: (ConnectionEditorUiState) -> ConnectionEditorUiState) {
         val current = page.value

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import one.zephyr.mobile.model.Connection
 import one.zephyr.mobile.model.MobileError
 import one.zephyr.mobile.model.Protocol
+import one.zephyr.mobile.protocol.ssh.HopAuth
 import one.zephyr.mobile.protocol.ssh.HostKeyPolicy
 import one.zephyr.mobile.protocol.ssh.RouteHop
 import one.zephyr.mobile.protocol.ssh.SshConnectOutcome
@@ -16,12 +17,18 @@ import one.zephyr.mobile.protocol.ssh.SshRoute
 /**
  * SSH [TerminalHost] over [SshEngine].
  *
- * Telnet stays on the unavailable host until its socket is injected. Direct SSH is the only live
- * path here; proxy / jump are rejected by the engine with a structured error.
+ * The stored route is dialled, not just the target's TCP port: a jump or proxy
+ * chain is part of the connection. Hard-coding a direct Target here is what
+ * made a working jump on the server fail on the phone after PR #45 wired the
+ * engine and the planner but never this host.
  */
 class SshTerminalHost(
     private val engine: SshEngine,
     private val findConnection: suspend (String) -> Connection?,
+    private val routePlanner: suspend (Connection) -> SshRoute = { connection ->
+        SshRoute(listOf(RouteHop.Target(connection.host, connection.port)))
+    },
+    private val hopAuthProvider: suspend (SshRoute) -> Map<String, HopAuth> = { emptyMap() },
 ) : TerminalHost {
 
     private val lastTarget = LinkedHashMap<String, RememberedTarget>()
@@ -36,11 +43,36 @@ class SshTerminalHost(
             return TerminalOpenOutcome.Failed(UnavailableTerminalHost.TELNET_NO_SOCKET)
         }
         lastTarget[request.sessionId] = RememberedTarget(request.host, request.port, presented = null)
-        val route = SshRoute(listOf(RouteHop.Target(request.host, request.port)))
         val credential = credentialOf(request) ?: run {
             request.wipe()
             return TerminalOpenOutcome.Failed(
                 MobileError.local(code = "auth_missing", message = "请先填写密码或选择 SSH Key", retryable = false),
+            )
+        }
+        val connection = findConnection(request.connectionId)
+        val route = try {
+            if (connection != null) routePlanner(connection)
+            else SshRoute(listOf(RouteHop.Target(request.host, request.port)))
+        } catch (error: Exception) {
+            request.wipe()
+            return TerminalOpenOutcome.Failed(
+                MobileError.local(
+                    code = "route_invalid",
+                    message = error.message ?: "路由配置无效",
+                    retryable = false,
+                ),
+            )
+        }
+        val hopCredentials = try {
+            hopAuthProvider(route)
+        } catch (error: Exception) {
+            request.wipe()
+            return TerminalOpenOutcome.Failed(
+                MobileError.local(
+                    code = "jump_auth_missing",
+                    message = error.message ?: "跳板机没有可用的 SSH 凭据",
+                    retryable = false,
+                ),
             )
         }
         val outcome = engine.connect(
@@ -49,6 +81,7 @@ class SshTerminalHost(
                 route = route,
                 username = request.username,
                 credential = credential,
+                hopCredentials = hopCredentials,
                 hostKeyPolicy = HostKeyPolicy.PROMPT_UNKNOWN_BLOCK_CHANGED,
                 cols = request.columns,
                 rows = request.rows,

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalHost.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalHost.kt
@@ -129,6 +129,8 @@ data class TerminalOpenRequest(
     val host: String,
     val port: Int,
     val username: String,
+    /** Needed so the host can look the connection up and resolve its stored route. */
+    val connectionId: String = "",
     val password: CharArray? = null,
     val privateKey: CharArray? = null,
     val passphrase: CharArray? = null,

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/TerminalViewModel.kt
@@ -348,6 +348,7 @@ class TerminalViewModel(
                 host = connection.host,
                 port = connection.port,
                 username = connection.username,
+                connectionId = connection.id,
                 password = credentials.password,
                 privateKey = credentials.privateKey,
                 passphrase = credentials.passphrase,

--- a/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/test/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHostTest.kt
@@ -21,7 +21,7 @@ class SshTerminalHostTest {
     @Test
     fun missingCredentialsNeverReachTheEngine() = runBlocking {
         val engine = RecordingEngine()
-        val host = SshTerminalHost(engine) { null }
+        val host = SshTerminalHost(engine, findConnection = { null })
         val outcome = host.open(
             TerminalOpenRequest(
                 sessionId = "s1",
@@ -39,7 +39,7 @@ class SshTerminalHostTest {
     @Test
     fun trustHostKeyForwardsTheRememberedAddress() = runBlocking {
         val engine = RecordingEngine()
-        val host = SshTerminalHost(engine) { null }
+        val host = SshTerminalHost(engine, findConnection = { null })
         val outcome = host.open(
             TerminalOpenRequest(
                 sessionId = "s1",
@@ -61,7 +61,7 @@ class SshTerminalHostTest {
     @Test
     fun trustHostKeyStillReachesTheEngineAfterTheRequestIsDropped() = runBlocking {
         val engine = RecordingEngine()
-        val host = SshTerminalHost(engine) { null }
+        val host = SshTerminalHost(engine, findConnection = { null })
         host.open(
             TerminalOpenRequest(
                 sessionId = "s1",
@@ -81,9 +81,61 @@ class SshTerminalHostTest {
     }
 
     @Test
+    fun aJumpRouteIsPassedToTheEngineWithPerHopCredentials() = runBlocking {
+        val engine = RecordingEngine()
+        val jump = one.zephyr.mobile.model.Connection(
+            id = "jump-1",
+            ownerUserId = "u1",
+            protocol = Protocol.SSH,
+            name = "bastion",
+            host = "bastion.internal",
+            port = 22,
+            username = "jump",
+        )
+        val target = jump.copy(id = "target-1", name = "prod", host = "10.0.0.5", username = "root")
+        val route = one.zephyr.mobile.protocol.ssh.SshRoute(
+            listOf(
+                one.zephyr.mobile.protocol.ssh.RouteHop.SshJump(
+                    host = jump.host,
+                    port = jump.port,
+                    username = jump.username,
+                    connectionId = jump.id,
+                ),
+                one.zephyr.mobile.protocol.ssh.RouteHop.Target(target.host, target.port),
+            ),
+        )
+        val hopAuth = one.zephyr.mobile.protocol.ssh.HopAuth(
+            username = "jump",
+            credential = one.zephyr.mobile.protocol.ssh.SshCredential.Password("hop-secret".toCharArray()),
+        )
+        val host = SshTerminalHost(
+            engine = engine,
+            findConnection = { id -> if (id == target.id) target else null },
+            routePlanner = { route },
+            hopAuthProvider = { mapOf(jump.id to hopAuth) },
+        )
+        host.open(
+            TerminalOpenRequest(
+                sessionId = "s1",
+                protocol = Protocol.SSH,
+                host = target.host,
+                port = target.port,
+                username = target.username,
+                connectionId = target.id,
+                password = "target-secret".toCharArray(),
+            ),
+        )
+        val seen = engine.lastRequest
+        requireNotNull(seen)
+        assertEquals(route, seen.route)
+        assertEquals(setOf(jump.id), seen.hopCredentials.keys)
+        assertEquals("root", seen.username)
+    }
+
+    @Test
     fun telnetStaysOnTheUnavailablePath() = runBlocking {
         val engine = RecordingEngine()
-        val host = SshTerminalHost(engine) { null }
+        val host = SshTerminalHost(engine, findConnection = { null })
         val outcome = host.open(
             TerminalOpenRequest(
                 sessionId = "s1",
@@ -105,9 +157,11 @@ class SshTerminalHostTest {
         var acceptedSession: String? = null
         var acceptedHost: String? = null
         var acceptedPort: Int? = null
+        var lastRequest: SshConnectRequest? = null
         override val isAvailable: Boolean = true
         override suspend fun connect(request: SshConnectRequest): SshConnectOutcome {
             connects += 1
+            lastRequest = request
             return SshConnectOutcome.Failed(one.zephyr.mobile.model.MobileError.local("unused", "unused"))
         }
         override fun output(sessionId: String): Flow<ByteArray> = emptyFlow()

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt
@@ -137,16 +137,31 @@ data class SshConnectRequest(
     val route: SshRoute,
     val username: String,
     /**
-     * Resolved credential material.
+     * Resolved credential material for the *target*.
      *
      * Held as a value only for the duration of the call. DEVELOPMENT.md 12 keeps connection secrets
      * in the native SessionSecretArena, never in a Kotlin field that outlives the dial.
      */
     val credential: SshCredential,
+    /**
+     * Per-hop credentials keyed by the hop's [RouteHop.SshJump.connectionId].
+     *
+     * The main end's `createRoutedSSHConnection` authenticates every hop with
+     * that hop's own connection (`connectSSHClient(hop)`), not the target's.
+     * Missing an entry here is a configuration error at that hop, not a
+     * fallback onto the target's password.
+     */
+    val hopCredentials: Map<String, HopAuth> = emptyMap(),
     val hostKeyPolicy: HostKeyPolicy,
     val cols: Int = 80,
     val rows: Int = 24,
     val encoding: String = "UTF-8",
+)
+
+/** Username + secret for one hop in a jump chain. */
+data class HopAuth(
+    val username: String,
+    val credential: SshCredential,
 )
 
 sealed interface SshCredential {

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRoute.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshRoute.kt
@@ -15,13 +15,21 @@ sealed interface RouteHop {
     data class Socks5(override val host: String, override val port: Int, val username: String) : RouteHop
     data class HttpConnect(override val host: String, override val port: Int, val username: String) : RouteHop
 
-    /** An intermediate SSH server the next hop is tunnelled through. */
+    /**
+     * An intermediate SSH server the next hop is tunnelled through.
+     *
+     * [username] and [connectionId] identify the hop's own SSH connection, not
+     * the target's: the main end authenticates each hop with `connectSSHClient(hop)`
+     * using that hop's stored secrets. Reusing the target's credential here is
+     * what made a working jump on the server fail on the phone.
+     */
     data class SshJump(
         override val host: String,
         override val port: Int,
         val username: String,
         val connectionId: String,
     ) : RouteHop
+
 
     data class Target(override val host: String, override val port: Int) : RouteHop
 }

--- a/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
+++ b/zephyr_one/mobile/android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt
@@ -121,7 +121,7 @@ class SshjEngine internal constructor(
                     throw error
                 }
                 stage = ConnectStage.AUTHENTICATION
-                authenticate(hopClient, request)
+                authenticateHop(hopClient, jump, request)
                 stage = ConnectStage.TRANSPORT
                 upstream = hopClient
             }
@@ -587,11 +587,26 @@ class SshjEngine internal constructor(
     }
 
     private fun authenticate(client: SSHClient, request: SshConnectRequest) {
-        when (val credential = request.credential) {
-            is SshCredential.Password -> client.authPassword(request.username, String(credential.value))
+        applyAuth(client, request.username, request.credential)
+    }
+
+    /**
+     * Main-end `connectSSHClient(hop)`: the hop authenticates as itself. Falling
+     * back to the target's username/password is the failure that made a jump
+     * that works on the server fail on the phone.
+     */
+    private fun authenticateHop(client: SSHClient, jump: RouteHop.SshJump, request: SshConnectRequest) {
+        val hop = request.hopCredentials[jump.connectionId]
+            ?: error("jump_auth_missing: 跳板 ${jump.host}:${jump.port} 没有可用的 SSH 凭据")
+        applyAuth(client, hop.username, hop.credential)
+    }
+
+    private fun applyAuth(client: SSHClient, username: String, credential: SshCredential) {
+        when (credential) {
+            is SshCredential.Password -> client.authPassword(username, String(credential.value))
             is SshCredential.PrivateKey -> {
                 val provider = SshPrivateKeyLoader.load(String(credential.pem), credential.passphrase)
-                client.authPublickey(request.username, provider)
+                client.authPublickey(username, provider)
             }
             SshCredential.Interactive -> error("keyboard-interactive 尚未接入")
         }

--- a/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
@@ -51,14 +51,44 @@ test('dialers resolve the stored route rather than always dialling direct', () =
   const root = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
   const pool = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ManagedSshSessionPool.kt');
   const tester = read('android/app/src/main/kotlin/one/zephyr/mobile/app/SshConnectionTester.kt');
+  const host = read('android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SshTerminalHost.kt');
 
   /* The regression: every dialer hard-coded SshRoute([Target]) and the planner
    * was dead code, so a configured jump/proxy chain was silently ignored and
-   * the unreachable direct target read as "not configured / unusable". */
+   * the unreachable direct target read as "not configured / unusable". The
+   * terminal host was the last remaining bypass after PR #45. */
   assert.match(root, /accountRoutePlanner\(account\)/);
   assert.match(pool, /routePlanner\.plan\(connection\)/);
   assert.doesNotMatch(pool, /route = SshRoute\(listOf\(RouteHop\.Target\(connection\.host, connection\.port\)\)\)/);
   assert.match(tester, /routePlanner\(connection\)/);
+  assert.match(host, /routePlanner\(connection\)/);
+  assert.doesNotMatch(host, /val route = SshRoute\(listOf\(RouteHop\.Target\(request\.host, request\.port\)\)\)/);
+});
+
+test('every hop authenticates with its own stored secrets not the target\'s', () => {
+  const engine = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshjEngine.kt');
+  const request = read('android/protocol-ssh/src/main/kotlin/one/zephyr/mobile/protocol/ssh/SshEngine.kt');
+  const root = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+  /* Main-end createRoutedSSHConnection calls connectSSHClient(hop) per hop.
+   * Reusing request.credential (the target's password) on a jump is the
+   * failure that made a working jump on the server fail on the phone. */
+  assert.match(request, /val hopCredentials: Map<String, HopAuth>/);
+  assert.match(engine, /authenticateHop\(hopClient, jump, request\)/);
+  assert.match(engine, /request\.hopCredentials\[jump\.connectionId\]/);
+  assert.match(root, /fun AccountContainer\.hopAuthFor/);
+  assert.match(root, /hopAuthProvider = \{ route -> account\.hopAuthFor\(route\) \}/);
+});
+
+test('the editor jump picker lists SSH connections like the main end', () => {
+  const screen = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt');
+  const vm = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt');
+  /* JumpChainEditor existed but RouteSection never composed it: tapping the
+   * JUMP row silently added the first JumpHost resource, and SSH connections
+   * (what the main end actually stores in jumpHostIds) were not even listed. */
+  assert.match(screen, /ConnectionMode\.JUMP -> JumpChainEditor\(ui, onIntent\)/);
+  assert.match(screen, /for \(connection in ui\.jumpConnections\)/);
+  assert.match(vm, /val jumpConnections: List<Connection>/);
+  assert.match(vm, /row\.protocol == Protocol\.SSH/);
 });
 
 test('main-end jump resolution semantics are pinned in one place', () => {


### PR DESCRIPTION
PR #45 让引擎能拨跳板链，但移动端跳板仍不可用。对照主端后是三处没对齐，不是引擎本身。

## 根因

1. **终端拨号仍直连** — `SshTerminalHost` 硬编码 `SshRoute([Target])`。用户点连接走的是终端 tab，planner 和 hop 循环从未执行。
2. **每跳复用目标凭据** — 主端 `createRoutedSSHConnection` 对 hop N 调用 `connectSSHClient(hop)`，用的是跳板自己的密码/密钥。移动端把目标用户名密码套在每一跳上，跳板和目标凭据不同时（常见情况）认证失败。
3. **编辑器 UI 没接上** — `JumpChainEditor` 写了但 `RouteSection` 从未 compose。点 JUMP 只是静默塞进第一个 JumpHost 资源；主端 `jumpHostIds` 存的是 SSH 连接 id，编辑器既不列出这些连接，草稿还把裸连接 id 判成「路由需要修复」。

## 修复（与主端对齐）

- `SshConnectRequest.hopCredentials`：按 hop 的 connectionId 取该跳自己的凭据；引擎 `authenticateHop` 不再回落到目标密码。
- 三个拨号点（`SshTerminalHost` / `ManagedSshSessionPool` / `DirectSshConnectionTester`）全部走 planner + `hopAuthFor`。
- 编辑器：`RouteSection` 真正渲染 `JumpChainEditor`；候选 = 可用 SSH 连接（对齐 `jumpConnectionOptions`）+ JumpHost 别名；inventory 同时接受资源 id 和连接 id。

## 测试

`ssh-jump-route-contract.test.mjs` 新增 3 条：终端 host 不再直连、`authenticateHop`/`hopAuthFor`、JumpChainEditor 与 SSH 连接列表。移动端 374 pass / 10 fail（基线 PaX/Java）；桌面 92/92。
