### PR TITLE
fix(one): complete bidirectional Link sync and harden startup recovery

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt
@@ -54,11 +54,13 @@ class ZephyrOneApplication : Application(), Configuration.Provider {
         super.onCreate()
         RdpAndroidRuntime.installHome(filesDir)
         container = AppContainer(this)
-        container.clearPendingBindingAuthentication()
         WorkManager.initialize(this, workManagerConfiguration)
         ProcessLifecycleOwner.get().lifecycle.addObserver(LockLifecycleObserver())
         applicationScope.launch {
             try {
+                // Pending password/TOTP state is process-local and cannot resume after death. Clear
+                // its durable crumbs off Main together with the rest of startup recovery.
+                container.clearPendingBindingAuthentication()
                 runCatching { container.bindingCoordinator.completePendingTeardown() }
                 // A database tombstone can outlive its journal if the process died after the journal clear.
                 runCatching { container.sweepErasedAccountDatabases() }

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -44,6 +44,8 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
@@ -168,14 +170,45 @@ fun ZephyrOneRoot(
 ) {
     Surface(modifier = modifier.fillMaxSize(), color = ZephyrTheme.palette.surfaces.background) {
         val account by container.accounts.collectAsState()
+        var recoveryAttempt by remember { mutableStateOf(0) }
+        var recoveryError by remember { mutableStateOf<String?>(null) }
+        LaunchedEffect(account, recoveryAttempt) {
+            if (account == null) {
+                // Opening Room/SQLCipher and reconciling platform grants are blocking operations.
+                // Keep them off Main; if recovery fails, render a retryable state rather than an
+                // endless blank/loading frame with no diagnostic surface.
+                recoveryError = null
+                runCatching {
+                    withContext(Dispatchers.IO) { container.ensureLocalWorkspace().activate() }
+                }.onFailure { failure ->
+                    recoveryError = failure.message ?: failure::class.java.simpleName
+                }
+            }
+        }
         when {
             /* The lock gate outranks everything, including a bound account: AppLock is the product
              * gate, and drawing a screen behind it would expose content to the recents screenshot. */
             locked -> LockGate(onUnlockRequested = onUnlockRequested)
 
-            /* Startup recovery is still opening the local workspace. The window already matches
-             * the dashboard colour, so this is a same-colour hold rather than a black flash. */
-            account == null -> Box(Modifier.fillMaxSize())
+            /* Recovery is rebuilding the local fallback after an unusable bound graph. Never draw
+             * a visually blank application state; a visible progress affordance also distinguishes
+             * recovery from a crashed composition. */
+            account == null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                val error = recoveryError
+                if (error == null) {
+                    one.zephyr.mobile.ui.component.CircularProgressIndicator()
+                } else {
+                    Column(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Text("工作区恢复失败", style = ZephyrTextStyles.pushedTitle)
+                        Text(error.take(180), color = ZephyrTheme.palette.onFloatingMuted, textAlign = TextAlign.Center)
+                        Button(onClick = { recoveryAttempt += 1 }) { Text("重试") }
+                    }
+                }
+            }
 
             else -> account?.let { activeAccount ->
                 key(activeAccount.generation) {

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
@@ -192,6 +192,7 @@ interface ManagedBindingGraph {
     /** Discards an unpublished generation without touching application-wide platform grants. */
     fun discardPreparedState()
     suspend fun bootstrapAfterBind(): List<SyncRoundResult>
+    suspend fun runForegroundRound(): List<SyncRoundResult> = emptyList()
     suspend fun runScheduledRound(): List<SyncRoundResult>
     suspend fun accountDatabaseRequiresBootstrap(): Boolean = false
     suspend fun markAccountDatabaseReady() = Unit
@@ -293,7 +294,8 @@ class BindingCoordinator internal constructor(
 
     private data class RestorePreparation(
         val result: BindingRestoreResult,
-        val bootstrapGraph: ManagedBindingGraph? = null,
+        val restoredGraph: ManagedBindingGraph? = null,
+        val requiresBootstrap: Boolean = false,
         val binding: AccountBinding? = null,
     )
 
@@ -347,15 +349,20 @@ class BindingCoordinator internal constructor(
             if (host.currentGraph() !== graph) replaceGraphLocked(graph)
             RestorePreparation(
                 result = BindingRestoreResult.Restored(stored.binding),
-                bootstrapGraph = graph.takeIf { requiresBootstrap },
+                restoredGraph = graph,
+                requiresBootstrap = requiresBootstrap,
                 binding = stored.binding,
             )
         }
         // Bootstrap can perform network I/O. Keep it outside the coordinator mutex so unbind or a
         // revoke can cancel the graph, join the round, and erase the database immediately.
-        preparation.bootstrapGraph?.takeIf { bootstrap }?.let { graph ->
-            graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
-                markBootstrapReadyIfCurrent(graph, checkNotNull(preparation.binding), round.endState)
+        preparation.restoredGraph?.takeIf { bootstrap }?.let { graph ->
+            if (preparation.requiresBootstrap) {
+                graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
+                    markBootstrapReadyIfCurrent(graph, checkNotNull(preparation.binding), round.endState)
+                }
+            } else {
+                graph.runForegroundRound()
             }
         }
         workersMayRun = preparation.result !is BindingRestoreResult.LocalCleanupRequired
@@ -364,13 +371,13 @@ class BindingCoordinator internal constructor(
 
     /** Retries a restored account's initial sync without blocking process startup. */
     suspend fun bootstrapRestoredBinding() {
-        val graph = mutex.withLock {
-            val current = host.currentGraph() ?: return
-            if (!current.accountDatabaseRequiresBootstrap()) return
-            current
-        }
-        graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
-            markBootstrapReadyIfCurrent(graph, graph.binding, round.endState)
+        val graph = mutex.withLock { host.currentGraph() ?: return }
+        if (graph.accountDatabaseRequiresBootstrap()) {
+            graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
+                markBootstrapReadyIfCurrent(graph, graph.binding, round.endState)
+            }
+        } else {
+            graph.runForegroundRound()
         }
     }
 

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
@@ -634,7 +634,21 @@ class AccountContainer(
 
     /** Runs the first bootstrap inside this account's cancellable lifetime. */
     override suspend fun bootstrapAfterBind(): List<SyncRoundResult> =
-        if (!localMode && networkEnabled.get()) syncScope.async { syncEngine.onBindComplete() }.await() else emptyList()
+        if (!localMode && networkEnabled.get()) syncScope.async {
+            // A failed pre-fix first round may have persisted REAUTH_REQUIRED even though no snapshot
+            // was ever committed. The encrypted readiness marker is the authority for whether this
+            // generation has usable data; missing marker forces a fresh bootstrap after credentials
+            // become valid again. Invalid credentials still fail validation and restore reauth.
+            if (accountDatabaseRequiresBootstrap()) {
+                syncState.ensure(bindingKey)
+                syncState.updateState(bindingKey, one.zephyr.mobile.contracts.BindingState.BOUND_NEEDS_BOOTSTRAP)
+            }
+            syncEngine.onBindComplete()
+        }.await() else emptyList()
+
+    /** Runs once after a restored, already-bootstrapped graph is published. */
+    override suspend fun runForegroundRound(): List<SyncRoundResult> =
+        if (!localMode && networkEnabled.get()) syncScope.async { syncEngine.onForegroundStart() }.await() else emptyList()
 
     /** Runs only when the worker's persisted identity has already matched this graph. */
     override suspend fun runScheduledRound(): List<SyncRoundResult> =

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/StartupThemeTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/StartupThemeTest.kt
@@ -40,6 +40,9 @@ class StartupThemeTest {
         assertTrue(source.contains("finally"))
         assertTrue(source.contains("readyState.value = true"))
         assertTrue(source.contains("TimeoutCancellationException"))
+        val onCreate = source.substringAfter("override fun onCreate()")
+        assertFalse(onCreate.substringBefore("applicationScope.launch").contains("clearPendingBindingAuthentication"))
+        assertTrue(onCreate.substringAfter("applicationScope.launch").contains("clearPendingBindingAuthentication"))
     }
 
     @Test

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
@@ -301,6 +301,8 @@ class BindingCoordinatorTest {
             restoredGraphsAreRecoverable = true,
         )
         assertTrue(first.restoreActiveBinding() is BindingRestoreResult.Restored)
+        assertEquals(1, firstGraphs.single().foregroundCalls)
+        assertEquals(0, firstGraphs.single().bootstrapCalls)
 
         // A new host/coordinator models process death: no in-memory graph is carried across.
         val recreatedGraphs = mutableListOf<FakeGraph>()
@@ -313,11 +315,54 @@ class BindingCoordinatorTest {
         )
         assertTrue(recreated.restoreActiveBinding() is BindingRestoreResult.Restored)
         val graph = recreatedGraphs.single()
+        assertEquals(1, graph.foregroundCalls)
+        assertEquals(0, graph.bootstrapCalls)
 
         val workerGraph = recreated.graphForWorker(graph.bindingKey, graph.generation)
         assertNotNull(workerGraph)
         workerGraph!!.runScheduledRound()
         assertEquals(1, graph.scheduledCalls)
+    }
+
+    @Test
+    fun `deferred restored binding runs exactly one foreground round when already bootstrapped`() = runTest {
+        val storage = FakeStorage(mutableListOf()).apply { active = storedBinding() }
+        val graphs = mutableListOf<FakeGraph>()
+        val coordinator = coordinator(
+            storage,
+            FakeHost(mutableListOf()),
+            graphs,
+            mutableListOf(),
+            restoredGraphsAreRecoverable = true,
+        )
+
+        assertTrue(coordinator.restoreActiveBinding(bootstrap = false) is BindingRestoreResult.Restored)
+        val graph = graphs.single()
+        assertEquals(0, graph.bootstrapCalls)
+        assertEquals(0, graph.foregroundCalls)
+
+        coordinator.bootstrapRestoredBinding()
+        assertEquals(0, graph.bootstrapCalls)
+        assertEquals(1, graph.foregroundCalls)
+    }
+
+    @Test
+    fun `deferred restored binding runs bootstrap without a duplicate foreground round`() = runTest {
+        val storage = FakeStorage(mutableListOf()).apply { active = storedBinding() }
+        val graphs = mutableListOf<FakeGraph>()
+        val coordinator = coordinator(
+            storage,
+            FakeHost(mutableListOf()),
+            graphs,
+            mutableListOf(),
+            restoredGraphsAreRecoverable = true,
+            restoredDatabaseRequiresBootstrap = true,
+        )
+
+        assertTrue(coordinator.restoreActiveBinding(bootstrap = false) is BindingRestoreResult.Restored)
+        coordinator.bootstrapRestoredBinding()
+        assertEquals(1, graphs.single().bootstrapCalls)
+        assertEquals(0, graphs.single().foregroundCalls)
     }
 
     @Test
@@ -1800,6 +1845,7 @@ private class FakeGraph(
     private val job = SupervisorJob()
     private val scope = CoroutineScope(job + Dispatchers.Default)
     var bootstrapCalls = 0
+    var foregroundCalls = 0
     var scheduledCalls = 0
     var databaseReadyCalls = 0
     var storedAccess: String? = null
@@ -1840,6 +1886,12 @@ private class FakeGraph(
         events += "graph.bootstrap"
         bootstrapCalls += 1
         listOf(successfulRound(SyncTrigger.BIND_COMPLETE))
+    }.await()
+
+    override suspend fun runForegroundRound(): List<SyncRoundResult> = scope.async {
+        events += "graph.foreground"
+        foregroundCalls += 1
+        listOf(successfulRound(SyncTrigger.FOREGROUND_START))
     }.await()
 
     override suspend fun runScheduledRound(): List<SyncRoundResult> = scope.async {

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/LinkSyncTransport.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/LinkSyncTransport.kt
@@ -1,6 +1,7 @@
 package one.zephyr.mobile.sync
 
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
@@ -85,7 +86,7 @@ class LinkSyncTransport(
             put("sinceCursor", sinceCursor)
             if (limit != null) put("limit", limit)
         }
-        val ack = channel.syncOp("changes", body)
+        val ack = channel.syncOp("changes", wireBody("changes", body))
         json.decodeFromJsonElement(ChangePageDto.serializer(), ack).toDomain()
     }
 
@@ -116,14 +117,13 @@ class LinkSyncTransport(
                 registryHash = registryHash,
                 operations = operationDtos,
             )
-            /* The op discriminator rides alongside the standard push fields; the server bridge reads
-             * `op` and the rest of the body is the exact PushRequestDto the HTTP route would get. */
+            /* wireBody injects the op discriminator for every verb. The remaining body is the
+             * exact PushRequestDto the HTTP route would get. */
             val body = buildJsonObject {
-                put("op", "push")
                 json.encodeToJsonElement(PushRequestDto.serializer(), request).jsonObject
                     .forEach { (k, v) -> put(k, v) }
             }
-            val ack = channel.syncOp("push", body)
+            val ack = channel.syncOp("push", wireBody("push", body))
             json.decodeFromJsonElement(PushResponseDto.serializer(), ack).toDomain()
         }
     }
@@ -131,12 +131,21 @@ class LinkSyncTransport(
     override suspend fun ack(cursor: Long, appliedOpIds: List<String>): ApiResult<ValidatedAck> = runLink {
         val request = AckRequestDto(deviceId = deviceId, cursor = cursor, appliedOpIds = appliedOpIds)
         val body = buildJsonObject {
-            put("op", "ack")
             json.encodeToJsonElement(AckRequestDto.serializer(), request).jsonObject
                 .forEach { (k, v) -> put(k, v) }
         }
-        channel.syncOp("ack", body)
+        channel.syncOp("ack", wireBody("ack", body))
         ValidatedAck
+    }
+
+    private fun wireBody(op: String, body: JsonObject): JsonObject = buildJsonObject {
+        put("op", JsonPrimitive(op))
+        body.forEach { (key, value) ->
+            require(key != "op" || value == JsonPrimitive(op)) {
+                "Link sync body op does not match the requested operation"
+            }
+            put(key, value)
+        }
     }
 
     private suspend fun <T> runLink(block: suspend () -> T): ApiResult<T> = try {

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncEngine.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncEngine.kt
@@ -164,8 +164,11 @@ class SyncEngine(
             }
         }
 
-        scope.launch { run(SyncTrigger.FOREGROUND_START, respectPolicy = true) }
     }
+
+    /** One explicit foreground-start round after restore has decided bootstrap is not required. */
+    suspend fun onForegroundStart(): List<SyncRoundResult> =
+        run(SyncTrigger.FOREGROUND_START, respectPolicy = true)
 
     /**
      * @param respectPolicy false for user-initiated rounds, which must work on any link.

--- a/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/LinkSyncTransportTest.kt
+++ b/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/LinkSyncTransportTest.kt
@@ -59,6 +59,7 @@ class LinkSyncTransportTest {
         assertEquals(5L, (result as ApiResult.Success).value.nextCursor)
         assertEquals(1, channel.calls.size)
         assertEquals("changes", channel.calls[0].first)
+        assertEquals("changes", channel.calls[0].second["op"]!!.jsonPrimitive.content)
         assertEquals(5L, channel.calls[0].second["sinceCursor"]!!.jsonPrimitive.longOrNull)
     }
 
@@ -85,6 +86,7 @@ class LinkSyncTransportTest {
         assertTrue(result is ApiResult.Success)
         val (op, body) = channel.calls.single()
         assertEquals("push", op)
+        assertEquals("push", body["op"]!!.jsonPrimitive.content)
         assertEquals("batch-1", body["batchId"]!!.jsonPrimitive.content)
         assertEquals("hash-1", body["registryHash"]!!.jsonPrimitive.content)
         assertEquals("dev-1", body["deviceId"]!!.jsonPrimitive.content)
@@ -112,6 +114,19 @@ class LinkSyncTransportTest {
         val result = transport.ack(cursor = 3, appliedOpIds = listOf("op-1"))
         assertTrue(result is ApiResult.Failure)
         assertEquals("link_unavailable", (result as ApiResult.Failure).error.code)
+    }
+
+    @Test
+    fun `ack carries its op discriminator and standard fields`() = runTest {
+        val channel = FakeChannel()
+        channel.ackResponder = { _, _ -> buildJsonObject { put("ok", true) } }
+        val transport = LinkSyncTransport(channel, "dev-1", NoopFallback)
+        assertTrue(transport.ack(cursor = 3, appliedOpIds = listOf("op-1")) is ApiResult.Success)
+        val (op, body) = channel.calls.single()
+        assertEquals("ack", op)
+        assertEquals("ack", body["op"]!!.jsonPrimitive.content)
+        assertEquals(3L, body["cursor"]!!.jsonPrimitive.longOrNull)
+        assertEquals("op-1", body["appliedOpIds"]!!.jsonArray.single().jsonPrimitive.content)
     }
 
     /** The HTTP fallback is never exercised by these tests; it exists so bootstrap/caps delegate. */

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Components.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Components.kt
@@ -116,7 +116,7 @@ fun SyncStatusPill(status: SyncStatus, modifier: Modifier = Modifier) {
         status.bindingState == BindingState.FATAL_INCOMPATIBLE -> "版本不兼容" to palette.status.error
         status.isRunning -> "同步中" to palette.brand.accent
         status.pendingCount > 0 -> "待同步 " + status.pendingCount to palette.status.pendingSync
-        status.lastError != null -> "上次失败" to palette.status.error
+        status.lastError != null -> status.lastError.code.take(22) to palette.status.error
         status.lastSuccessAt != null -> "已同步" to palette.status.success
         else -> "未同步" to palette.status.offline
     }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Components.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Components.kt
@@ -109,6 +109,7 @@ fun SecretPresenceField(
 @Composable
 fun SyncStatusPill(status: SyncStatus, modifier: Modifier = Modifier) {
     val palette = ZephyrTheme.palette
+    val lastError = status.lastError
     val (text, color) = when {
         status.conflictCount > 0 -> "冲突 " + status.conflictCount to palette.status.conflict
         status.bindingState == BindingState.REAUTH_REQUIRED -> "需要重新绑定" to palette.status.warning
@@ -116,7 +117,7 @@ fun SyncStatusPill(status: SyncStatus, modifier: Modifier = Modifier) {
         status.bindingState == BindingState.FATAL_INCOMPATIBLE -> "版本不兼容" to palette.status.error
         status.isRunning -> "同步中" to palette.brand.accent
         status.pendingCount > 0 -> "待同步 " + status.pendingCount to palette.status.pendingSync
-        status.lastError != null -> status.lastError.code.take(22) to palette.status.error
+        lastError != null -> lastError.code.take(22) to palette.status.error
         status.lastSuccessAt != null -> "已同步" to palette.status.success
         else -> "未同步" to palette.status.offline
     }

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
@@ -367,6 +367,7 @@ fun FileSyncScreen(
     val palette = ZephyrTheme.palette
     val phase = when {
         status.isRunning -> "正在同步"
+        status.lastError != null -> "同步失败 · ${status.lastError.code}"
         status.conflictCount > 0 -> "需要处理冲突"
         status.lastSuccessAt != null -> "镜像已同步"
         else -> "镜像待同步"
@@ -398,6 +399,7 @@ fun FileSyncScreen(
                             Text(
                                 when {
                                     localMode -> "未绑定主端 · 本机工作区可离线使用"
+                                    status.lastError != null -> status.lastError.message.take(96)
                                     status.lastSuccessAt != null -> "上次成功 · 下次自动 ${intervalLabel(settings.intervalSec)}"
                                     else -> "等待首次同步 · 下次自动 ${intervalLabel(settings.intervalSec)}"
                                 },
@@ -416,7 +418,7 @@ fun FileSyncScreen(
                         Text(
                             buildString {
                                 append("待推送 ${status.pendingCount}")
-                                if (status.lastError != null) append(" · 上次失败")
+                                status.lastError?.let { append(" · ${it.code}") }
                             },
                             color = palette.onFloatingSubtle,
                             fontSize = 12.5.sp,

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
@@ -365,9 +365,10 @@ fun FileSyncScreen(
     onBack: () -> Unit,
 ) {
     val palette = ZephyrTheme.palette
+    val lastError = status.lastError
     val phase = when {
         status.isRunning -> "正在同步"
-        status.lastError != null -> "同步失败 · ${status.lastError.code}"
+        lastError != null -> "同步失败 · ${lastError.code}"
         status.conflictCount > 0 -> "需要处理冲突"
         status.lastSuccessAt != null -> "镜像已同步"
         else -> "镜像待同步"
@@ -399,7 +400,7 @@ fun FileSyncScreen(
                             Text(
                                 when {
                                     localMode -> "未绑定主端 · 本机工作区可离线使用"
-                                    status.lastError != null -> status.lastError.message.take(96)
+                                    lastError != null -> lastError.message.take(96)
                                     status.lastSuccessAt != null -> "上次成功 · 下次自动 ${intervalLabel(settings.intervalSec)}"
                                     else -> "等待首次同步 · 下次自动 ${intervalLabel(settings.intervalSec)}"
                                 },
@@ -418,7 +419,7 @@ fun FileSyncScreen(
                         Text(
                             buildString {
                                 append("待推送 ${status.pendingCount}")
-                                status.lastError?.let { append(" · ${it.code}") }
+                                lastError?.let { append(" · ${it.code}") }
                             },
                             color = palette.onFloatingSubtle,
                             fontSize = 12.5.sp,

--- a/zephyr_one/mobile/tests/android-link-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/android-link-runtime.test.mjs
@@ -76,6 +76,39 @@ test('Android publishes local-to-bound account replacement atomically', () => {
   assert.match(screen, /prepared\?\.identity\?\.wipe\(\)/);
 });
 
+test('Android Link channel injects every sync op before sealing', () => {
+  const container = read('android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt');
+  const transport = read('android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/LinkSyncTransport.kt');
+  assert.match(transport, /private fun wireBody\(op: String, body: JsonObject\)/);
+  assert.match(transport, /put\("op", JsonPrimitive\(op\)\)/);
+  assert.match(transport, /channel\.syncOp\("changes", wireBody\("changes", body\)\)/);
+  assert.match(transport, /channel\.syncOp\("push", wireBody\("push", body\)\)/);
+  assert.match(transport, /channel\.syncOp\("ack", wireBody\("ack", body\)\)/);
+  assert.match(container, /kind = LinkKinds\.SYNC_OP, body = body/);
+});
+
+test('root recovers an absent account instead of drawing a permanent blank frame', () => {
+  const root = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+  assert.match(root, /if \(account == null\)/);
+  assert.match(root, /withContext\(Dispatchers\.IO\).*container\.ensureLocalWorkspace\(\)\.activate\(\)/s);
+  assert.match(root, /CircularProgressIndicator/);
+  assert.match(root, /工作区恢复失败/);
+  assert.match(root, /recoveryAttempt \+= 1/);
+  assert.doesNotMatch(root, /account == null -> Box\(Modifier\.fillMaxSize\(\)\)/);
+});
+
+test('startup sync recovery resets incomplete generations and avoids duplicate rounds', () => {
+  const account = read('android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt');
+  const coordinator = read('android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt');
+  const engine = read('android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncEngine.kt');
+  assert.match(account, /accountDatabaseRequiresBootstrap\(\)/);
+  assert.match(account, /BindingState\.BOUND_NEEDS_BOOTSTRAP/);
+  assert.match(coordinator, /if \(graph\.accountDatabaseRequiresBootstrap\(\)\)/);
+  assert.match(coordinator, /graph\.runForegroundRound\(\)/);
+  assert.doesNotMatch(engine, /scope\.launch \{ run\(SyncTrigger\.FOREGROUND_START/);
+  assert.match(engine, /suspend fun onForegroundStart\(\)/);
+});
+
 test('server never caches a failed Go device registration', () => {
   const proxy = readRepo('link-v2-go-proxy.js');
   assert.match(proxy, /throw failure/);

--- a/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
+++ b/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
@@ -446,17 +446,38 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
   });
   assert.equal(consume.status, 200, await consume.clone().text());
   const binding = await consume.json();
+  const serverNote = await server.api(login.cookie, 'POST', '/api/notes', {
+    title: 'server-to-device',
+    content: 'must arrive in bootstrap',
+  });
+  assert.equal(serverNote.status, 200);
+  const serverNoteId = serverNote.body.note.noteId;
   const proofFetch = createProofClient({
     base: server.url(''),
     access: binding.accessCredential,
     deviceId,
     privateKey: signing.privateKey,
   });
-  const bootstrap = await proofFetch('/api/mobile/v1/sync/bootstrap?pageSize=50');
-  assert.equal(bootstrap.status, 200, await bootstrap.clone().text());
-  const snapshot = await bootstrap.json();
-  assert.equal(snapshot.ok, true);
+  let pageToken = null;
+  let snapshot = null;
+  const bootstrapEntities = [];
+  do {
+    const pathname = '/api/mobile/v1/sync/bootstrap?pageSize=50' +
+      (pageToken ? '&pageToken=' + encodeURIComponent(pageToken) : '');
+    const bootstrap = await proofFetch(pathname);
+    assert.equal(bootstrap.status, 200, await bootstrap.clone().text());
+    const page = await bootstrap.json();
+    assert.equal(page.ok, true);
+    if (snapshot === null) snapshot = page;
+    else assert.equal(page.snapshotCursor, snapshot.snapshotCursor);
+    bootstrapEntities.push(...page.entities);
+    pageToken = page.complete ? null : page.nextPageToken;
+    assert.ok(page.complete || pageToken);
+  } while (pageToken);
   assert.ok(Number.isSafeInteger(snapshot.snapshotCursor));
+  assert.ok(bootstrapEntities.some((change) =>
+    change.entityType === 'note' && change.entityId === serverNoteId && change.payload.title === 'server-to-device'
+  ));
 
   const devices = await server.api(login.cookie, 'GET', '/api/one/clients');
   assert.equal(devices.status, 200);
@@ -503,13 +524,47 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     return unpacked.body;
   }
 
+  const deviceNoteId = 'note-device-upstream-0001';
+  const pushed = await syncOp({
+    op: 'push',
+    protocolVersion: 1,
+    deviceId,
+    batchId: 'batch-device-upstream-1',
+    baseCursor: snapshot.snapshotCursor,
+    registryHash: binding.registryHash,
+    operations: [{
+      opId: 'op-device-upstream-1',
+      entityType: 'note',
+      entityId: deviceNoteId,
+      action: 'upsert',
+      baseRevision: 0,
+      clientModifiedAt: Date.now(),
+      fieldMask: ['title', 'content'],
+      payload: { title: 'device-to-server', content: 'must arrive on main end' },
+    }],
+  });
+  assert.equal(pushed.ok, true);
+  assert.equal(pushed.results[0].status, 'accepted', JSON.stringify(pushed));
+  const upstream = await server.api(login.cookie, 'GET', `/api/notes/${deviceNoteId}`);
+  assert.equal(upstream.status, 200);
+  assert.equal(upstream.body.note.title, 'device-to-server');
+
+  const mainAfterSnapshot = await server.api(login.cookie, 'POST', '/api/notes', {
+    title: 'server-after-bootstrap',
+    content: 'must arrive through changes',
+  });
+  assert.equal(mainAfterSnapshot.status, 200);
+  const changedNoteId = mainAfterSnapshot.body.note.noteId;
+
   const changes = await syncOp({ op: 'changes', sinceCursor: snapshot.snapshotCursor, limit: 50 });
   assert.equal(changes.ok, true);
   assert.equal(changes.fromCursor, snapshot.snapshotCursor);
-  assert.equal(changes.nextCursor, snapshot.snapshotCursor);
-  assert.deepEqual(changes.changes, []);
+  assert.ok(changes.nextCursor > snapshot.snapshotCursor);
+  assert.ok(changes.changes.some((change) =>
+    change.entityType === 'note' && change.entityId === changedNoteId && change.payload.title === 'server-after-bootstrap'
+  ));
 
-  const acknowledged = await syncOp({ op: 'ack', cursor: changes.nextCursor, appliedOpIds: [] });
+  const acknowledged = await syncOp({ op: 'ack', cursor: changes.nextCursor, appliedOpIds: ['op-device-upstream-1'] });
   assert.equal(acknowledged.ok, true);
 
   const status = await syncOp({ op: 'status' });


### PR DESCRIPTION
## Root causes

This is the client-side half that the previous server fixes could not repair.

1. `LinkChannel.syncOp(op, body)` ignored `op`. `changes` therefore sealed `{sinceCursor,limit}` without the required discriminator and the server correctly rejected it as `unsupported_op`. The prior end-to-end test manually inserted `op`, bypassing the real Kotlin wire builder.
2. A pre-fix `token_missing` round persisted `REAUTH_REQUIRED` before any snapshot committed. After the server was upgraded, that stale state prevented a clean first-bootstrap recovery even though the device credentials were valid again.
3. `SyncEngine.start()` immediately launched `FOREGROUND_START`, while bind/restore separately launched `BIND_COMPLETE`/restore bootstrap. Startup could perform duplicate sync rounds, Link dials and DB work.
4. `ready=true` with `account=null` still rendered an empty same-colour box forever. Recovery had no visible failure or retry path.
5. Sync UI collapsed every transport/protocol error into “同步失败”, hiding the actual wire failure.

## Fix

- `LinkSyncTransport` now owns the invariant that every `changes`/`push`/`ack` body contains a matching `op` before it reaches any channel implementation.
- An account generation without its encrypted database-ready marker is reset to `BOUND_NEEDS_BOOTSTRAP` before the first round. Invalid credentials still fail validation and return to reauth; valid credentials recover without deleting the binding.
- Engine installation no longer launches an implicit duplicate foreground round. Restore chooses exactly one explicit path: bootstrap if required, otherwise one foreground round.
- `account=null` rebuilds the local fallback on `Dispatchers.IO`; failure renders a diagnostic/retry state rather than a permanent blank frame.
- Pending binding-auth cleanup moves off the Application main-thread hot path.
- Sync pill and file-sync card expose the actual error code/message.

## Bidirectional regression gate

The live enrollment test now proves actual convergence in both directions:

- main-end note exists before bootstrap -> appears in the device snapshot
- device creates a note through sealed Link `push` -> main-end note API reads it
- main end creates a note after the snapshot -> sealed Link `changes` returns it
- device ACK -> server status cursor advances and last-sync authority is updated

The test still covers enrollment, browser approval, consume, proof challenge, authenticated bootstrap, Go handshake and sealed SYNC_ACK.

## Validation

- Android Link/runtime structural gates: 9/9
- enrollment + real bidirectional convergence: 7/7
- combined critical set: 16/16
- full mobile contract local static batch: all assertions pass except the known PaX/JVM `keytool` startup limitation; Android CI is the compiler authority

## Performance scope

This removes duplicate startup sync rounds, keeps workspace DB fallback off Main and moves pending-auth cleanup off Main. It does **not** claim the separate ≤1s cold-start target without 30-run physical-device measurements; that benchmark remains a distinct follow-up gate.
