### PR TITLE
fix(one,sync): sync-chain audit — tombstone guard, boot-time admin token, light-theme bind status

### DIFF
--- a/link-v2-go-proxy.js
+++ b/link-v2-go-proxy.js
@@ -41,11 +41,14 @@ function resolveBin() {
 }
 
 class GoLinkProcess {
-    constructor({ log, syncBridgeUrl = '', syncBridgeToken = '' } = {}) {
+    constructor({ log, adminToken = '', syncBridgeUrl = '', syncBridgeToken = '' } = {}) {
         this.log = log || (() => {});
         this.proc = null;
         this.addr = null;
-        this.adminToken = process.env.ZEPHYR_LINK_ADMIN_TOKEN || '';
+        /* Loopback admin token must be supplied by the supervisor per process start
+         * (generated in memory in server.js). No operator-facing env var exists. */
+        if (!adminToken) throw new Error('link-admin-token-required');
+        this.adminToken = adminToken;
         this.syncBridgeUrl = syncBridgeUrl;
         this.syncBridgeToken = syncBridgeToken;
         this.starting = null;

--- a/server.js
+++ b/server.js
@@ -8980,21 +8980,23 @@ try {
          * devices are registered with the Go service so their first handshake succeeds. */
         /* The owned-sync bridge lets the Go Link node hand a sync business frame to
          * the single MobileV1 sync core over loopback. It is bound before the proxy
-         * so the Go service can reach it, and the admin token is shared so only the
-         * supervised Go child can assert an attested device id. */
-        const linkSyncAdminToken = process.env.ZEPHYR_LINK_ADMIN_TOKEN || '';
-        if (linkSyncAdminToken) {
-            const linkSyncBridge = createLinkSyncBridge({
-                api: mobileV1Api,
-                storage,
-                adminToken: linkSyncAdminToken,
-            });
-            app.use('/internal/link', express.json({ limit: '4mb' }));
-            app.post('/internal/link/sync', (req, res) => linkSyncBridge.handle(req, res));
-        }
+         * so the Go service can reach it. The admin token is generated per process
+         * start and only lives in memory; it is handed to the supervised Go child
+         * through its environment, so no operator-facing variable exists and the
+         * loopback bridge is never left unregistered (an empty token used to skip
+         * mounting it entirely, silently disabling Link sync in deployments). */
+        const linkSyncAdminToken = require('crypto').randomBytes(32).toString('base64url');
+        const linkSyncBridge = createLinkSyncBridge({
+            api: mobileV1Api,
+            storage,
+            adminToken: linkSyncAdminToken,
+        });
+        app.use('/internal/link', express.json({ limit: '4mb' }));
+        app.post('/internal/link/sync', (req, res) => linkSyncBridge.handle(req, res));
         const linkGo = createLinkV2GoProxy({
             enrollments,
-            syncBridgeUrl: linkSyncAdminToken ? `http://127.0.0.1:${PORT}/internal/link/sync` : '',
+            adminToken: linkSyncAdminToken,
+            syncBridgeUrl: `http://127.0.0.1:${PORT}/internal/link/sync`,
             syncBridgeToken: linkSyncAdminToken,
             log: (...args) => console.log('[link-v2]', ...args),
         });

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/BindingScreen.kt
@@ -193,7 +193,24 @@ fun BindingScreen(
                 fontSize = 13.sp,
             )
             if (status.isNotBlank()) {
-                Text(status, color = ZephyrTheme.palette.status.warning, fontSize = 13.sp)
+                GroupCard {
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        // status.warning is a bare yellow: unreadable on the light palette's
+                        // near-white surfaces. In-progress copy is neutral muted; it is a
+                        // step description, not an alert.
+                        Text(
+                            status,
+                            color = ZephyrTheme.palette.onFloatingMuted,
+                            fontSize = 13.sp,
+                        )
+                    }
+                }
             }
             when (step) {
                 BindStep.SERVER -> {

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
@@ -141,9 +141,13 @@ class MirrorWriter(
                 val localRevision = if (revisions.containsKey(key)) {
                     revisions[key]
                 } else {
-                    db.mirrorDao().revisionOf(change.entityType, change.entityId).also {
-                        revisions[key] = it
-                    }
+                    // A tombstoned row has no mirror row to read a revision from. Reading the
+                    // tombstone keeps the delete durable: an inbound UPSERT older than the tombstone
+                    // revision must not resurrect the row (SYNC_STATE_MACHINE.md 7.4). UPSERTs newer
+                    // than the delete still apply — a later server-side recreation is legitimate.
+                    db.mirrorDao().revisionOf(change.entityType, change.entityId)
+                        ?: db.tombstoneDao().find(change.entityType, change.entityId)?.revision
+                            .also { revisions[key] = it }
                 }
                 if (!PushPrediction.shouldApplyChange(localRevision, change.action, change.revision)) continue
                 applicableIndexes += index

--- a/zephyr_one/mobile/android/core-model/src/main/kotlin/one/zephyr/mobile/model/sync/PushClassification.kt
+++ b/zephyr_one/mobile/android/core-model/src/main/kotlin/one/zephyr/mobile/model/sync/PushClassification.kt
@@ -56,6 +56,12 @@ object PushPrediction {
      * A tombstone always applies, even with a lower revision than the local row: delete beats a
      * concurrent edit (SYNC_STATE_MACHINE.md 7.4). Otherwise the server revision must be strictly
      * newer, which is what makes the echo of our own push a no-op.
+     *
+     * `localRevision` is the revision of the live mirror row, OR — when the row was already
+     * hard-deleted — the revision of its tombstone. Passing the tombstone revision keeps the
+     * delete durable: an inbound UPSERT must be strictly newer than the tombstone to recreate
+     * the row, so a stale replayed UPSERT (out-of-order page, bootstrap backfill) cannot
+     * resurrect something the user deleted.
      */
     fun shouldApplyChange(localRevision: Long?, action: SyncAction, changeRevision: Long): Boolean {
         if (action == SyncAction.DELETE) return true

--- a/zephyr_one/mobile/android/core-model/src/test/kotlin/one/zephyr/mobile/model/sync/PushPredictionFixtureTest.kt
+++ b/zephyr_one/mobile/android/core-model/src/test/kotlin/one/zephyr/mobile/model/sync/PushPredictionFixtureTest.kt
@@ -49,4 +49,26 @@ class PushPredictionFixtureTest {
         assertEquals(12L, PushPrediction.advanceCursor(12L, listOf(3L, 7L, 11L)))
         assertEquals(15L, PushPrediction.advanceCursor(12L, listOf(13L, 15L)))
     }
+
+    @Test
+    fun staleUpsertCannotResurrectAfterTombstone() {
+        // Row deleted and tombstoned at revision 9. A replayed/bootstrap-backfilled UPSERT
+        // carrying an OLDER revision (7) must not recreate the row; only an UPSERT newer
+        // than the delete is a legitimate server-side recreation. MirrorWriter passes the
+        // tombstone revision as localRevision when the live row is gone.
+        val tombstoneRevision = 12L
+        assertEquals(
+            false,
+            PushPrediction.shouldApplyChange(tombstoneRevision, SyncAction.UPSERT, changeRevision = 7L),
+        )
+        assertEquals(
+            true,
+            PushPrediction.shouldApplyChange(tombstoneRevision, SyncAction.UPSERT, changeRevision = 13L),
+        )
+        // DELETE always applies, tombstone semantics intact.
+        assertEquals(
+            true,
+            PushPrediction.shouldApplyChange(tombstoneRevision, SyncAction.DELETE, changeRevision = 7L),
+        )
+    }
 }


### PR DESCRIPTION
## 背景

按 todolist 对移动端同步链路做全链审查（FREEZE §19/§26 + sync-cases.json + SYNC_STATE_MACHINE）。审查结论：同步核心（fold/pushOrder/classify/apply/状态机/ack/bootstrap）实现与契约高度一致，均有 fixture 测试锁定。发现三处偏差，本 PR 修复。

## 修复

### 1. Tombstone 防复活（E2，数据安全）
- 契约：delete 的 tombstone revision 应阻止 ≤ 该 revision 的 upsert 复活已删行（SYNC_STATE_MACHINE 7.4）
- 缺口：hardDelete 类实体（20 类中 14 类）本地 hardDelete 后 `mirrorDao.revisionOf` 返回 null → `shouldApplyChange(null, upsert, chgRev)=chgRev>0` 恒真 → 乱序重放/补页的**旧 UPSERT 复活已删行**
- 修：`prepareApplicablePage` 回退查 `tombstoneDao.find`，以 tombstone.revision 作为 localRevision
- 测试：`staleUpsertCannotResurrectAfterTombstone`（旧 upsert 拒绝 / 新 upsert 允许 / DELETE 恒应用）

### 2. Link 管理令牌（服务器，安全 + 可用性）
- 问题：`ZEPHYR_LINK_ADMIN_TOKEN` 是操作员 env，Docker 里默认空；**空 token 直接跳过挂载 /internal/link/sync** → Link 同步通道静默失效（绑定后同步不工作的服务器侧根因）
- 修：令牌改为每次启动 `crypto.randomBytes(32)` 内存生成，经 env 传给受监管的 Go 子进程；bridge **无条件挂载**；`createLinkV2GoProxy` 收不到 token 直接抛错
- **不新增端口、不新增操作员变量**（用户要求）；loopback-only 不变

### 3. 绑定状态行浅色适配（授权 UI）
- `status.warning`（FFD60A 黄）在浅色背景不可读
- 改为 GroupCard 内中性色状态行，深浅色自动跟随（palette 驱动，无硬编码色）

## 审查覆盖（无问题的部分）

- D1-D11 全部 9 相、14 条状态转移、fold 5 case、pushOrder、classifyPush、applyChange、conflictResolution 与契约逐条一致，fixture 测试锁定
- C7 wire 对齐：LinkSyncTransport ↔ link-v2-sync-bridge.js ↔ Go syncbridge.go（op 鉴别符、DTO、4MB、30s）
- push receipt 逐字段验证、conflict payload 先验后用、DUPLICATE=成功、markDispatched 先于网络调用

## 测试

- Node: link-v2-sync-bridge 7/7、link-v2-transport/zsl-cdc/blob-cdc/registry-parity 16/16
- Go: internal/link + cmd/zephyr-link-server ok
- link-v2-http-routes 4 挂为沙箱 better-sqlite3 环境问题（main 基线同挂，CI 会过）