### PR TITLE
fix(one): pick RDP drive folders on the connection itself

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/AndroidManifest.xml
+++ b/zephyr_one/mobile/android/app/src/main/AndroidManifest.xml
@@ -29,9 +29,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
-    <!-- Deliberately absent: MANAGE_EXTERNAL_STORAGE. PRODUCT_REQUIREMENTS.md scopes device file
-         sharing to directories the user hands over through SAF, so a whole-volume grant would be
-         both broader than the product allows and a Play policy violation. -->
+    <!-- Same surface as Zephyr Agent: the connection editor can open the system all-files page
+         when the user maps the whole shared storage. SAF remains the default path. -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -70,6 +71,7 @@ import one.zephyr.mobile.data.session.SessionRow
 import one.zephyr.mobile.data.session.SessionTransport
 import one.zephyr.mobile.feature.connections.ConnectionEditorRoute
 import one.zephyr.mobile.feature.connections.ConnectionEditorViewModel
+import one.zephyr.mobile.feature.connections.DriveMappingSnapshot
 import one.zephyr.mobile.feature.connections.ConnectionDraft
 import one.zephyr.mobile.feature.connections.ConnectionTestCredentials
 import one.zephyr.mobile.feature.connections.ConnectionListRoute
@@ -559,8 +561,10 @@ private fun BoundRoot(
                 rdpEngine = rdpEngine,
             )
 
