### PR TITLE
fix(mobile): make the jump chain actually pickable

### DIFF
--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import one.zephyr.mobile.ui.component.ActionSheet
+import one.zephyr.mobile.ui.component.ActionSheetGroup
+import one.zephyr.mobile.ui.component.ActionSheetItem
 import one.zephyr.mobile.ui.component.AlertDialog
 import one.zephyr.mobile.ui.component.AssistChip
 import one.zephyr.mobile.ui.component.Button
@@ -111,6 +114,7 @@ fun ConnectionEditorScreen(
         )
 
         PageStateScaffold(state = state, modifier = Modifier.fillMaxSize()) { ui ->
+            var pickingJump by remember { mutableStateOf(false) }
             Box(Modifier.fillMaxSize()) {
                 Column(
                     modifier = Modifier
@@ -124,7 +128,7 @@ fun ConnectionEditorScreen(
                             when (section) {
                                 EditorSection.BASIC -> BasicSection(ui, onIntent)
                                 EditorSection.AUTH -> AuthSection(ui, onIntent)
-                                EditorSection.ROUTE -> RouteSection(ui, onIntent)
+                                EditorSection.ROUTE -> RouteSection(ui, onIntent, onPickJump = { pickingJump = true })
                                 EditorSection.RDP_CHANNELS -> RdpChannelSection(ui, onIntent)
                                 EditorSection.RDP_DISPLAY -> RdpDisplaySection(ui, onIntent)
                                 EditorSection.FILE_SYNC -> FileSyncSection(ui, onIntent)
@@ -145,6 +149,15 @@ fun ConnectionEditorScreen(
                 ) {
                     FixedActions(ui = ui, onIntent = onIntent)
                 }
+                JumpHostPickerSheet(
+                    visible = pickingJump,
+                    ui = ui,
+                    onDismiss = { pickingJump = false },
+                    onPick = { id ->
+                        pickingJump = false
+                        onIntent(EditorIntent.JumpAdded(id))
+                    },
+                )
             }
         }
     }
@@ -345,16 +358,16 @@ private fun AuthSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) ->
 }
 
 @Composable
-private fun RouteSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -> Unit) {
+private fun RouteSection(
+    ui: ConnectionEditorUiState,
+    onIntent: (EditorIntent) -> Unit,
+    onPickJump: () -> Unit,
+) {
     val draft = ui.draft
     val mode = draft.current.connectionMode
     SettingsRow(
         title = "方式",
-        value = when (mode) {
-            ConnectionMode.DIRECT -> modeLabel(mode)
-            ConnectionMode.PROXY -> modeLabel(mode)
-            ConnectionMode.JUMP -> "JumpHost · ${draft.current.jumpHostIds.size} 级"
-        },
+        value = modeLabel(mode),
         showChevron = true,
         showDivider = mode != ConnectionMode.DIRECT,
         onClick = {
@@ -377,94 +390,134 @@ private fun RouteSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -
             )
         }
 
-        ConnectionMode.JUMP -> JumpChainEditor(ui, onIntent)
+        ConnectionMode.JUMP -> JumpChainEditor(ui, onIntent, onPickJump)
     }
 }
 
 /**
- * Ordered jump chain.
+ * Ordered jump chain, rendered entirely inside the GroupCard.
  *
- * Reordering uses explicit up/down buttons rather than a drag handle: the chain is at most 8 rows,
- * order is semantically load-bearing, and buttons carry accessibility labels a drag gesture cannot
- * (SCREEN_CATALOG.md 26).
+ * The caption used to sit outside the card and was clipped by GroupCard's
+ * rounded clip. The add control used a DropdownMenu inside that same clipped
+ * scrolling card, so it either never appeared or could not be tapped. Both
+ * rows are SettingsRow now; picking a hop opens a full-screen ActionSheet
+ * above the card.
  */
 @Composable
