### PR TITLE
fix(ai): conversation delete no longer skips or 409s on stale revision

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -9317,12 +9317,46 @@ function deleteAiChat(id) {
     });
 }
 async function deleteAiChatConfirmed(id) {
-    const target = aiChatSessions.find((session) => session.id === id);
-    if (target?.revision > 0) {
-        await api(`/api/ai/history/conversations/${encodeURIComponent(id)}`, {
-            method: 'DELETE',
-            body: JSON.stringify({ expectedRevision: target.revision }),
-        });
+    /* Two real failure modes lived here: a session whose local revision was 0 skipped the server
+     * delete entirely (so it came back on reload), and a stale local revision produced a 409. Make
+     * the session canonical first (which persists a revision-0 local session and returns its real
+     * revision), refresh from the server so the revision is current, then delete with that. A 404
+     * means the server never had it — that is a successful delete, not an error. */
+    let target = aiChatSessions.find((session) => session.id === id);
+    if (target && !(target.revision > 0)) {
+        target = await ensureCanonicalAiConversation(target).catch(() => target);
+    }
+    if (target) {
+        let revision = Number(target.revision) || 0;
+        if (!(revision > 0)) {
+            await loadAiChats({ force: true }).catch(() => {});
+            target = aiChatSessions.find((session) => session.id === id);
+            revision = Number(target?.revision) || 0;
+        }
+        if (revision > 0) {
+            try {
+                await api(`/api/ai/history/conversations/${encodeURIComponent(id)}`, {
+                    method: 'DELETE',
+                    body: JSON.stringify({ expectedRevision: revision }),
+                });
+            } catch (error) {
+                /* A 409 means our revision was stale — refetch the current one and delete once more
+                 * instead of failing the user. A 404 means it was already gone server-side. */
+                if (error?.status === 409 || error?.code === 'revision_conflict') {
+                    await loadAiChats({ force: true }).catch(() => {});
+                    const fresh = aiChatSessions.find((session) => session.id === id);
+                    const freshRevision = Number(fresh?.revision) || 0;
+                    if (freshRevision > 0) {
+                        await api(`/api/ai/history/conversations/${encodeURIComponent(id)}`, {
+                            method: 'DELETE',
+                            body: JSON.stringify({ expectedRevision: freshRevision }),
+                        });
+                    }
+                } else if (error?.status !== 404) {
+                    throw error;
+                }
+            }
+        }
     }
     if (aiEditingSessionId === id) cancelAiMessageEdit({ focus: false });
     const controller = aiRunForSession(id);

--- a/tests/ai-history-web-contract.test.mjs
+++ b/tests/ai-history-web-contract.test.mjs
@@ -93,7 +93,13 @@ test('delete, clear, edit, and regeneration use canonical CAS deletes', () => {
   const tailDelete = between('async function deleteCanonicalAiTail', 'async function sendAiMessage');
   const send = between('async function sendAiMessage()', 'async function appendAiFiles');
 
-  assert.match(conversationDelete, /method:\s*'DELETE'[\s\S]*expectedRevision:\s*target\.revision/);
+  /* The delete must still be a canonical CAS delete — an expectedRevision is always sent. The
+   * revision now comes from the canonical-ized session (a refetched `revision` local), not the
+   * possibly-stale in-memory `target.revision`, so a 0 or stale revision can no longer silently
+   * skip or 409 the server delete. */
+  assert.match(conversationDelete, /method:\s*'DELETE'[\s\S]*expectedRevision:\s*revision/);
+  assert.match(conversationDelete, /ensureCanonicalAiConversation/);
+  assert.match(conversationDelete, /revision_conflict/);
   assert.match(clear, /method:\s*'DELETE'[\s\S]*expectedRevision:\s*session\.revision/);
   assert.match(tailDelete, /method:\s*'DELETE'[\s\S]*expectedRevision:\s*Number\(message\.revision\)\s*\|\|\s*1/);
   assert.match(send, /await deleteCanonicalAiTail\(session,\s*editingIndex\)/);


### PR DESCRIPTION
主端 AI 对话删除失败修复。

两个真实失败模式：
- 本地 revision=0 的会话跳过服务端 DELETE → 重新加载又出现；
- 陈旧内存 revision → 409 revision_conflict → 提示删除失败。

修复：删除前 canonical 化会话 + 刷新 revision，409 自动重读重试一次，404 视为已删。仍是 canonical CAS delete。web 契约断言更新。

测试：ai-history 全套 35/35（service/runtime/web-contract/mobile-v1）。