### PR TITLE
fix(link): pass adminToken through createLinkV2GoProxy to the child process

### DIFF
--- a/link-v2-go-proxy.js
+++ b/link-v2-go-proxy.js
@@ -119,8 +119,8 @@ function stopLinkV2Go() {
     if (shared.proc) { shared.proc.stop(); shared.proc = null; }
 }
 
-function createLinkV2GoProxy({ log, enrollments, syncBridgeUrl, syncBridgeToken } = {}) {
-    const proc = sharedProcess(log, { syncBridgeUrl, syncBridgeToken });
+function createLinkV2GoProxy({ log, enrollments, adminToken, syncBridgeUrl, syncBridgeToken } = {}) {
+    const proc = sharedProcess(log, { adminToken, syncBridgeUrl, syncBridgeToken });
     // Devices the Go service is known to hold this process lifetime, so we only
     // re-register once per device per restart instead of on every handshake.
     const registered = new Set();


### PR DESCRIPTION
## 严重回归（PR #68 引入，必须立即修）

server.js 改为内存随机生成管理令牌后传给 `createLinkV2GoProxy`，但**工厂函数没有接收 adminToken**——参数被丢弃，`GoLinkProcess` 构造器的必填守卫抛 `link-admin-token-required`，`server.js` 的 try/catch 吞掉（只打日志 `[link-v2] enrollment failed to mount`），**整个 /api/link/v2 反代没挂** → 所有 Link 端点 404（绑定界面报 unstructured HTTP 404）。

## 修复

工厂签名加 `adminToken` 并透传 `sharedProcess` → `GoLinkProcess`。

## 验证

- 有 token：router 正常构造 ✅
- 无 token：工厂抛错（fail-closed）✅
- link-v2-sync-bridge 7/7 ✅