-private fun JumpChainEditor(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -> Unit) {
+private fun JumpChainEditor(
+    ui: ConnectionEditorUiState,
+    onIntent: (EditorIntent) -> Unit,
+    onPickJump: () -> Unit,
+) {
     val chain = ui.draft.current.jumpHostIds
-    /* Labels prefer the JumpHost resource name when the stored id is a resource
-     * id, otherwise the SSH connection's own name — the same two sources the
-     * main end's jumpConnectionOptions / jumpHostConfig?.name path uses. */
-    val names = buildMap {
-        for (connection in ui.jumpConnections) {
-            put(connection.id, connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port)
-        }
-        for (host in ui.jumpHosts) {
-            put(host.id, host.name)
-        }
-    }
-
-    Text(
-        text = stringResource(R.string.editor_jump_chain, Connection.MAX_JUMP_DEPTH),
-        style = ZephyrTheme.typography.caption,
-    )
+    val names = jumpHopLabels(ui)
+    val addable = jumpAddable(ui)
     ui.issueFor("jumpHostIds")?.let { IssueText(it) }
 
     chain.forEachIndexed { index, id ->
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = (index + 1).toString() + ". " + (names[id] ?: id),
-                style = ZephyrTheme.typography.mono,
-                modifier = Modifier.weight(1f),
-            )
-            IconButton(
-                onClick = { onIntent(EditorIntent.JumpMoved(index, index - 1)) },
-                enabled = index > 0,
-            ) {
-                Icon(ZephyrIcons.ArrowUp, contentDescription = stringResource(R.string.editor_jump_up))
-            }
-            IconButton(
-                onClick = { onIntent(EditorIntent.JumpMoved(index, index + 1)) },
-                enabled = index < chain.size - 1,
-            ) {
-                Icon(ZephyrIcons.ArrowDown, contentDescription = stringResource(R.string.editor_jump_down))
-            }
-            IconButton(onClick = { onIntent(EditorIntent.JumpRemoved(id)) }) {
-                Icon(ZephyrIcons.Close, contentDescription = stringResource(R.string.editor_jump_remove))
-            }
-        }
+        SettingsRow(
+            title = (index + 1).toString() + ". " + (names[id] ?: id),
+            showDivider = true,
+            trailing = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(
+                        onClick = { onIntent(EditorIntent.JumpMoved(index, index - 1)) },
+                        enabled = index > 0,
+                    ) {
+                        Icon(ZephyrIcons.ArrowUp, contentDescription = stringResource(R.string.editor_jump_up))
+                    }
+                    IconButton(
+                        onClick = { onIntent(EditorIntent.JumpMoved(index, index + 1)) },
+                        enabled = index < chain.size - 1,
+                    ) {
+                        Icon(ZephyrIcons.ArrowDown, contentDescription = stringResource(R.string.editor_jump_down))
+                    }
+                    IconButton(onClick = { onIntent(EditorIntent.JumpRemoved(id)) }) {
+                        Icon(ZephyrIcons.Close, contentDescription = stringResource(R.string.editor_jump_remove))
+                    }
+                }
+            },
+        )
     }
 