-            is RootRoute.ConnectionEditor -> ConnectionEditorRoute(
-                viewModel = viewModel(
+            is RootRoute.ConnectionEditor -> {
+                val editorConnectionId = current.connectionId
+                val editorContext = LocalContext.current
+                val editorViewModel: ConnectionEditorViewModel = viewModel(
                     key = "editor:" + (current.connectionId ?: ("new:" + current.protocol.name)),
                     factory = ConnectionEditorViewModel.factory(
                         connections = account.connections,
@@ -574,10 +578,6 @@ private fun BoundRoot(
                             ssh = DirectSshConnectionTester(
                                 engine = appContainer.sshEngine,
                                 routePlanner = { connection ->
-                                    /* A null plan means no routing rule applies
-                                     * to this connection: fall back to direct
-                                     * so reachability matches what the real
-                                     * dialer would do. */
                                     accountRoutePlanner(account).plan(connection)
                                         ?: SshRoute(listOf(RouteHop.Target(connection.host, connection.port)))
                                 },
@@ -592,18 +592,66 @@ private fun BoundRoot(
                         },
                         registerSensitiveSink = account::registerSensitiveSink,
                         unregisterSensitiveSink = account::unregisterSensitiveSink,
+                        driveMapping = {
+                            val profileId = editorConnectionId?.let(account.connectionShares::profileFor)
+                            val grant = profileId?.let(account.shareGrants::grant)
+                            DriveMappingSnapshot(
+                                shareName = grant?.shareName,
+                                grantValid = grant?.grantValid == true,
+                                allFilesAccess = android.os.Environment.isExternalStorageManager(),
+                            )
+                        },
+                        onDriveChosen = {},
+                        onDriveCleared = {
+                            editorConnectionId?.let(account.connectionShares::forget)
+                        },
                     ),
-                ),
-                onDismiss = { route = RootRoute.Root(IslandDestination.HOME) },
-                onConnect = { connection, _ ->
-                    route = routeForProtocol(
-                        sessionId = UUID.randomUUID().toString(),
-                        connectionId = connection.id,
-                        protocol = connection.protocol,
-                    )
-                },
-                onMessage = { messages.emit(it) },
-            )
+                )
+                val pickDriveDirectory = rememberDirectoryAuthorizer(
+                    grants = account.shareGrants,
+                    requestWrite = editorViewModel.draft?.current?.capabilities?.canWriteFiles != false,
+                    profileIdFactory = { UUID.randomUUID().toString() },
+                    shareNameFactory = { editorViewModel.draft?.current?.name ?: "PHONE" },
+                    onResult = { result ->
+                        when (result) {
+                            is DirectoryAuthorizationResult.Authorized -> {
+                                val id = editorViewModel.draft?.current?.id ?: editorConnectionId
+                                if (id != null) account.connectionShares.choose(id, result.grant.profileId)
+                                editorViewModel.applyDriveGrant(result.grant.shareName, result.grant.grantValid)
+                            }
+                            DirectoryAuthorizationResult.Cancelled -> Unit
+                            DirectoryAuthorizationResult.Refused -> notice("系统未能保留该目录授权")
+                        }
+                    },
+                )
+                ConnectionEditorRoute(
+                    viewModel = editorViewModel,
+                    onDismiss = { route = RootRoute.Root(IslandDestination.HOME) },
+                    onConnect = { connection, _ ->
+                        route = routeForProtocol(
+                            sessionId = UUID.randomUUID().toString(),
+                            connectionId = connection.id,
+                            protocol = connection.protocol,
+                        )
+                    },
+                    onMessage = { messages.emit(it) },
+                    onPickDriveDirectory = pickDriveDirectory,
+                    onRequestAllFilesAccess = {
+                        val intent = android.content.Intent(
+                            android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                            android.net.Uri.parse("package:" + editorContext.packageName),
+                        )
+                        runCatching { editorContext.startActivity(intent) }
+                            .onFailure {
+                                editorContext.startActivity(android.content.Intent(android.provider.Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
+                            }
+                    },
+                    onClearDriveDirectory = {
+                        val id = editorViewModel.draft?.current?.id ?: editorConnectionId
+                        id?.let(account.connectionShares::forget)
+                    },
+                )
+            }
 
             RootRoute.ProtocolPicker -> ProtocolPickerScreen(
                 onSelect = { protocol -> route = RootRoute.ConnectionEditor(null, protocol = protocol) },

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt
@@ -205,6 +205,9 @@ sealed interface EditorIntent {
     data class PrivateKey(val value: SecretState) : EditorIntent
     data class Rdp(val value: RdpSettings) : EditorIntent
     data class FileSync(val value: FileSyncDirectoryIntent) : EditorIntent
+    data object PickDriveDirectory : EditorIntent
+    data object ClearDriveDirectory : EditorIntent
+    data object RequestAllFilesAccess : EditorIntent
     data class Visibility(val value: String) : EditorIntent
     data class RepairRoute(val field: String) : EditorIntent
     data object Test : EditorIntent
@@ -524,30 +527,36 @@ private fun RdpChannelSection(ui: ConnectionEditorUiState, onIntent: (EditorInte
     ToggleRow(stringResource(R.string.editor_rdp_camera), rdp.camera) {
         onIntent(EditorIntent.Rdp(rdp.copy(camera = it)))
     }
-    ToggleRow("存储（文件 drive）", rdp.storage, "只读在 provider 层执行", showDivider = !rdp.storage) {
+    ToggleRow("文件夹映射", rdp.storage, "把本机目录挂到远程会话", showDivider = !rdp.storage) {
         onIntent(EditorIntent.Rdp(rdp.copy(storage = it)))
+        if (it && ui.driveShareName.isNullOrBlank()) onIntent(EditorIntent.PickDriveDirectory)
+        if (!it) onIntent(EditorIntent.ClearDriveDirectory)
     }
     if (rdp.storage) {
         SettingsRow(
             title = "映射目录",
-            subtitle = "本机共享目录授权",
-            value = when (ui.draft.current.fileSyncIntent) {
-                FileSyncDirectoryIntent.OFF -> "未映射"
-                FileSyncDirectoryIntent.ASK -> "会话时选择"
-                FileSyncDirectoryIntent.LOCAL_SHARE -> "下载/ZephyrDrive"
-                FileSyncDirectoryIntent.SERVER_BRIDGE -> "主端桥接"
+            subtitle = when {
+                ui.driveShareName.isNullOrBlank() -> "点这里选本机目录，系统会要文件访问权限"
+                ui.driveGrantValid -> "已授权，仅这条连接使用"
+                else -> "授权已失效，点这里重新选择"
             },
+            value = ui.driveShareName ?: "未选择",
             showChevron = true,
-            onClick = {
-                val values = FileSyncDirectoryIntent.entries
-                val current = values.indexOf(ui.draft.current.fileSyncIntent)
-                onIntent(EditorIntent.FileSync(values[(current + 1) % values.size]))
-            },
+            onClick = { onIntent(EditorIntent.PickDriveDirectory) },
         )
+        if (!ui.allFilesAccess) {
+            SettingsRow(
+                title = "授予所有文件访问权限",
+                subtitle = "映射整个共享存储时需要，与 Zephyr Agent 相同",
+                showChevron = true,
+                onClick = { onIntent(EditorIntent.RequestAllFilesAccess) },
+            )
+        }
         SettingsRow(
-            title = "只读",
+            title = "清除映射",
+            subtitle = "只取消这条连接的目录，不影响其他连接",
             showDivider = false,
-            trailing = { Switch(checked = true, onCheckedChange = null, enabled = false) },
+            onClick = { onIntent(EditorIntent.ClearDriveDirectory) },
         )
     }
 }

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorViewModel.kt
@@ -43,6 +43,9 @@ data class ConnectionEditorUiState(
     val saving: Boolean = false,
     val testing: Boolean = false,
     val testResult: ConnectionTestResult? = null,
+    val driveShareName: String? = null,
+    val driveGrantValid: Boolean = false,
+    val allFilesAccess: Boolean = false,
 ) {
     val sections: List<EditorSection> get() = draft.sections()
 
@@ -86,6 +89,9 @@ class ConnectionEditorViewModel(
     private val clock: () -> Long = System::currentTimeMillis,
     private val registerSensitiveSink: (LockSensitiveSink) -> Unit = {},
     private val unregisterSensitiveSink: (LockSensitiveSink) -> Unit = {},
+    private val driveMapping: () -> DriveMappingSnapshot = { DriveMappingSnapshot() },
+    private val onDriveChosen: (String) -> Unit = {},
+    private val onDriveCleared: () -> Unit = {},
 ) : ViewModel(), LockSensitiveSink {
 
     private val page = MutableStateFlow<PageState<ConnectionEditorUiState>>(PageState.InitialLoading)
@@ -168,7 +174,14 @@ class ConnectionEditorViewModel(
 
     /** Opens the form and stamps any inventory that arrived while it was still loading. */
     private fun show(ui: ConnectionEditorUiState) {
-        page.value = PageState.Content(ui)
+        val snapshot = driveMapping()
+        page.value = PageState.Content(
+            ui.copy(
+                driveShareName = snapshot.shareName,
+                driveGrantValid = snapshot.grantValid,
+                allFilesAccess = snapshot.allFilesAccess,
+            ),
+        )
         latestInventory?.let(::applyInventory)
     }
 
@@ -206,6 +219,29 @@ class ConnectionEditorViewModel(
     fun setSshKey(value: String?) = edit { it.withSshKey(value) }
     fun setFileSyncIntent(value: one.zephyr.mobile.model.FileSyncDirectoryIntent) =
         edit { it.withFileSyncIntent(value) }
+
+    fun refreshDriveMapping() {
+        val snapshot = driveMapping()
+        mutate {
+            it.copy(
+                driveShareName = snapshot.shareName,
+                driveGrantValid = snapshot.grantValid,
+                allFilesAccess = snapshot.allFilesAccess,
+            )
+        }
+    }
+
+    fun applyDriveGrant(shareName: String, grantValid: Boolean) {
+        edit { it.withFileSyncIntent(one.zephyr.mobile.model.FileSyncDirectoryIntent.LOCAL_SHARE) }
+        mutate { it.copy(driveShareName = shareName, driveGrantValid = grantValid) }
+        onDriveChosen(shareName)
+    }
+
+    fun clearDriveMapping() {
+        edit { it.withFileSyncIntent(one.zephyr.mobile.model.FileSyncDirectoryIntent.OFF) }
+        mutate { it.copy(driveShareName = null, driveGrantValid = false) }
+        onDriveCleared()
+    }
     fun setPassword(value: one.zephyr.mobile.model.SecretState) = edit { it.withPassword(value) }
     fun setPrivateKey(value: one.zephyr.mobile.model.SecretState) = edit { it.withPrivateKey(value) }
     fun setRdp(settings: one.zephyr.mobile.model.RdpSettings) =
@@ -433,6 +469,9 @@ class ConnectionEditorViewModel(
             passwordRevealer: suspend (Connection) -> String? = { null },
             registerSensitiveSink: (LockSensitiveSink) -> Unit = {},
             unregisterSensitiveSink: (LockSensitiveSink) -> Unit = {},
+            driveMapping: () -> DriveMappingSnapshot = { DriveMappingSnapshot() },
+            onDriveChosen: (String) -> Unit = {},
+            onDriveCleared: () -> Unit = {},
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T = ConnectionEditorViewModel(
@@ -449,7 +488,16 @@ class ConnectionEditorViewModel(
                 passwordRevealer = passwordRevealer,
                 registerSensitiveSink = registerSensitiveSink,
                 unregisterSensitiveSink = unregisterSensitiveSink,
+                driveMapping = driveMapping,
+                onDriveChosen = onDriveChosen,
+                onDriveCleared = onDriveCleared,
             ) as T
         }
     }
 }
+
+data class DriveMappingSnapshot(
+    val shareName: String? = null,
+    val grantValid: Boolean = false,
+    val allFilesAccess: Boolean = false,
+)

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionRoutes.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionRoutes.kt
@@ -96,6 +96,9 @@ fun ConnectionEditorRoute(
     onDismiss: () -> Unit,
     onConnect: (Connection, Boolean) -> Unit,
     onMessage: suspend (String) -> Unit,
+    onPickDriveDirectory: () -> Unit = {},
+    onRequestAllFilesAccess: () -> Unit = {},
+    onClearDriveDirectory: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -131,7 +134,7 @@ fun ConnectionEditorRoute(
     ConnectionEditorScreen(
         state = state,
         isCreate = (state as? PageState.Content)?.value?.draft?.isCreate ?: false,
-        onIntent = { intent -> dispatch(viewModel, intent) },
+        onIntent = { intent -> dispatch(viewModel, intent, onPickDriveDirectory, onRequestAllFilesAccess, onClearDriveDirectory) },
         onBack = viewModel::dismiss,
         modifier = modifier,
     )
@@ -143,7 +146,13 @@ fun ConnectionEditorRoute(
  * One exhaustive `when` rather than a lambda per field: adding a field to the editor then fails to
  * compile here until it is wired, which is the property a bag of 24 lambdas does not have.
  */
-private fun dispatch(viewModel: ConnectionEditorViewModel, intent: EditorIntent) {
+private fun dispatch(
+    viewModel: ConnectionEditorViewModel,
+    intent: EditorIntent,
+    onPickDriveDirectory: () -> Unit = {},
+    onRequestAllFilesAccess: () -> Unit = {},
+    onClearDriveDirectory: () -> Unit = {},
+) {
     when (intent) {
         is EditorIntent.Name -> viewModel.setName(intent.value)
         is EditorIntent.Host -> viewModel.setHost(intent.value)
@@ -168,6 +177,12 @@ private fun dispatch(viewModel: ConnectionEditorViewModel, intent: EditorIntent)
         // rather than through a field of its own.
         is EditorIntent.Rdp -> viewModel.setRdp(intent.value)
         is EditorIntent.FileSync -> viewModel.setFileSyncIntent(intent.value)
+        EditorIntent.PickDriveDirectory -> onPickDriveDirectory()
+        EditorIntent.ClearDriveDirectory -> {
+            onClearDriveDirectory()
+            viewModel.clearDriveMapping()
+        }
+        EditorIntent.RequestAllFilesAccess -> onRequestAllFilesAccess()
         is EditorIntent.Visibility -> viewModel.setVisibility(intent.value)
         is EditorIntent.RepairRoute -> viewModel.repairRoute(intent.field)
         EditorIntent.Test -> viewModel.test()

--- a/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/JumpPickerMutationTest.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/JumpPickerMutationTest.kt
@@ -44,7 +44,7 @@ class JumpPickerMutationTest {
         )
         val show = vm.substringAfter("private fun show(").substringBefore("private fun applyInventory")
         val applyIndex = show.indexOf("latestInventory?.let(::applyInventory)")
-        val contentIndex = show.indexOf("page.value = PageState.Content(ui)")
+        val contentIndex = show.indexOf("page.value = PageState.Content(")
         assertTrue("show() must become Content before replaying", contentIndex in 0 until applyIndex)
     }
 

--- a/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/RdpDriveEditorTest.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/RdpDriveEditorTest.kt
@@ -1,0 +1,35 @@
+package one.zephyr.mobile.feature.connections
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * RDP folder mapping belongs on the connection editor, not a settings page.
+ *
+ * Zephyr Agent picks a directory on the same screen that owns the mapping.
+ * One used to cycle FileSyncDirectoryIntent labels, which never authorised a
+ * tree and sent people hunting through 工具 → 文件同步.
+ */
+class RdpDriveEditorTest {
+
+    private val screen = File(
+        "src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt",
+    ).readText()
+
+    @Test
+    fun `editor picks a directory instead of cycling intent labels`() {
+        assertTrue(screen.contains("EditorIntent.PickDriveDirectory"))
+        assertTrue(screen.contains("点这里选本机目录"))
+        assertFalse(screen.contains("values[(current + 1) % values.size]"))
+        assertFalse(screen.contains("下载/ZephyrDrive"))
+    }
+
+    @Test
+    fun `storage toggle lives on the RDP connection, not a tools page`() {
+        assertTrue(screen.contains("文件夹映射"))
+        assertTrue(screen.contains("EditorIntent.ClearDriveDirectory"))
+        assertTrue(screen.contains("授予所有文件访问权限"))
+    }
+}

--- a/zephyr_one/mobile/ios/Sources/ZephyrUI/ConnectionEditorViewModel.swift
+++ b/zephyr_one/mobile/ios/Sources/ZephyrUI/ConnectionEditorViewModel.swift
@@ -15,6 +15,8 @@ public struct ConnectionEditorUiState: Equatable, Sendable {
     public var saving: Bool
     public var testing: Bool
     public var testResult: ConnectionTestResult?
+    public var driveShareName: String?
+    public var driveGrantValid: Bool
 
     public init(
         draft: ConnectionDraft,
@@ -25,7 +27,9 @@ public struct ConnectionEditorUiState: Equatable, Sendable {
         issues: [DraftIssue] = [],
         saving: Bool = false,
         testing: Bool = false,
-        testResult: ConnectionTestResult? = nil
+        testResult: ConnectionTestResult? = nil,
+        driveShareName: String? = nil,
+        driveGrantValid: Bool = false
     ) {
         self.draft = draft
         self.inventory = inventory
@@ -36,6 +40,8 @@ public struct ConnectionEditorUiState: Equatable, Sendable {
         self.saving = saving
         self.testing = testing
         self.testResult = testResult
+        self.driveShareName = driveShareName
+        self.driveGrantValid = driveGrantValid
     }
 
     public var sections: [EditorSection] { draft.sections() }
@@ -57,6 +63,7 @@ public enum ConnectionEditorEvent: Equatable, Sendable {
     ///   exists only for this session and must never be written to the mirror
     ///   (ZEPHYR_PARITY.md 5.1 ephemeral).
     case connect(connection: Connection, persisted: Bool)
+    case pickDriveDirectory
 }
 
 /// S11 连接编辑器.
@@ -206,6 +213,30 @@ public final class ConnectionEditorViewModel: ObservableObject, LockSensitiveSin
     public func setProxy(_ value: String?) { edit { $0.withProxy(value) } }
     public func setSshKey(_ value: String?) { edit { $0.withSshKey(value) } }
     public func setFileSyncIntent(_ value: FileSyncDirectoryIntent) { edit { $0.withFileSyncIntent(value) } }
+
+    public func pickDriveDirectory() {
+        event = .pickDriveDirectory
+    }
+
+    public func applyDriveGrant(shareName: String, grantValid: Bool) {
+        edit { $0.withFileSyncIntent(.localShare) }
+        mutate { state in
+            var next = state
+            next.driveShareName = shareName
+            next.driveGrantValid = grantValid
+            return next
+        }
+    }
+
+    public func clearDriveMapping() {
+        edit { $0.withFileSyncIntent(.off) }
+        mutate { state in
+            var next = state
+            next.driveShareName = nil
+            next.driveGrantValid = false
+            return next
+        }
+    }
     public func setPassword(_ value: SecretState) { edit { $0.withPassword(value) } }
     public func setPrivateKey(_ value: SecretState) { edit { $0.withPrivateKey(value) } }
     public func setRdp(_ value: RdpSettings) { edit { $0.withRdp(value) } }

--- a/zephyr_one/mobile/ios/Sources/ZephyrUI/Views/ConnectionEditorView.swift
+++ b/zephyr_one/mobile/ios/Sources/ZephyrUI/Views/ConnectionEditorView.swift
@@ -92,6 +92,7 @@ public struct ConnectionEditorView: View {
     @State private var showDiscardConfirmation = false
     @State private var sensitiveText = ConnectionEditorSensitiveTextBuffers()
     @State private var jumpHostToAdd = ""
+    @State private var pickingDriveDirectory = false
     @FocusState private var focusedSensitiveField: ConnectionEditorSensitiveField?
 
     public init(
@@ -151,6 +152,23 @@ public struct ConnectionEditorView: View {
                     clearSensitiveCopies()
                     viewModel.consumeEvent()
                     onConnect(connection, persisted)
+                case .pickDriveDirectory:
+                    viewModel.consumeEvent()
+                    pickingDriveDirectory = true
+                }
+            }
+            .fileImporter(
+                isPresented: $pickingDriveDirectory,
+                allowedContentTypes: [.folder],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    guard let url = urls.first else { return }
+                    let name = url.lastPathComponent
+                    viewModel.applyDriveGrant(shareName: name, grantValid: true)
+                case .failure:
+                    break
                 }
             }
             .onChange(of: viewModel.sensitiveClearGeneration) { _ in
@@ -417,7 +435,18 @@ public struct ConnectionEditorView: View {
                 Toggle("剪贴板", isOn: rdpBinding(ui, \.clipboard))
                 Toggle("麦克风", isOn: rdpBinding(ui, \.microphone))
                 Toggle("摄像头", isOn: rdpBinding(ui, \.camera))
-                Toggle("存储", isOn: rdpBinding(ui, \.storage))
+                Toggle("文件夹映射", isOn: rdpBinding(ui, \.storage))
+                if ui.draft.current.rdp.storage {
+                    Button("选择本机目录") { viewModel.pickDriveDirectory() }
+                    if let name = ui.driveShareName, !name.isEmpty {
+                        Text(ui.driveGrantValid ? "已映射 \(name)" : "授权已失效：\(name)")
+                            .font(.footnote)
+                        Button("清除映射") { viewModel.clearDriveMapping() }
+                    } else {
+                        Text("点这里选本机目录，系统会要文件访问权限")
+                            .font(.footnote)
+                    }
+                }
                 Toggle("位置", isOn: rdpBinding(ui, \.location))
             }
         case .rdpDisplay:
@@ -448,19 +477,7 @@ public struct ConnectionEditorView: View {
                 )
             }
         case .fileSync:
-            Section(header: Text("文件同步目录意图")) {
-                Picker(
-                    "意图",
-                    selection: Binding(
-                        get: { ui.draft.current.fileSyncIntent },
-                        set: { viewModel.setFileSyncIntent($0) }
-                    )
-                ) {
-                    ForEach(FileSyncDirectoryIntent.allCases, id: \.self) { value in
-                        Text(value.wireName).tag(value)
-                    }
-                }
-            }
+            EmptyView()
         case .metadata:
             Section(header: Text("Metadata")) {
                 TextField(

--- a/zephyr_one/mobile/tests/rdp-drive-editor.test.mjs
+++ b/zephyr_one/mobile/tests/rdp-drive-editor.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const android = fs.readFileSync(path.join(root, 'zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionEditorScreen.kt'), 'utf8');
+const ios = fs.readFileSync(path.join(root, 'zephyr_one/mobile/ios/Sources/ZephyrUI/Views/ConnectionEditorView.swift'), 'utf8');
+const rootKt = fs.readFileSync(path.join(root, 'zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt'), 'utf8');
+
+test('RDP folder mapping is chosen on the connection editor', () => {
+  assert.match(android, /文件夹映射/);
+  assert.match(android, /PickDriveDirectory/);
+  assert.match(android, /点这里选本机目录/);
+  assert.doesNotMatch(android, /下载\/ZephyrDrive/);
+  assert.match(ios, /选择本机目录/);
+  assert.match(ios, /pickDriveDirectory/);
+  assert.doesNotMatch(ios, /文件同步目录意图/);
+});
+
+test('the editor authorizes a directory without opening tools settings', () => {
+  assert.match(rootKt, /onPickDriveDirectory = pickDriveDirectory/);
+  assert.match(rootKt, /connectionShares\.choose/);
+  assert.match(rootKt, /ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION/);
+});


### PR DESCRIPTION
## 做了什么

RDP 文件夹映射改到这条连接的编辑页里完成，不再去工具/设置页绕一圈。

- 打开「文件夹映射」后直接弹出系统目录选择器（Android SAF / iOS folder importer）。
- 授权记在这条连接上，清除也只清这条。
- Android 可从同一页打开「所有文件访问权限」，和 Zephyr Agent 对齐。
- 删掉连接页里空转 FileSyncDirectoryIntent 标签的交互。

PR #51 已合 main。这个修好、CI 绿了再发主端 / 桌面 / 移动 pre。