### PR TITLE
fix(one): LaunchedEffect key change killed the bind coroutine mid-flight

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
@@ -90,7 +90,11 @@ fun BindingScreen(
         }
     }
 
-    LaunchedEffect(prepared, step) {
+    // NOTE: only `prepared` may be a key here. `step` must NOT be: the loop itself sets
+    // step = WORKING on approval, and a key change cancels this coroutine mid-flight —
+    // killing the consume/bootstrap work silently and leaving the screen spinning on
+    // WORKING forever with no error. That was the actual cause of the endless spinner.
+    LaunchedEffect(prepared) {
         val current = prepared ?: return@LaunchedEffect
         if (step != BindStep.WAITING) return@LaunchedEffect
         while (true) {


### PR DESCRIPTION
## 真正的根因（终于找到了）

绑定批准后永远转圈、无错误、无超时——之前的超时加固（45s withTimeout、可取消 HTTP、readLine 超时）全部无效，因为协程在被调用前就死了：

```kotlin
LaunchedEffect(prepared, step) {   // step 是 key
    ...
    "approved" -> {
        step = BindStep.WORKING    // 改 key = 立即取消自己
        val result = withTimeout(45_000) { consumePreparedEnrollment(...) }  // 从未真正执行
        when (result) { ... }      // 死代码，永远到不了
    }
}
```

`step = BindStep.WORKING` 改变了 LaunchedEffect 的 key → 协程被取消重启 → 重启后 `step != WAITING` 直接 return。consume 刚被调就取消，结果分支永远不执行。

## 修复

LaunchedEffect 只以 `prepared` 为 key；`step` 转换（WORKING/SERVER）在循环内只是普通 state 写入，不再重启自己。

## 为什么之前的修复无效

pre41/42/43 的所有超时与取消加固都是对的，但它们包在一个已经死掉的协程里——超时永远无法触发，因为没有任何东西在跑。