### PR TITLE
fix(one): bind flow hangs forever + binding screen UI overhaul

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
@@ -21,8 +21,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.material3.CircularProgressIndicator
 import one.zephyr.mobile.ui.component.Button
+import one.zephyr.mobile.ui.component.CircularProgressIndicator
 import one.zephyr.mobile.ui.component.FieldRow
 import one.zephyr.mobile.ui.component.GroupCard
 import one.zephyr.mobile.ui.component.Text
@@ -289,8 +289,6 @@ fun BindingScreen(
                         ) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(20.dp),
-                                strokeWidth = 2.dp,
-                                color = ZephyrTheme.palette.brand.accent,
                             )
                             Text(
                                 "正在写入设备密钥并拉取镜像…",
@@ -353,7 +351,7 @@ private fun EnrollmentWaitingCard(
                     color = palette.onBackground,
                 )
             }
-            Box(Modifier.fillMaxWidth().padding(horizontal = 14.dp).height(1.dp).background(palette.surfaces.outlineSoft))
+            HorizontalDivider(Modifier.padding(horizontal = 14.dp))
             Column(
                 Modifier
                     .fillMaxWidth()
@@ -369,7 +367,7 @@ private fun EnrollmentWaitingCard(
                     color = palette.onBackground,
                 )
             }
-            Box(Modifier.fillMaxWidth().padding(horizontal = 14.dp).height(1.dp).background(palette.surfaces.outlineSoft))
+            HorizontalDivider(Modifier.padding(horizontal = 14.dp))
             Column(
                 Modifier
                     .fillMaxWidth()

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
@@ -25,6 +25,7 @@ import one.zephyr.mobile.ui.component.Button
 import one.zephyr.mobile.ui.component.CircularProgressIndicator
 import one.zephyr.mobile.ui.component.FieldRow
 import one.zephyr.mobile.ui.component.GroupCard
+import one.zephyr.mobile.ui.component.HorizontalDivider
 import one.zephyr.mobile.ui.component.Text
 import one.zephyr.mobile.ui.component.TextButton
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## 绑定卡死根因

Go `Node.Dial`/`SendFrame` 用裸 `http.Post`（`http.DefaultClient`，零超时）。主端不可达或半开连接时握手永久阻塞 → 绑定永远卡「正在写入设备密钥并拉取镜像」。

## 修复

- Go `dialClient` 加 15s 超时（handshake + push）
- Kotlin 绑定 UI 加 90s `withTimeout` 兜底
- 授权页 UI 重写：GroupCard + FieldRow（对齐设置/笔记风格）、等待页卡片化（二维码卡 + 短码/SAS/指纹分组卡）、WORKING 步加进度指示
- 不用 material3（项目无此依赖），用 core-ui 的 CircularProgressIndicator + HorizontalDivider

## 测试

- Go: vet + test 全过
- Kotlin: 括号平衡 + 组件签名对齐（FieldRow/GroupCard/HorizontalDivider/CircularProgressIndicator 均为项目 core-ui 组件）
- .so 已在干净树重建（vcs.modified=false）