### PR TITLE
fix(link): allow enrollment devices to complete first bootstrap

### DIFF
--- a/mobile-v1-routes.js
+++ b/mobile-v1-routes.js
@@ -49,6 +49,9 @@ const mobileProof = require('./mobile-v1-proof');
 const secretCrypto = require('./secret-crypto');
 const { HttpError } = require('./authz');
 
+/** Link enrollment has no legacy Client Token; this marker is frozen on the bind row. */
+const LINK_ENROLLMENT_TOKEN_ID = 'link-v2-enrollment';
+
 /** Protocol versions this build speaks. A client outside this set is fatal. */
 const PROTOCOL_VERSIONS = [1];
 const MAX_OPS_PER_BATCH = 200;
@@ -781,14 +784,17 @@ class MobileV1Api {
             return null;
         }
 
-        /* The Client Token that authorised the binding must still exist. Its
-         * deletion on the main end is the documented way to cut a device off,
-         * so a stale binding must not keep syncing. */
+        /* Legacy Client-Token bindings remain coupled to that token's lifetime. Link enrollment
+         * deliberately has no Client Token; its sentinel row is revoked through mobile_devices and
+         * must not be looked up in the legacy token registry. Doing so rejects every first
+         * capabilities/bootstrap request with token_missing after an otherwise successful bind. */
         try {
-            const tokens = this.fileAgentManager.listTokens(user.username);
-            if (!tokens.some((t) => t.id === row.token_id)) {
-                sendError(res, 403, 'token_missing', '\u5173\u8054 Token \u5df2\u5220\u9664\uff0c\u8bf7\u91cd\u65b0\u7ed1\u5b9a', { requestId: req.mobileRequestId });
-                return null;
+            if (row.token_id !== LINK_ENROLLMENT_TOKEN_ID) {
+                const tokens = this.fileAgentManager.listTokens(user.username);
+                if (!tokens.some((t) => t.id === row.token_id)) {
+                    sendError(res, 403, 'token_missing', '\u5173\u8054 Token \u5df2\u5220\u9664\uff0c\u8bf7\u91cd\u65b0\u7ed1\u5b9a', { requestId: req.mobileRequestId });
+                    return null;
+                }
             }
         } catch {
             // A token registry read failure must not be reported as "revoked".

--- a/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
+++ b/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createProofClient } from './mobile-v1-proof-client.mjs';
 
 const require = createRequire(import.meta.url);
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -444,6 +445,18 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     }),
   });
   assert.equal(consume.status, 200, await consume.clone().text());
+  const binding = await consume.json();
+  const proofFetch = createProofClient({
+    base: server.url(''),
+    access: binding.accessCredential,
+    deviceId,
+    privateKey: signing.privateKey,
+  });
+  const bootstrap = await proofFetch('/api/mobile/v1/sync/bootstrap?pageSize=50');
+  assert.equal(bootstrap.status, 200, await bootstrap.clone().text());
+  const snapshot = await bootstrap.json();
+  assert.equal(snapshot.ok, true);
+  assert.ok(Number.isSafeInteger(snapshot.snapshotCursor));
 
   const devices = await server.api(login.cookie, 'GET', '/api/one/clients');
   assert.equal(devices.status, 200);
@@ -465,30 +478,42 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     x25519Public: Buffer.from(hello.x25519Public, 'base64url'),
     mlkemCiphertext: Buffer.from(hello.mlkemCiphertext, 'base64url'),
   });
-  const sealed = session.seal(codec.pack({
-    kind: codec.KIND.SYNC_OP,
-    body: { op: 'status' },
-  }));
-  const push = await fetch(server.url('/api/link/v2/push'), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      sessionId: hello.sessionId,
-      seq: sealed.seq,
-      iv: Buffer.from(sealed.iv).toString('base64url'),
-      ct: Buffer.from(sealed.ct).toString('base64url'),
-      tag: Buffer.from(sealed.tag).toString('base64url'),
-    }),
-  });
-  assert.equal(push.status, 200, await push.clone().text());
-  const ack = await push.json();
-  const unpacked = codec.unpack(session.open({
-    seq: ack.seq,
-    iv: Buffer.from(ack.iv, 'base64url'),
-    ct: Buffer.from(ack.ct, 'base64url'),
-    tag: Buffer.from(ack.tag, 'base64url'),
-  }));
-  assert.equal(unpacked.kind, codec.KIND.SYNC_ACK);
-  assert.equal(unpacked.body.ok, true);
-  assert.equal(unpacked.body.state, 'IDLE', JSON.stringify(unpacked.body));
+  async function syncOp(body) {
+    const sealed = session.seal(codec.pack({ kind: codec.KIND.SYNC_OP, body }));
+    const push = await fetch(server.url('/api/link/v2/push'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        sessionId: hello.sessionId,
+        seq: sealed.seq,
+        iv: Buffer.from(sealed.iv).toString('base64url'),
+        ct: Buffer.from(sealed.ct).toString('base64url'),
+        tag: Buffer.from(sealed.tag).toString('base64url'),
+      }),
+    });
+    assert.equal(push.status, 200, await push.clone().text());
+    const ack = await push.json();
+    const unpacked = codec.unpack(session.open({
+      seq: ack.seq,
+      iv: Buffer.from(ack.iv, 'base64url'),
+      ct: Buffer.from(ack.ct, 'base64url'),
+      tag: Buffer.from(ack.tag, 'base64url'),
+    }));
+    assert.equal(unpacked.kind, codec.KIND.SYNC_ACK);
+    return unpacked.body;
+  }
+
+  const changes = await syncOp({ op: 'changes', sinceCursor: snapshot.snapshotCursor, limit: 50 });
+  assert.equal(changes.ok, true);
+  assert.equal(changes.fromCursor, snapshot.snapshotCursor);
+  assert.equal(changes.nextCursor, snapshot.snapshotCursor);
+  assert.deepEqual(changes.changes, []);
+
+  const acknowledged = await syncOp({ op: 'ack', cursor: changes.nextCursor, appliedOpIds: [] });
+  assert.equal(acknowledged.ok, true);
+
+  const status = await syncOp({ op: 'status' });
+  assert.equal(status.ok, true);
+  assert.equal(status.state, 'IDLE', JSON.stringify(status));
+  assert.equal(status.cursor, changes.nextCursor);
 });


### PR DESCRIPTION
## Root cause\nLink enrollment intentionally uses the sentinel token id `link-v2-enrollment` and does not create a legacy Client Token. The HTTP device-auth layer still required every device row's token id to exist in the legacy token registry. Therefore the first proof challenge/bootstrap failed with `token_missing` after enrollment had otherwise succeeded.\n\n## Fix\n- preserve legacy token-lifetime checks for legacy bindings\n- authorize Link-enrollment devices from the live `mobile_devices` authority instead\n- extend the real enrollment test through authenticated bootstrap, Link changes, Link ack, and final status/cursor\n\n## Validation\n- enrollment suite 7/7\n- proof/bootstrap suites 7/7\n- real full first-sync loop passes