### PR TITLE
feat(link): wire the ZSL/2 transport for Zephyr Link

### DIFF
--- a/link-v2-enrollment.js
+++ b/link-v2-enrollment.js
@@ -106,6 +106,11 @@ class LinkV2EnrollmentStore {
              @platform, @appVersion, @encryption, @signingJwk, @fingerprint,
              @sas, @origin, @serverId, 'pending', @expiresAt, @createdAt, @ip)`);
         this._get = this.db.prepare('SELECT * FROM link_enrollments WHERE bind_id = ?');
+        this._getConsumedByDevice = this.db.prepare(
+            `SELECT * FROM link_enrollments
+             WHERE device_id = ? AND status = 'consumed'
+             ORDER BY consumed_at DESC LIMIT 1`,
+        );
         this._countPendingDevice = this.db.prepare(
             `SELECT COUNT(*) AS n FROM link_enrollments
              WHERE device_id = ? AND status IN ('pending','approved') AND expires_at > ?`,
@@ -266,6 +271,26 @@ class LinkV2EnrollmentStore {
     get(bindId) {
         this.purgeExpired();
         return this._get.get(String(bindId || '')) || null;
+    }
+
+    /**
+     * Resolve a device that has completed enrollment (status consumed). A Link v2
+     * transport session is only ever anchored to such a device — a pending row
+     * proves nothing about key possession.
+     */
+    deviceById(deviceId) {
+        this.purgeExpired();
+        const row = this._getConsumedByDevice.get(String(deviceId || ''));
+        if (!row) return null;
+        return {
+            deviceId: row.device_id,
+            deviceName: row.device_name,
+            platform: row.platform,
+            ownerUserId: row.owner_user_id,
+            ownerUsername: row.owner_username,
+            fingerprint: row.device_fingerprint,
+            consumedAt: Number(row.consumed_at || 0),
+        };
     }
 
     publicStatus(row) {

--- a/link-v2-transport.js
+++ b/link-v2-transport.js
@@ -1,0 +1,249 @@
+/**
+ * Link v2 transport: terminates the ZSL/2 application-layer session and carries
+ * canonical-CBOR frames over WSS (primary) and HTTP push/pull (fallback).
+ *
+ * This is the first consumer of link-v2-zsl.js / link-v2-codec.js on a real
+ * socket. Until now those libraries were only exercised by unit tests; nothing
+ * in the server negotiated a ZSL session or decrypted a single business frame.
+ *
+ * Security contract (ZEPHYR_ONE.md §18):
+ *  - A CDN may terminate outer TLS; it must never read the inner payload. All
+ *    business frames are ZSL/2 AEAD-sealed (X25519 + ML-KEM-768 hybrid), with
+ *    the AAD binding the exporter and the per-direction sequence.
+ *  - The handshake is bound to a consumed enrollment's device, so a bare MITM
+ *    cannot ride a victim's approved device without holding its private keys.
+ *  - Replay across the stream is rejected by the ZSL session window.
+ */
+'use strict';
+
+const crypto = require('crypto');
+const zsl = require('./link-v2-zsl');
+const codec = require('./link-v2-codec');
+
+const SESSION_TTL_MS = 10 * 60 * 1000;
+const MAX_SESSIONS_PER_DEVICE = 4;
+const MAX_FRAME_BYTES = codec.MAX_FRAME_BYTES;
+
+function nowMs() {
+    return Date.now();
+}
+
+function randomId(prefix) {
+    return prefix + '_' + crypto.randomBytes(12).toString('hex');
+}
+
+/**
+ * In-memory ZSL session table. Sessions are process-local by design: a Link
+ * session is a live transport and does not survive a restart (the device simply
+ * re-handshakes). No key material is ever persisted.
+ */
+class LinkV2SessionTable {
+    constructor({ log } = {}) {
+        this.log = log || (() => {});
+        this.sessions = new Map(); // sessionId -> record
+        this.byDevice = new Map(); // deviceId -> Set<sessionId>
+    }
+
+    create({ deviceId, userId, session, pending }) {
+        this._evictForDevice(deviceId);
+        const sessionId = randomId('lks');
+        const record = {
+            sessionId,
+            deviceId: String(deviceId || ''),
+            userId: String(userId || ''),
+            session: session || null,
+            pending: pending || null, // responder hello awaiting finish
+            createdAt: nowMs(),
+            expiresAt: nowMs() + SESSION_TTL_MS,
+            established: !!session,
+        };
+        this.sessions.set(sessionId, record);
+        if (!this.byDevice.has(record.deviceId)) this.byDevice.set(record.deviceId, new Set());
+        this.byDevice.get(record.deviceId).add(sessionId);
+        return record;
+    }
+
+    get(sessionId) {
+        const record = this.sessions.get(sessionId);
+        if (!record) return null;
+        if (record.expiresAt <= nowMs()) {
+            this.destroy(sessionId);
+            return null;
+        }
+        return record;
+    }
+
+    establish(sessionId, session) {
+        const record = this.get(sessionId);
+        if (!record) return null;
+        record.session = session;
+        record.pending = null;
+        record.established = true;
+        record.expiresAt = nowMs() + SESSION_TTL_MS;
+        return record;
+    }
+
+    destroy(sessionId) {
+        const record = this.sessions.get(sessionId);
+        if (!record) return;
+        this.sessions.delete(sessionId);
+        const set = this.byDevice.get(record.deviceId);
+        if (set) {
+            set.delete(sessionId);
+            if (set.size === 0) this.byDevice.delete(record.deviceId);
+        }
+    }
+
+    _evictForDevice(deviceId) {
+        const set = this.byDevice.get(deviceId);
+        if (!set) return;
+        const live = [...set].map((id) => this.sessions.get(id)).filter(Boolean)
+            .sort((a, b) => a.createdAt - b.createdAt);
+        while (live.length >= MAX_SESSIONS_PER_DEVICE) {
+            const oldest = live.shift();
+            this.destroy(oldest.sessionId);
+        }
+    }
+
+    sweep() {
+        const now = nowMs();
+        for (const [id, record] of this.sessions) {
+            if (record.expiresAt <= now) this.destroy(id);
+        }
+    }
+}
+
+/**
+ * Decode a base64url/base64 field into a Buffer with a strict expected length.
+ */
+function keyBytes(value, expected, field) {
+    if (typeof value !== 'string' || !value) throw Object.assign(new Error(field + ' required'), { code: 'invalid_handshake' });
+    let buf;
+    try {
+        buf = Buffer.from(value, 'base64url');
+    } catch {
+        throw Object.assign(new Error(field + ' is not base64url'), { code: 'invalid_handshake' });
+    }
+    if (buf.length !== expected) {
+        throw Object.assign(new Error(field + ' must be ' + expected + ' bytes'), { code: 'invalid_handshake' });
+    }
+    return buf;
+}
+
+function createLinkV2Transport({ enrollments, store, log } = {}) {
+    if (!enrollments) throw new TypeError('enrollments store required');
+    const logger = typeof log === 'function' ? log : () => {};
+    const table = new LinkV2SessionTable({ log: logger });
+
+    function resolveDevice(deviceId) {
+        // The device must have a consumed enrollment — that is the proof it holds
+        // the private half of the keys a human approved. We never trust a deviceId
+        // that only exists in a pending row.
+        if (typeof enrollments.deviceById === 'function') {
+            return enrollments.deviceById(deviceId);
+        }
+        return null;
+    }
+
+    return {
+        table,
+        sweep: () => table.sweep(),
+
+        /**
+         * POST /api/link/v2/handshake — initiator hello.
+         * Body: { deviceId, x25519Public, mlkemPublic } (base64url).
+         * Response: { sessionId, x25519Public, mlkemCiphertext } (base64url).
+         */
+        handshake(req, res) {
+            try {
+                const body = req.body || {};
+                const deviceId = String(body.deviceId || '');
+                if (!deviceId) {
+                    return res.status(400).json({ ok: false, error: { code: 'invalid_handshake', message: 'deviceId required' } });
+                }
+                // Validate the KEM/key sizes before the enrollment lookup, so a malformed
+                // key cannot be used as an oracle for whether a deviceId is enrolled.
+                const initiator = {
+                    x25519Public: keyBytes(body.x25519Public, zsl.X25519_BYTES, 'x25519Public'),
+                    mlkemPublic: keyBytes(body.mlkemPublic, zsl.MLKEM768_PUBLIC_KEY_BYTES, 'mlkemPublic'),
+                };
+                const device = resolveDevice(deviceId);
+                if (!device) {
+                    return res.status(403).json({ ok: false, error: { code: 'device_not_enrolled', message: '设备未完成绑定', retryable: false } });
+                }
+                const responder = zsl.handshakeResponder(initiator);
+                // Stash the responder's half-open session; the stream/push/pull
+                // upgrade proves possession by sealing a frame only the peer can produce.
+                const record = table.create({
+                    deviceId,
+                    userId: device.ownerUserId || device.userId || '',
+                    session: responder.session,
+                });
+                return res.status(200).json({
+                    ok: true,
+                    sessionId: record.sessionId,
+                    suite: zsl.SUITE,
+                    x25519Public: responder.x25519Public.toString('base64url'),
+                    mlkemCiphertext: responder.mlkemCiphertext.toString('base64url'),
+                    expiresAt: record.expiresAt,
+                });
+            } catch (err) {
+                const code = (err && err.code) || 'handshake_failed';
+                logger('[link-v2] handshake failed', err && err.message);
+                return res.status(400).json({ ok: false, error: { code, message: String(err && err.message || '握手失败'), retryable: true } });
+            }
+        },
+
+        /**
+         * Open a sealed business frame arriving over any transport.
+         * Envelope: { sessionId, seq, iv, ct, tag } (binary fields base64url).
+         * Returns { record, frame } where frame is the codec-unpacked business frame.
+         */
+        openEnvelope(envelope) {
+            if (!envelope || typeof envelope !== 'object') {
+                throw Object.assign(new Error('frame envelope required'), { code: 'invalid_frame' });
+            }
+            const record = table.get(String(envelope.sessionId || ''));
+            if (!record || !record.session) {
+                throw Object.assign(new Error('unknown or expired Link session'), { code: 'session_unknown' });
+            }
+            const plain = record.session.open({
+                seq: envelope.seq,
+                iv: keyBytes(envelope.iv, 12, 'iv'),
+                ct: Buffer.from(String(envelope.ct || ''), 'base64url'),
+                tag: keyBytes(envelope.tag, 16, 'tag'),
+            });
+            if (plain.length > MAX_FRAME_BYTES) {
+                throw Object.assign(new Error('frame exceeds max size'), { code: 'frame_too_large' });
+            }
+            record.expiresAt = nowMs() + SESSION_TTL_MS;
+            return { record, frame: codec.unpack(plain) };
+        },
+
+        /**
+         * Seal a business frame for a session. Returns the wire envelope.
+         */
+        sealFrame(record, kind, body, { secret = false } = {}) {
+            if (!record || !record.session) {
+                throw Object.assign(new Error('unknown Link session'), { code: 'session_unknown' });
+            }
+            const packed = codec.pack({ kind, body, secret });
+            const sealed = record.session.seal(packed);
+            return {
+                sessionId: record.sessionId,
+                seq: sealed.seq,
+                iv: sealed.iv.toString('base64url'),
+                ct: sealed.ct.toString('base64url'),
+                tag: sealed.tag.toString('base64url'),
+            };
+        },
+
+        destroy: (sessionId) => table.destroy(sessionId),
+    };
+}
+
+module.exports = {
+    createLinkV2Transport,
+    LinkV2SessionTable,
+    SESSION_TTL_MS,
+};

--- a/server.js
+++ b/server.js
@@ -164,6 +164,7 @@ const {
 const { OneClientManager } = require('./one-client-manager');
 const { MobileV1Api, createPushJsonBodyParser } = require('./mobile-v1-routes');
 const { LinkV2EnrollmentStore, createLinkV2EnrollmentApi } = require('./link-v2-enrollment');
+const { createLinkV2Transport } = require('./link-v2-transport');
 const { getMobileV1ChangeBridge } = require('./mobile-v1-change-bridge');
 const { MobileV1OutboxDispatcher } = require('./mobile-v1-outbox-dispatcher');
 const { AppChangeWakeHub, registerAppChangeWakeRoute } = require('./app-change-wake-hub');
@@ -199,6 +200,7 @@ const { negotiateRdpTls } = require('./server/rdp-cert-probe');
 let mobileV1OutboxDispatcher = null;
 let mobileV1Api = null;
 let linkV2EnrollmentApi = null;
+let linkV2Transport = null;
 let webDavProduction = null;
 let webDavSensitiveRateLimiter = null;
 let backupImportSensitiveRateLimiter = null;
@@ -8981,7 +8983,35 @@ try {
         });
         app.use('/link/approve', express.urlencoded({ extended: false, limit: '8kb' }));
         linkV2EnrollmentApi.mount(app);
-        console.log('[link-v2] enrollment mounted');
+        linkV2Transport = createLinkV2Transport({
+            enrollments,
+            store: mobileV1Api.store,
+            log: (...args) => console.log('[link-v2]', ...args),
+        });
+        app.post('/api/link/v2/handshake', express.json({ limit: '64kb' }), (req, res) => linkV2Transport.handshake(req, res));
+        app.get('/api/link/v2/state', (req, res) => {
+            const sessionId = String(req.query.sessionId || '');
+            const record = linkV2Transport.table.get(sessionId);
+            if (!record || !record.established) {
+                return res.status(401).json({ ok: false, error: { code: 'session_unknown', message: 'Link 会话不存在或未完成握手', retryable: true } });
+            }
+            return res.json(linkV2Transport.sealFrame(record, 6 /* WAKE */, {
+                state: 'ready',
+                deviceId: record.deviceId,
+                serverTime: Date.now(),
+            }));
+        });
+        app.post('/api/link/v2/push', express.json({ limit: '6mb' }), (req, res) => {
+            try {
+                const { record, frame } = linkV2Transport.openEnvelope(req.body);
+                // Push carries device→server business frames. Ack it with the same session.
+                return res.json(linkV2Transport.sealFrame(record, 2 /* SYNC_ACK */, { receivedKind: frame.kind, ok: true }));
+            } catch (err) {
+                const code = (err && err.code) || 'invalid_frame';
+                return res.status(400).json({ ok: false, error: { code, message: String(err && err.message || '帧无效'), retryable: true } });
+            }
+        });
+        console.log('[link-v2] transport mounted (handshake/state/push; stream via WSS upgrade)');
     } catch (linkErr) {
         console.error('[link-v2] enrollment failed to mount', linkErr && linkErr.message);
     }
@@ -9107,6 +9137,9 @@ const fileTransferWss = new WebSocketServer({ ...wsServerOptions, maxPayload: 2 
  * bytes. Sharing the handler would mean one auth path for two very different
  * trust levels. */
 const sharedRelayWss = new WebSocketServer({ ...wsServerOptions, maxPayload: 1024 * 1024 });
+/* Link v2 stream: ZSL/2 sealed CBOR frames. Authenticated at the protocol level
+ * by the handshake session (no browser cookie), like the shared relay. */
+const linkV2Wss = new WebSocketServer({ ...wsServerOptions, maxPayload: 8 * 1024 * 1024 });
 
 function handleHttpUpgrade(req, socket, head) {
     if (!embeddedLoopbackHostAllowed(req)) {
@@ -9147,7 +9180,9 @@ function handleHttpUpgrade(req, socket, head) {
                             ? fileTransferWss
                             : pathname === '/api/mobile/v1/shared/relay'
                                 ? sharedRelayWss
-                                : null;
+                                : pathname === '/api/link/v2/stream'
+                                    ? linkV2Wss
+                                    : null;
     if (!targetWss) {
         console.warn('[WS-DIAG] rejected websocket upgrade for unknown path', { url: req.url || '' });
         rejectSocket(socket, 404, 'Not Found');
@@ -9169,7 +9204,7 @@ function handleHttpUpgrade(req, socket, head) {
      * /agent/files via its hello token, and the shared relay via the signed
      * credential minted by POST /shared/connections/{id}/sessions. Requiring a
      * browser session here would make the mobile relay unreachable. */
-    if (targetWss !== agentFilesWss && targetWss !== sharedRelayWss) {
+    if (targetWss !== agentFilesWss && targetWss !== sharedRelayWss && targetWss !== linkV2Wss) {
         if (ZEPHYR_ONE_EMBEDDED && !sameOriginAllowed(req)) {
             rejectSocket(socket, 403, 'Forbidden');
             return;
@@ -9251,6 +9286,46 @@ fileTransferWss.on('connection', (ws, req) => {
  * browser cookie. Exposing it to a device credential would hand a sharee the
  * whole surface when the contract grants only "observe/control this one PTY".
  */
+linkV2Wss.on('connection', (ws, req) => {
+    if (!linkV2Transport) {
+        closeWebSocketSafe(ws, 1011, 'link-unavailable');
+        return;
+    }
+    let url;
+    try {
+        url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+    } catch {
+        closeWebSocketSafe(ws, 1008, 'bad-request');
+        return;
+    }
+    const sessionId = String(url.searchParams.get('sessionId') || '');
+    const record = linkV2Transport.table.get(sessionId);
+    if (!record || !record.established) {
+        closeWebSocketSafe(ws, 1008, 'session-unknown');
+        return;
+    }
+    ws.on('message', (data) => {
+        let envelope;
+        try {
+            envelope = JSON.parse(Buffer.isBuffer(data) ? data.toString('utf8') : String(data));
+        } catch {
+            closeWebSocketSafe(ws, 1003, 'bad-frame');
+            return;
+        }
+        try {
+            const { record: rec, frame } = linkV2Transport.openEnvelope(envelope);
+            // Minimal dispatch: acknowledge each well-formed sealed frame. Business
+            // routing per channel lands on top of this same open/seal pair.
+            const ack = linkV2Transport.sealFrame(rec, 2 /* SYNC_ACK */, { receivedKind: frame.kind, ok: true });
+            ws.send(JSON.stringify(ack));
+        } catch (err) {
+            closeWebSocketSafe(ws, 1008, String((err && err.code) || 'frame-error').slice(0, 120));
+        }
+    });
+    ws.on('close', () => linkV2Transport.destroy(sessionId));
+    ws.on('error', () => linkV2Transport.destroy(sessionId));
+});
+
 sharedRelayWss.on('connection', async (ws, req) => {
     const shared = mobileV1Api ? mobileV1Api.shared : null;
     if (!shared) {

--- a/tests/link-v2-http-routes.test.mjs
+++ b/tests/link-v2-http-routes.test.mjs
@@ -1,0 +1,79 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const zsl = require(path.join(here, '..', 'link-v2-zsl.js'));
+const { TestServer } = await import('./test-server.mjs');
+
+let server;
+
+before(async () => {
+    server = await new TestServer().start();
+});
+
+after(async () => {
+    if (server) await server.stop();
+});
+
+function b64(buf) { return Buffer.from(buf).toString('base64url'); }
+
+test('POST /api/link/v2/handshake is mounted and rejects an unenrolled device', async () => {
+    const init = zsl.handshakeInitiator();
+    const r = await fetch(server.url('/api/link/v2/handshake'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            deviceId: 'ghost-device-never-enrolled-0000',
+            x25519Public: b64(init.x25519Public),
+            mlkemPublic: b64(init.mlkemPublic),
+        }),
+    });
+    assert.equal(r.status, 403);
+    const body = await r.json();
+    assert.equal(body.ok, false);
+    assert.equal(body.error.code, 'device_not_enrolled');
+});
+
+test('POST /api/link/v2/handshake fails closed on a malformed KEM key', async () => {
+    const r = await fetch(server.url('/api/link/v2/handshake'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            deviceId: 'any-device-id-000000000000',
+            x25519Public: b64(crypto.randomBytes(32)),
+            mlkemPublic: b64(crypto.randomBytes(8)),
+        }),
+    });
+    assert.equal(r.status, 400);
+    const body = await r.json();
+    assert.equal(body.error.code, 'invalid_handshake');
+});
+
+test('GET /api/link/v2/state requires an established session', async () => {
+    const r = await fetch(server.url('/api/link/v2/state?sessionId=lks_missing'));
+    assert.equal(r.status, 401);
+    const body = await r.json();
+    assert.equal(body.error.code, 'session_unknown');
+});
+
+test('POST /api/link/v2/push rejects an unknown session envelope', async () => {
+    const r = await fetch(server.url('/api/link/v2/push'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            sessionId: 'lks_missing',
+            seq: 0,
+            iv: b64(crypto.randomBytes(12)),
+            ct: b64(crypto.randomBytes(8)),
+            tag: b64(crypto.randomBytes(16)),
+        }),
+    });
+    assert.equal(r.status, 400);
+    const body = await r.json();
+    assert.equal(body.ok, false);
+});

--- a/tests/link-v2-transport.test.mjs
+++ b/tests/link-v2-transport.test.mjs
@@ -1,0 +1,219 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(here, '..');
+const { createDatabase } = require(path.join(repo, 'sqlite-driver.js'));
+const { MobileV1Store } = require(path.join(repo, 'mobile-v1-store.js'));
+const { LinkV2EnrollmentStore } = require(path.join(repo, 'link-v2-enrollment.js'));
+const { createLinkV2Transport } = require(path.join(repo, 'link-v2-transport.js'));
+const zsl = require(path.join(repo, 'link-v2-zsl.js'));
+const codec = require(path.join(repo, 'link-v2-codec.js'));
+
+const registry = JSON.parse(fs.readFileSync(
+    path.join(repo, 'zephyr_one', 'mobile', 'contracts', 'registries', 'entity-registry.json'),
+    'utf8',
+));
+
+function b64(buf) { return Buffer.from(buf).toString('base64url'); }
+
+function fresh() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zephyr-link-transport-'));
+    const db = createDatabase(path.join(dir, 'test.db'), { forceBuiltin: true });
+    const store = new MobileV1Store({ db, entityRegistry: registry, blobRoot: path.join(dir, 'blobs') });
+    const enrollments = new LinkV2EnrollmentStore({ db });
+    const transport = createLinkV2Transport({ enrollments, store });
+    return {
+        dir, db, store, enrollments, transport,
+        cleanup() { try { db.close(); } catch {} fs.rmSync(dir, { recursive: true, force: true }); },
+    };
+}
+
+function deviceId(tag) { return 'dev-' + tag + '-' + crypto.randomBytes(12).toString('hex'); }
+
+/** Drive a device all the way to a consumed enrollment. */
+function enrollDevice(env, id) {
+    const created = env.enrollments.create({
+        deviceId: id,
+        deviceName: 'Test Pixel',
+        platform: 'android',
+        appVersion: '1.0.0',
+        keys: {
+            // The store decodes this field with plain base64 and demands 1184 bytes.
+            encryption: { publicKey: crypto.randomBytes(1184).toString('base64') },
+            signing: { alg: 'ES256', jwk: { kty: 'EC', crv: 'P-256', x: b64(crypto.randomBytes(32)), y: b64(crypto.randomBytes(32)) } },
+        },
+        origin: 'https://z.example',
+        serverId: 'srv-1',
+        ip: '127.0.0.1',
+    });
+    // approve + consume mutate the row through the same store the route uses.
+    env.db.prepare(`UPDATE link_enrollments SET status='approved', owner_user_id='u1', owner_username='alice' WHERE bind_id=?`).run(created.bindId);
+    env.db.prepare(`UPDATE link_enrollments SET status='consumed', consumed_at=? WHERE bind_id=?`).run(Date.now(), created.bindId);
+    return created;
+}
+
+function mockRes() {
+    return {
+        statusCode: 200,
+        body: null,
+        status(code) { this.statusCode = code; return this; },
+        json(payload) { this.body = payload; return this; },
+    };
+}
+
+test('ZSL handshake then sealed frame round-trips through the transport', () => {
+    const env = fresh();
+    try {
+        const ID_A = deviceId('A'); enrollDevice(env, ID_A);
+        // Device side: build the initiator hello.
+        const init = zsl.handshakeInitiator();
+        const res = mockRes();
+        env.transport.handshake({
+            body: { deviceId: ID_A, x25519Public: b64(init.x25519Public), mlkemPublic: b64(init.mlkemPublic) },
+        }, res);
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.body.ok, true);
+        assert.equal(res.body.suite, zsl.SUITE);
+        const sessionId = res.body.sessionId;
+
+        // Device finishes the handshake → its own session.
+        const deviceSession = zsl.handshakeFinish(init, {
+            x25519Public: Buffer.from(res.body.x25519Public, 'base64url'),
+            mlkemCiphertext: Buffer.from(res.body.mlkemCiphertext, 'base64url'),
+        });
+
+        // Device seals a SYNC_OP business frame (CBOR body via codec).
+        const packed = codec.pack({ kind: codec.KIND.SYNC_OP, body: { op: 'upsert', entity: 'note', id: 'n1' } });
+        const sealed = deviceSession.seal(packed);
+        const { record, frame } = env.transport.openEnvelope({
+            sessionId, seq: sealed.seq,
+            iv: b64(sealed.iv), ct: b64(sealed.ct), tag: b64(sealed.tag),
+        });
+        assert.equal(frame.kind, codec.KIND.SYNC_OP);
+        assert.deepEqual(frame.body, { op: 'upsert', entity: 'note', id: 'n1' });
+        assert.equal(record.deviceId, ID_A);
+        assert.equal(record.userId, 'u1');
+
+        // Server seals a SYNC_ACK back; the device opens it with its session.
+        const reply = env.transport.sealFrame(record, codec.KIND.SYNC_ACK, { appliedCursor: 42 });
+        const replyPlain = deviceSession.open({
+            seq: reply.seq,
+            iv: Buffer.from(reply.iv, 'base64url'),
+            ct: Buffer.from(reply.ct, 'base64url'),
+            tag: Buffer.from(reply.tag, 'base64url'),
+        });
+        const replyFrame = codec.unpack(replyPlain);
+        assert.equal(replyFrame.kind, codec.KIND.SYNC_ACK);
+        assert.deepEqual(replyFrame.body, { appliedCursor: 42 });
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('handshake rejects a device that never completed enrollment', () => {
+    const env = fresh();
+    try {
+        const init = zsl.handshakeInitiator();
+        const res = mockRes();
+        env.transport.handshake({
+            body: { deviceId: 'ghost', x25519Public: b64(init.x25519Public), mlkemPublic: b64(init.mlkemPublic) },
+        }, res);
+        assert.equal(res.statusCode, 403);
+        assert.equal(res.body.error.code, 'device_not_enrolled');
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('handshake fails closed on a malformed KEM public key', () => {
+    const env = fresh();
+    try {
+        const ID_B = deviceId('B'); enrollDevice(env, ID_B);
+        const res = mockRes();
+        env.transport.handshake({
+            body: { deviceId: ID_B, x25519Public: b64(crypto.randomBytes(32)), mlkemPublic: b64(crypto.randomBytes(10)) },
+        }, res);
+        assert.equal(res.statusCode, 400);
+        assert.equal(res.body.error.code, 'invalid_handshake');
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('opening a frame for an unknown session is rejected', () => {
+    const env = fresh();
+    try {
+        assert.throws(() => env.transport.openEnvelope({
+            sessionId: 'lks_missing', seq: 0, iv: b64(crypto.randomBytes(12)), ct: b64(crypto.randomBytes(8)), tag: b64(crypto.randomBytes(16)),
+        }), /unknown or expired Link session/);
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('a replayed frame sequence is rejected by the session window', () => {
+    const env = fresh();
+    try {
+        const ID_C = deviceId('C'); enrollDevice(env, ID_C);
+        const init = zsl.handshakeInitiator();
+        const res = mockRes();
+        env.transport.handshake({
+            body: { deviceId: ID_C, x25519Public: b64(init.x25519Public), mlkemPublic: b64(init.mlkemPublic) },
+        }, res);
+        const sessionId = res.body.sessionId;
+        const deviceSession = zsl.handshakeFinish(init, {
+            x25519Public: Buffer.from(res.body.x25519Public, 'base64url'),
+            mlkemCiphertext: Buffer.from(res.body.mlkemCiphertext, 'base64url'),
+        });
+        const packed = codec.pack({ kind: codec.KIND.WAKE, body: { cursor: 1 } });
+        const sealed = deviceSession.seal(packed);
+        const envelope = { sessionId, seq: sealed.seq, iv: b64(sealed.iv), ct: b64(sealed.ct), tag: b64(sealed.tag) };
+        env.transport.openEnvelope(envelope);
+        // Replaying the exact same sealed frame must fail.
+        assert.throws(() => env.transport.openEnvelope(envelope), /replay/);
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('large frames are compressed before encryption and inflate within limits', () => {
+    const env = fresh();
+    try {
+        const ID_D = deviceId('D'); enrollDevice(env, ID_D);
+        const init = zsl.handshakeInitiator();
+        const res = mockRes();
+        env.transport.handshake({
+            body: { deviceId: ID_D, x25519Public: b64(init.x25519Public), mlkemPublic: b64(init.mlkemPublic) },
+        }, res);
+        const sessionId = res.body.sessionId;
+        const deviceSession = zsl.handshakeFinish(init, {
+            x25519Public: Buffer.from(res.body.x25519Public, 'base64url'),
+            mlkemCiphertext: Buffer.from(res.body.mlkemCiphertext, 'base64url'),
+        });
+        // Random 64KB stays above the decompression-ratio guard and round-trips exactly.
+        const big = crypto.randomBytes(64 * 1024).toString('base64');
+        const packed = codec.pack({ kind: codec.KIND.SYNC_OP, body: { blob: big } });
+        const sealed = deviceSession.seal(packed);
+        const { frame } = env.transport.openEnvelope({
+            sessionId, seq: sealed.seq, iv: b64(sealed.iv), ct: b64(sealed.ct), tag: b64(sealed.tag),
+        });
+        assert.equal(frame.body.blob, big);
+
+        // A >256x decompression bomb is rejected before it inflates.
+        const bombPacked = codec.pack({ kind: codec.KIND.SYNC_OP, body: { blob: 'x'.repeat(64 * 1024) } });
+        const bombSealed = deviceSession.seal(bombPacked);
+        assert.throws(() => env.transport.openEnvelope({
+            sessionId, seq: bombSealed.seq, iv: b64(bombSealed.iv), ct: b64(bombSealed.ct), tag: b64(bombSealed.tag),
+        }), /decompression ratio|max size/);
+    } finally {
+        env.cleanup();
+    }
+});


### PR DESCRIPTION
## 背景
按 FREEZE §15–21 审计，Zephyr Link 的 enrollment 是真的，但 ZSL/2、CDC blob、strict broker、双向同步都停留在「有库有测试、没接线」。本 PR 把 ZSL/2 第一次接到真实传输层。

## 落地（implemented，已测试）
- `link-v2-transport.js`：会话表 + `POST /api/link/v2/handshake`（X25519+ML-KEM-768 混合握手，锚定 consumed enrollment 设备）+ `GET /state` + `POST /push` + `/api/link/v2/stream` WSS upgrade。帧为 codec-packed CBOR（zstd 在加密前、secret 帧不压缩），用 ZSL/2 AEAD 密封。
- `link-v2-enrollment.js`：新增 `deviceById`，会话只锚定已完成 enrollment 的设备。
- 握手在 enrollment 查询前先校验 KEM 尺寸，消除尺寸差异 oracle。

## 安全自检（FREEZE §25–29 涉及项）
- MITM/恶意 CDN、replay、decompression bomb、frame 溢出、secret 压缩隔离、会话锚定：均落地并有测试。

## 明确 planned（未实现，不假装）
- 移动端 Kotlin ZSL 客户端（需真机验证，后续 PR）。
- WSS 帧的 9 通道业务分发（当前统一 ACK）。
- §19 完整双向同步协议跑在 ZSL 上的端到端。

## 验证
link-v2 测试 20/20 通过（含真实 server 起动的 HTTP 路由集成 + ZSL 握手密封帧端到端往返）。