-    /* Main-end jumpConnectionOptions: every usable SSH connection except the
-     * one being edited. JumpHost resources are extra named aliases for those
-     * same connections. */
-    val addable = buildList {
+    val canAdd = chain.size < Connection.MAX_JUMP_DEPTH
+    SettingsRow(
+        title = stringResource(R.string.editor_jump_add),
+        subtitle = when {
+            !canAdd -> stringResource(R.string.editor_jump_full)
+            addable.isEmpty() -> stringResource(R.string.editor_jump_none)
+            chain.isEmpty() -> stringResource(R.string.editor_jump_empty)
+            else -> stringResource(R.string.editor_jump_chain, Connection.MAX_JUMP_DEPTH)
+        },
+        showChevron = canAdd && addable.isNotEmpty(),
+        showDivider = false,
+        onClick = if (canAdd && addable.isNotEmpty()) onPickJump else null,
+    )
+}
+
+@Composable
+private fun JumpHostPickerSheet(
+    visible: Boolean,
+    ui: ConnectionEditorUiState,
+    onDismiss: () -> Unit,
+    onPick: (String) -> Unit,
+) {
+    val addable = jumpAddable(ui)
+    ActionSheet(
+        visible = visible,
+        onDismiss = onDismiss,
+        groups = listOf(
+            ActionSheetGroup(
+                title = stringResource(R.string.editor_jump_add),
+                items = addable.map { (id, label) ->
+                    ActionSheetItem(label = label, onClick = { onPick(id) })
+                },
+            ),
+            ActionSheetGroup(
+                items = listOf(
+                    ActionSheetItem(
+                        label = stringResource(R.string.dialog_cancel),
+                        cancel = true,
+                        onClick = onDismiss,
+                    ),
+                ),
+            ),
+        ),
+    )
+}
+
+/**
+ * Main-end jumpConnectionOptions: every usable SSH connection except the one
+ * being edited. JumpHost resources are extra named aliases for those same
+ * connections.
+ */
+private fun jumpAddable(ui: ConnectionEditorUiState): List<Pair<String, String>> {
+    val chain = ui.draft.current.jumpHostIds
+    val labels = jumpHopLabels(ui)
+    val seen = mutableSetOf<String>()
+    return buildList {
         for (connection in ui.jumpConnections) {
-            if (connection.id !in chain && connection.id in ui.inventory.usableJumpHostIds) {
-                add(connection.id to (connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port))
+            if (connection.id !in chain && connection.id in ui.inventory.usableJumpHostIds && seen.add(connection.id)) {
+                add(connection.id to (labels[connection.id] ?: connection.host))
             }
         }
         for (host in ui.jumpHosts) {
-            if (host.id !in chain && host.id in ui.inventory.usableJumpHostIds && host.connectionId !in chain) {
-                add(host.id to host.name)
+            if (host.id !in chain && host.id in ui.inventory.usableJumpHostIds && host.connectionId !in chain && seen.add(host.id)) {
+                add(host.id to (labels[host.id] ?: host.name))
             }
         }
     }
-    if (addable.isNotEmpty() && chain.size < Connection.MAX_JUMP_DEPTH) {
-        var expanded by remember { mutableStateOf(false) }
-        OutlinedButton(onClick = { expanded = true }) {
-            Text(stringResource(R.string.editor_jump_add))
-        }
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            for ((id, label) in addable) {
-                DropdownMenuItem(
-                    text = { Text(label) },
-                    onClick = {
-                        expanded = false
-                        onIntent(EditorIntent.JumpAdded(id))
-                    },
-                )
-            }
-        }
+}
+
+private fun jumpHopLabels(ui: ConnectionEditorUiState): Map<String, String> = buildMap {
+    for (connection in ui.jumpConnections) {
+        put(
+            connection.id,
+            connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port,
+        )
+    }
+    for (host in ui.jumpHosts) {
+        put(host.id, host.name)
     }
 }
 

--- a/zephyr_one/mobile/android/feature-connections/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/feature-connections/src/main/res/values-en/strings.xml
@@ -78,6 +78,9 @@
     <string name="editor_none">None</string>
     <string name="editor_jump_chain">Jump chain (ordered, max %1$d hops)</string>
     <string name="editor_jump_add">Add hop</string>
+    <string name="editor_jump_empty">Pick an existing SSH connection as a hop</string>
+    <string name="editor_jump_none">No usable SSH connection to jump through. Save an SSH host first.</string>
+    <string name="editor_jump_full">Already at the 8-hop limit</string>
     <string name="editor_jump_remove">Remove hop</string>
     <string name="editor_jump_up">Move up</string>
     <string name="editor_jump_down">Move down</string>

--- a/zephyr_one/mobile/android/feature-connections/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/feature-connections/src/main/res/values/strings.xml
@@ -92,6 +92,9 @@
     <string name="editor_none">不使用</string>
     <string name="editor_jump_chain">跳板链（有序，最多 %1$d 级）</string>
     <string name="editor_jump_add">添加跳板</string>
+    <string name="editor_jump_empty">从已有 SSH 连接里选一台作为跳板</string>
+    <string name="editor_jump_none">没有可用的 SSH 连接可作跳板，先保存一台 SSH 主机</string>
+    <string name="editor_jump_full">已到 8 级上限</string>
     <string name="editor_jump_remove">移除此级</string>
     <string name="editor_jump_up">上移</string>
     <string name="editor_jump_down">下移</string>

--- a/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
@@ -85,10 +85,23 @@ test('the editor jump picker lists SSH connections like the main end', () => {
   /* JumpChainEditor existed but RouteSection never composed it: tapping the
    * JUMP row silently added the first JumpHost resource, and SSH connections
    * (what the main end actually stores in jumpHostIds) were not even listed. */
-  assert.match(screen, /ConnectionMode\.JUMP -> JumpChainEditor\(ui, onIntent\)/);
+  assert.match(screen, /ConnectionMode\.JUMP -> JumpChainEditor\(ui, onIntent, onPickJump\)/);
   assert.match(screen, /for \(connection in ui\.jumpConnections\)/);
   assert.match(vm, /val jumpConnections: List<Connection>/);
   assert.match(vm, /row\.protocol == Protocol\.SSH/);
+});
+
+test('the jump chain is selectable inside the card via a full-screen sheet', () => {
+  const screen = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt');
+  /* The caption sat outside GroupCard and was clipped. The add button was a
+   * DropdownMenu inside that clipped scrolling card, so an empty chain showed
+   * "JumpHost · 0 级" and nothing tappable. The add row is always composed;
+   * picking opens ActionSheet above the card. */
+  assert.match(screen, /JumpHostPickerSheet\(/);
+  assert.match(screen, /title = stringResource\(R\.string\.editor_jump_add\)/);
+  assert.match(screen, /onClick = if \(canAdd && addable\.isNotEmpty\(\)\) onPickJump else null/);
+  assert.doesNotMatch(screen, /DropdownMenu\(expanded = expanded[\s\S]*JumpAdded/);
+  assert.doesNotMatch(screen, /跳板链（有序/);
 });
 
 test('main-end jump resolution semantics are pinned in one place', () => {


### PR DESCRIPTION
pre30 的跳板 UI 不能用：标题溢出卡片，「JumpHost · 0 级」下面没有可点子项。

## 根因

- 「跳板链（有序，最多 8 级）」画在 `GroupCard` 外面，被卡片圆角 clip 切掉。
- 添加是卡片内部的 `DropdownMenu`。链为空时 `addable` 为空或菜单被 clip/滚动裁掉，屏幕上只剩不可点的「0 级」。

## 修复

- 每一跳都是卡片内的 `SettingsRow`（上移/下移/删除）。
- 「添加跳板」行始终存在；有可选 SSH 连接时点开全屏 `ActionSheet`（对齐主端 `jumpConnectionOptions`）。
- 没有可用 SSH、或已到 8 级，行上写明原因，不再藏按钮。

只改了编辑器 UI 和契约，没有夹带别的改动。
