### PR TITLE
fix(one): shorten bind timeout to 45s + fix misleading mirror copy

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
@@ -110,10 +110,11 @@ fun BindingScreen(
                         step = BindStep.WORKING
                         status = "主端已批准，正在完成本机绑定…"
                         val result = try {
-                            // Hard ceiling on the whole completion path: credential store, graph
-                            // build and the first bootstrap round. A peer that never answers used
-                            // to leave this screen on 正在写入设备密钥 forever.
-                            withTimeout(90_000) {
+                            // Hard ceiling on the whole completion path. OkHttp's callTimeout is
+                            // 120s and execute() is not cancellable, so this must fire first —
+                            // otherwise the coroutine times out but the HTTP call keeps running
+                            // and the result is never delivered to the UI.
+                            withTimeout(45_000) {
                                 container.bindingCoordinator.consumePreparedEnrollment(
                                     prepared = current,
                                     intervalSec = 300,
@@ -125,7 +126,7 @@ fun BindingScreen(
                             BindingCompletionResult.Failed(
                                 MobileError.local(
                                     "bind_completion_timeout",
-                                    "完成绑定超时（90 秒），请检查服务器可达后重试",
+                                    "完成绑定超时（45 秒），请检查手机能否访问服务器后重试",
                                 ),
                             )
                         }
@@ -292,7 +293,7 @@ fun BindingScreen(
                                 modifier = Modifier.size(20.dp),
                             )
                             Text(
-                                "正在写入设备密钥并拉取镜像…",
+                                "正在写入设备密钥并同步账号数据…",
                                 color = ZephyrTheme.palette.onBackground,
                                 fontSize = 14.sp,
                             )


### PR DESCRIPTION
## 问题

绑定卡在「正在写入设备密钥并拉取镜像」不动。

## 根因

1. `withTimeout(90_000)` 包了整个 consume+bootstrap，但 OkHttp `callTimeout = 120s` 且 `execute()` 是同步阻塞——协程取消不会中断 HTTP 调用，结果永远送不到 UI。
2. 「拉取镜像」文案误导——这是首次同步账号数据（bootstrap），不是 Docker 镜像。

## 修复

- 超时从 90s 缩到 45s（OkHttp callTimeout 120s 之前先触发，UI 能拿到超时错误）
- 超时提示改为「请检查手机能否访问服务器」
- 「拉取镜像」→「同步账号数据」