### PR TITLE
fix(mobile): keep jump-host inventory that arrives while the editor loads

### DIFF
--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -410,7 +410,7 @@ private fun JumpChainEditor(
     onPickJump: () -> Unit,
 ) {
     val chain = ui.draft.current.jumpHostIds
-    val names = jumpHopLabels(ui)
+    val names = JumpPicker.labels(ui.jumpConnections, ui.jumpHosts)
     val addable = jumpAddable(ui)
     ui.issueFor("jumpHostIds")?.let { IssueText(it) }
 
@@ -491,35 +491,13 @@ private fun JumpHostPickerSheet(
  * being edited. JumpHost resources are extra named aliases for those same
  * connections.
  */
-private fun jumpAddable(ui: ConnectionEditorUiState): List<Pair<String, String>> {
-    val chain = ui.draft.current.jumpHostIds
-    val labels = jumpHopLabels(ui)
-    val seen = mutableSetOf<String>()
-    return buildList {
-        for (connection in ui.jumpConnections) {
-            if (connection.id !in chain && connection.id in ui.inventory.usableJumpHostIds && seen.add(connection.id)) {
-                add(connection.id to (labels[connection.id] ?: connection.host))
-            }
-        }
-        for (host in ui.jumpHosts) {
-            if (host.id !in chain && host.id in ui.inventory.usableJumpHostIds && host.connectionId !in chain && seen.add(host.id)) {
-                add(host.id to (labels[host.id] ?: host.name))
-            }
-        }
-    }
-}
-
-private fun jumpHopLabels(ui: ConnectionEditorUiState): Map<String, String> = buildMap {
-    for (connection in ui.jumpConnections) {
-        put(
-            connection.id,
-            connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port,
-        )
-    }
-    for (host in ui.jumpHosts) {
-        put(host.id, host.name)
-    }
-}
+private fun jumpAddable(ui: ConnectionEditorUiState): List<Pair<String, String>> =
+    JumpPicker.addable(
+        connections = ui.jumpConnections,
+        jumps = ui.jumpHosts,
+        chain = ui.draft.current.jumpHostIds,
+        usableIds = ui.inventory.usableJumpHostIds,
+    )
 
 @Composable
 private fun RdpChannelSection(ui: ConnectionEditorUiState, onIntent: (EditorIntent) -> Unit) {

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
@@ -98,6 +98,15 @@ class ConnectionEditorViewModel(
     val message: SharedFlow<String> = messages
     private var revealExpiryJob: kotlinx.coroutines.Job? = null
 
+    /**
+     * Last inventory emission, kept even while [page] is still InitialLoading.
+     *
+     * `mutate` no-ops until the form is Content, and Room's first snapshot often arrives during
+     * `connections.find()`. Dropping it left the hop picker empty forever: the mirror does not
+     * re-emit until something actually changes.
+     */
+    private var latestInventory: JumpInventory? = null
+
     init {
         registerSensitiveSink(this)
         viewModelScope.launch { load() }
@@ -108,7 +117,7 @@ class ConnectionEditorViewModel(
             resources.observeSshKeys(ownerUserId),
             resources.observeJumpHosts(ownerUserId),
             connections.observeAll(ownerUserId),
-        ) { proxies, keys, jumps, rows -> InventorySnapshot(proxies, keys, jumps, rows) }
+        ) { proxies, keys, jumps, rows -> JumpInventory(proxies, keys, jumps, rows) }
             .onEach(::applyInventory)
             .launchIn(viewModelScope)
     }
@@ -116,13 +125,13 @@ class ConnectionEditorViewModel(
     private suspend fun load() {
         if (duplicateSourceId != null) {
             val source = connections.find(duplicateSourceId)
-            page.value = if (
+            if (
                 source == null || source.isDeleted ||
                 source.residency != one.zephyr.mobile.model.Residency.OWNED
             ) {
-                PageState.NotFoundOrRevoked
+                page.value = PageState.NotFoundOrRevoked
             } else {
-                PageState.Content(
+                show(
                     ConnectionEditorUiState(
                         ConnectionDraft.duplicate(source, ownerUserId, newIdFactory()),
                     ),
@@ -131,7 +140,7 @@ class ConnectionEditorViewModel(
             return
         }
         if (connectionId == null) {
-            page.value = PageState.Content(
+            show(
                 ConnectionEditorUiState(
                     ConnectionDraft.create(ownerUserId, newIdFactory(), protocol = initialProtocol),
                 ),
@@ -139,12 +148,12 @@ class ConnectionEditorViewModel(
             return
         }
         val existing = connections.find(connectionId)
-        page.value = when {
-            existing == null || existing.isDeleted -> PageState.NotFoundOrRevoked
+        when {
+            existing == null || existing.isDeleted -> page.value = PageState.NotFoundOrRevoked
             // A row the user may see but not edit opens read-only rather than pretending to save.
             !existing.capabilities.canEdit ->
-                PageState.PermissionDenied(Capability.EDIT, REASON_NO_EDIT)
-            else -> PageState.Content(
+                page.value = PageState.PermissionDenied(Capability.EDIT, REASON_NO_EDIT)
+            else -> show(
                 ConnectionEditorUiState(
                     draft = ConnectionDraft.edit(existing),
                     passwordRevealAllowed = ConnectionPasswordRevealPolicy.allowed(
@@ -157,43 +166,17 @@ class ConnectionEditorViewModel(
         }
     }
 
-    /** Only rows carrying USE may be referenced by a route (ZEPHYR_PARITY.md 5.3). */
-    private fun applyInventory(snapshot: InventorySnapshot) {
-        val jumpConnections = snapshot.rows.filter { row ->
-            row.protocol == Protocol.SSH &&
-                !row.isDeleted &&
-                row.capabilities.canUse &&
-                row.id != connectionId
-        }
-        val usableJumpIds = buildSet {
-            addAll(snapshot.jumps.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id })
-            /* Main-end jumpConnectionOptions stores a connection id directly.
-             * Treating only JumpHost resource ids as usable is what made a
-             * route saved on the server read as "路由需要修复" on the phone. */
-            addAll(jumpConnections.map { it.id })
-        }
-        val usable = RouteInventory(
-            usableProxyIds = snapshot.proxies.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
-            usableSshKeyIds = snapshot.keys.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id }.toSet(),
-            usableJumpHostIds = usableJumpIds,
-        )
-        mutate {
-            it.copy(
-                inventory = usable,
-                proxies = snapshot.proxies,
-                sshKeys = snapshot.keys,
-                jumpHosts = snapshot.jumps,
-                jumpConnections = jumpConnections,
-            )
-        }
+    /** Opens the form and stamps any inventory that arrived while it was still loading. */
+    private fun show(ui: ConnectionEditorUiState) {
+        page.value = PageState.Content(ui)
+        latestInventory?.let(::applyInventory)
     }
 
-    private data class InventorySnapshot(
-        val proxies: List<Proxy>,
-        val keys: List<SshKey>,
-        val jumps: List<JumpHost>,
-        val rows: List<Connection>,
-    )
+    /** Only rows carrying USE may be referenced by a route (ZEPHYR_PARITY.md 5.3). */
+    private fun applyInventory(snapshot: JumpInventory) {
+        latestInventory = snapshot
+        mutate { it.withJumpInventory(snapshot, connectionId) }
+    }
 
     private inline fun mutate(block: (ConnectionEditorUiState) -> ConnectionEditorUiState) {
         val current = page.value

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/JumpPicker.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/JumpPicker.kt
@@ -1,0 +1,101 @@
+package one.zephyr.mobile.feature.connections
+
+import one.zephyr.mobile.model.Connection
+import one.zephyr.mobile.model.JumpHost
+import one.zephyr.mobile.model.Protocol
+import one.zephyr.mobile.model.Proxy
+import one.zephyr.mobile.model.SshKey
+
+/**
+ * Snapshot of every route dependency the hop picker and validator need.
+ *
+ * Held separately from [ConnectionEditorUiState] so an emission that arrives while the editor is
+ * still [one.zephyr.mobile.model.PageState.InitialLoading] can be replayed onto the opened form
+ * instead of being dropped on the floor.
+ */
+internal data class JumpInventory(
+    val proxies: List<Proxy> = emptyList(),
+    val keys: List<SshKey> = emptyList(),
+    val jumps: List<JumpHost> = emptyList(),
+    val rows: List<Connection> = emptyList(),
+)
+
+/**
+ * Main-end `jumpConnectionOptions`: every live SSH connection except the one being edited.
+ *
+ * Capability.USE is required because a hop without USE cannot be authenticated. Owned rows carry
+ * the full owner set, so this does not hide the user's own hosts.
+ */
+internal object JumpPicker {
+
+    fun connections(rows: List<Connection>, editingId: String?): List<Connection> =
+        rows.filter { row ->
+            row.protocol == Protocol.SSH &&
+                !row.isDeleted &&
+                row.capabilities.canUse &&
+                row.id != editingId
+        }
+
+    fun usableIds(connections: List<Connection>, jumps: List<JumpHost>): Set<String> = buildSet {
+        addAll(connections.map { it.id })
+        addAll(jumps.filter { it.capabilities.canUse && it.deletedAt == null }.map { it.id })
+    }
+
+    fun labels(connections: List<Connection>, jumps: List<JumpHost>): Map<String, String> = buildMap {
+        for (connection in connections) {
+            put(
+                connection.id,
+                connection.name.ifBlank { connection.host } + " · " + connection.host + ":" + connection.port,
+            )
+        }
+        for (host in jumps) {
+            put(host.id, host.name)
+        }
+    }
+
+    fun addable(
+        connections: List<Connection>,
+        jumps: List<JumpHost>,
+        chain: List<String>,
+        usableIds: Set<String>,
+    ): List<Pair<String, String>> {
+        val names = labels(connections, jumps)
+        val seen = mutableSetOf<String>()
+        return buildList {
+            for (connection in connections) {
+                if (connection.id !in chain && connection.id in usableIds && seen.add(connection.id)) {
+                    add(connection.id to (names[connection.id] ?: connection.host))
+                }
+            }
+            for (host in jumps) {
+                if (host.id !in chain && host.id in usableIds && host.connectionId !in chain && seen.add(host.id)) {
+                    add(host.id to (names[host.id] ?: host.name))
+                }
+            }
+        }
+    }
+}
+
+internal fun ConnectionEditorUiState.withJumpInventory(
+    snapshot: JumpInventory,
+    editingId: String?,
+): ConnectionEditorUiState {
+    val jumpConnections = JumpPicker.connections(snapshot.rows, editingId)
+    return copy(
+        inventory = RouteInventory(
+            usableProxyIds = snapshot.proxies
+                .filter { it.capabilities.canUse && it.deletedAt == null }
+                .map { it.id }
+                .toSet(),
+            usableSshKeyIds = snapshot.keys
+                .filter { it.capabilities.canUse && it.deletedAt == null }
+                .map { it.id }
+                .toSet(),
+            usableJumpHostIds = JumpPicker.usableIds(jumpConnections, snapshot.jumps),
+        ),
+        proxies = snapshot.proxies,
+        sshKeys = snapshot.keys,
+        jumpHosts = snapshot.jumps,
+        jumpConnections = jumpConnections,
+    )
+}

--- a/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/JumpPickerMutationTest.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/JumpPickerMutationTest.kt
@@ -1,0 +1,77 @@
+package one.zephyr.mobile.feature.connections
+
+import one.zephyr.mobile.model.JumpHost
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source mutation: if `show()` stops replaying the inventory that arrived during
+ * load(), a device full of SSH hosts renders "没有可用的 SSH 连接可作跳板".
+ */
+class JumpPickerMutationTest {
+
+    private val vmSource: String by lazy {
+        val relative = "src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt"
+        val start = File(".").canonicalFile
+        val file = generateSequence(start) { it.parentFile }
+            .flatMap { root ->
+                sequenceOf(
+                    File(root, relative),
+                    File(root, "feature-connections/$relative"),
+                    File(root, "zephyr_one/mobile/android/feature-connections/$relative"),
+                )
+            }
+            .first { it.exists() }
+        file.readText()
+    }
+
+    @Test
+    fun `editor viewmodel still replays inventory dropped during load`() {
+        val vm = vmSource
+        assertTrue(
+            "latestInventory must be kept across InitialLoading",
+            vm.contains("private var latestInventory: JumpInventory? = null"),
+        )
+        assertTrue(
+            "show() must stamp the held snapshot onto the opened form",
+            vm.contains("latestInventory?.let(::applyInventory)"),
+        )
+        assertTrue(
+            "applyInventory must not depend on page already being Content to remember the snapshot",
+            vm.contains("latestInventory = snapshot"),
+        )
+        val show = vm.substringAfter("private fun show(").substringBefore("private fun applyInventory")
+        val applyIndex = show.indexOf("latestInventory?.let(::applyInventory)")
+        val contentIndex = show.indexOf("page.value = PageState.Content(ui)")
+        assertTrue("show() must become Content before replaying", contentIndex in 0 until applyIndex)
+    }
+
+    @Test
+    fun `a picker with hosts is not empty after the dropped-then-replayed merge`() {
+        val hop = Fixtures.connection(id = "c-a", name = "jump-a", host = "10.0.0.1")
+        val target = Fixtures.connection(id = "c-target", name = "target", host = "10.0.0.9")
+        val alias = JumpHost(id = "j-a", ownerUserId = Fixtures.OWNER, name = "named-jump", connectionId = "c-a")
+        val emptyForm = ConnectionEditorUiState(draft = ConnectionDraft.edit(target))
+        /* The mutation: skip withJumpInventory and the addable list stays empty. */
+        val skipped = JumpPicker.addable(
+            connections = emptyForm.jumpConnections,
+            jumps = emptyForm.jumpHosts,
+            chain = emptyForm.draft.current.jumpHostIds,
+            usableIds = emptyForm.inventory.usableJumpHostIds,
+        )
+        assertTrue(skipped.isEmpty())
+        val replayed = emptyForm.withJumpInventory(
+            JumpInventory(rows = listOf(target, hop), jumps = listOf(alias)),
+            editingId = target.id,
+        )
+        val addable = JumpPicker.addable(
+            connections = replayed.jumpConnections,
+            jumps = replayed.jumpHosts,
+            chain = replayed.draft.current.jumpHostIds,
+            usableIds = replayed.inventory.usableJumpHostIds,
+        )
+        assertEquals(listOf("c-a", "j-a"), addable.map { it.first })
+    }
+}

--- a/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/JumpPickerTest.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/JumpPickerTest.kt
@@ -1,0 +1,120 @@
+package one.zephyr.mobile.feature.connections
+
+import one.zephyr.mobile.model.CapabilitySet
+import one.zephyr.mobile.model.JumpHost
+import one.zephyr.mobile.model.Protocol
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Hop picker contents.
+ *
+ * The editor used to drop the first inventory emission while the form was still
+ * InitialLoading, then never ask Room again, so a user with many SSH hosts saw
+ * "没有可用的 SSH 连接可作跳板". These cases pin the list the sheet actually
+ * renders, including the merge that must happen after that dropped emission is
+ * replayed onto the opened form.
+ */
+class JumpPickerTest {
+
+    private val target = Fixtures.connection(id = "c-target", name = "target", host = "10.0.0.9")
+    private val hopA = Fixtures.connection(id = "c-a", name = "jump-a", host = "10.0.0.1")
+    private val hopB = Fixtures.connection(id = "c-b", name = "jump-b", host = "10.0.0.2")
+    private val rdp = Fixtures.connection(id = "c-rdp", name = "desk", host = "10.0.0.3", protocol = Protocol.RDP)
+    private val deleted = Fixtures.connection(id = "c-dead", name = "gone", host = "10.0.0.4", deletedAt = 1L)
+    private val noUse = Fixtures.connection(
+        id = "c-view",
+        name = "view-only",
+        host = "10.0.0.5",
+        capabilities = CapabilitySet.none,
+    )
+    private val alias = JumpHost(
+        id = "j-a",
+        ownerUserId = Fixtures.OWNER,
+        name = "named-jump",
+        connectionId = "c-a",
+    )
+
+    @Test
+    fun `lists every live SSH host except the one being edited`() {
+        val listed = JumpPicker.connections(
+            rows = listOf(target, hopA, hopB, rdp, deleted, noUse),
+            editingId = target.id,
+        )
+        assertEquals(listOf("c-a", "c-b"), listed.map { it.id })
+    }
+
+    @Test
+    fun `a create form with a null id still lists every live SSH host`() {
+        val listed = JumpPicker.connections(
+            rows = listOf(hopA, hopB, rdp),
+            editingId = null,
+        )
+        assertEquals(listOf("c-a", "c-b"), listed.map { it.id })
+    }
+
+    @Test
+    fun `addable excludes hops already in the chain and jump aliases of those hops`() {
+        val connections = listOf(hopA, hopB)
+        val usable = JumpPicker.usableIds(connections, listOf(alias))
+        val addable = JumpPicker.addable(
+            connections = connections,
+            jumps = listOf(alias),
+            chain = listOf(hopA.id),
+            usableIds = usable,
+        )
+        assertEquals(listOf("c-b"), addable.map { it.first })
+        assertFalse(addable.any { it.first == "j-a" })
+    }
+
+    @Test
+    fun `addable includes a jump-host alias when its connection is not already in the chain`() {
+        val connections = listOf(hopA, hopB)
+        val usable = JumpPicker.usableIds(connections, listOf(alias))
+        val addable = JumpPicker.addable(
+            connections = connections,
+            jumps = listOf(alias),
+            chain = emptyList(),
+            usableIds = usable,
+        )
+        assertEquals(listOf("c-a", "c-b", "j-a"), addable.map { it.first })
+        assertEquals("named-jump", addable.last().second)
+    }
+
+    @Test
+    fun `replaying inventory onto a freshly opened form fills the picker`() {
+        /* This is the race: Room emitted while load() was still in find(), mutate
+         * no-op'd, and the form opened with the default empty jumpConnections. */
+        val opened = ConnectionEditorUiState(draft = ConnectionDraft.edit(target))
+        assertTrue(opened.jumpConnections.isEmpty())
+        assertTrue(opened.inventory.usableJumpHostIds.isEmpty())
+
+        val filled = opened.withJumpInventory(
+            JumpInventory(rows = listOf(target, hopA, hopB, rdp), jumps = listOf(alias)),
+            editingId = target.id,
+        )
+        assertEquals(listOf("c-a", "c-b"), filled.jumpConnections.map { it.id })
+        assertTrue(filled.inventory.usableJumpHostIds.containsAll(listOf("c-a", "c-b", "j-a")))
+        assertFalse(filled.inventory.usableJumpHostIds.contains("c-target"))
+
+        val addable = JumpPicker.addable(
+            connections = filled.jumpConnections,
+            jumps = filled.jumpHosts,
+            chain = filled.draft.current.jumpHostIds,
+            usableIds = filled.inventory.usableJumpHostIds,
+        )
+        assertEquals(listOf("c-a", "c-b", "j-a"), addable.map { it.first })
+        assertTrue(addable.any { it.second.contains("10.0.0.1") })
+    }
+
+    @Test
+    fun `labels prefer the connection name then host colon port`() {
+        val unnamed = hopA.copy(name = "")
+        val labels = JumpPicker.labels(listOf(unnamed, hopB), listOf(alias))
+        assertEquals("10.0.0.1 · 10.0.0.1:22", labels.getValue("c-a"))
+        assertEquals("jump-b · 10.0.0.2:22", labels.getValue("c-b"))
+        assertEquals("named-jump", labels.getValue("j-a"))
+    }
+}

--- a/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
+++ b/zephyr_one/mobile/tests/ssh-jump-route-contract.test.mjs
@@ -82,13 +82,25 @@ test('every hop authenticates with its own stored secrets not the target\'s', ()
 test('the editor jump picker lists SSH connections like the main end', () => {
   const screen = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt');
   const vm = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt');
+  const picker = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/JumpPicker.kt');
   /* JumpChainEditor existed but RouteSection never composed it: tapping the
    * JUMP row silently added the first JumpHost resource, and SSH connections
    * (what the main end actually stores in jumpHostIds) were not even listed. */
   assert.match(screen, /ConnectionMode\.JUMP -> JumpChainEditor\(ui, onIntent, onPickJump\)/);
-  assert.match(screen, /for \(connection in ui\.jumpConnections\)/);
+  assert.match(screen, /JumpPicker\.addable\(/);
   assert.match(vm, /val jumpConnections: List<Connection>/);
-  assert.match(vm, /row\.protocol == Protocol\.SSH/);
+  assert.match(picker, /row\.protocol == Protocol\.SSH/);
+});
+
+test('inventory that arrives while the editor is still loading is replayed onto the form', () => {
+  const vm = read('android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt');
+  /* mutate() no-ops on InitialLoading. Room's first snapshot often lands during
+   * connections.find(), and the mirror does not re-emit, so dropping that
+   * snapshot left "没有可用的 SSH 连接可作跳板" on a device full of SSH hosts. */
+  assert.match(vm, /private var latestInventory: JumpInventory\? = null/);
+  assert.match(vm, /latestInventory\?\.let\(::applyInventory\)/);
+  assert.match(vm, /private fun show\(/);
+  assert.match(vm, /it\.withJumpInventory\(snapshot, connectionId\)/);
 });
 
 test('the jump chain is selectable inside the card via a full-screen sheet', () => {


### PR DESCRIPTION
## Why

Tapping 添加跳板 still showed `没有可用的 SSH 连接可作跳板` even with a full SSH host list.

The hop picker reads `ui.jumpConnections` from the editor inventory. That inventory is observed from Room, but `mutate()` no-ops while the page is still `InitialLoading`. Room's first snapshot often arrives during `connections.find()`, and the mirror does not re-emit until something actually changes, so the picker opened with the default empty list forever.

## What

- Hold the last inventory emission across loading.
- `show()` stamps that snapshot onto the form once it is `Content`.
- Extract `JumpPicker` so the list the sheet renders is the same function the tests pin (every live SSH host except the one being edited, plus JumpHost aliases).

## Tests

- `JumpPickerTest` covers listing, chain exclusion, alias inclusion, and the dropped-then-replayed merge.
- `JumpPickerMutationTest` fails if `show()` stops replaying the held snapshot.
- `ssh-jump-route-contract.test.mjs` pins the replay on the ViewModel (10/10 locally).