### PR TITLE
fix(ci): force-fetch tags in Docker changelog

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Generate changelog
         run: |
-          git fetch --tags
+          git fetch --tags --force
 
           CURRENT_TAG=${{ env.VERSION_TAG }}
 


### PR DESCRIPTION
v1.1.504 镜像已经推到 GHCR，Release 也已补上。这次失败发生在 Generate changelog：`git fetch --tags` 拒绝覆盖 runner 上已有的同名 tag。改成 `--force`，避免下次再卡在发布文案。