### PR TITLE
fix(sync): emit Android-valid timestamps for bootstrap changes

### DIFF
--- a/mobile-v1-routes.js
+++ b/mobile-v1-routes.js
@@ -1545,7 +1545,19 @@ class MobileV1Api {
                         action: 'upsert',
                         revision: adapter.revisionOf(row),
                         actorDeviceId: null,
-                        changedAt: Number(row.updatedAt || row.createdAt || 0),
+                        /* Every SyncChange requires a positive timestamp. Canonical services use
+                         * different event names, and old/config rows may predate updatedAt. Pick the
+                         * best durable source at the wire boundary; 1 is the explicit legacy epoch,
+                         * never wall-clock "now", so repeated bootstrap pages remain deterministic. */
+                        changedAt: Math.max(
+                            1,
+                            Number(row.updatedAt) || 0,
+                            Number(row.createdAt) || 0,
+                            Number(row.time) || 0,
+                            Number(row.occurredAt) || 0,
+                            Number(row.finishedAt) || 0,
+                            Number(row.startedAt) || 0,
+                        ),
                         /* fieldMask is the full editable set: a bootstrap row is the
                          * complete entity, not a patch. */
                         fieldMask: adapter.fieldMaskOf

--- a/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
+++ b/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
@@ -31,6 +31,42 @@ const registry = JSON.parse(fs.readFileSync(
   'utf8',
 ));
 
+function assertAndroidSyncChange(change) {
+  const spec = registry.entities.find((entry) => entry.type === change.entityType);
+  assert.ok(spec, `unknown entity type ${change.entityType}`);
+  assert.ok(Number.isSafeInteger(change.changeSeq) && change.changeSeq >= 0,
+    `${change.entityType} has invalid changeSeq ${change.changeSeq}`);
+  assert.ok(typeof change.entityId === 'string' && change.entityId.length > 0,
+    `${change.entityType} has a blank entityId`);
+  assert.ok(change.action === 'upsert' || change.action === 'delete',
+    `${change.entityType} has invalid action ${change.action}`);
+  assert.ok(Number.isSafeInteger(change.revision) && change.revision > 0,
+    `${change.entityType} has invalid revision ${change.revision}`);
+  assert.ok(Number.isSafeInteger(change.changedAt) && change.changedAt > 0,
+    `${change.entityType} has invalid changedAt ${change.changedAt}`);
+  const editable = new Set(spec.editableFields || []);
+  const forbidden = new Set([
+    ...(spec.secretFields || []), ...(spec.serverAuthorityFields || []),
+    ...(spec.opaquePreserveFields || []), ...(spec.deviceLocalFields || []),
+  ]);
+  const accepted = new Set();
+  for (const field of change.fieldMask || []) {
+    const root = String(field).split(/[.[]/, 1)[0];
+    assert.ok(!forbidden.has(root) && !forbidden.has(field),
+      `${change.entityType} fieldMask contains forbidden ${field}`);
+    assert.ok(editable.has(root) || editable.has(field),
+      `${change.entityType} fieldMask contains unknown ${field}`);
+    assert.ok(!accepted.has(field), `${change.entityType} fieldMask duplicates ${field}`);
+    accepted.add(field);
+  }
+  const payload = change.payload || {};
+  for (const secret of spec.secretFields || []) {
+    assert.ok(!Object.prototype.hasOwnProperty.call(payload, secret),
+      `${change.entityType} payload exposes secret ${secret}`);
+  }
+  if (change.action === 'delete') assert.deepEqual(payload, {});
+}
+
 function buildCurrentGoLinkServer(t) {
   const output = path.join(os.tmpdir(), `zephyr-link-server-${process.pid}-${Date.now()}`);
   const go = fs.existsSync('/usr/local/go126/bin/go') ? '/usr/local/go126/bin/go' : 'go';
@@ -475,6 +511,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     assert.ok(page.complete || pageToken);
   } while (pageToken);
   assert.ok(Number.isSafeInteger(snapshot.snapshotCursor));
+  bootstrapEntities.forEach(assertAndroidSyncChange);
   assert.ok(bootstrapEntities.some((change) =>
     change.entityType === 'note' && change.entityId === serverNoteId && change.payload.title === 'server-to-device'
   ));
@@ -560,6 +597,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
   assert.equal(changes.ok, true);
   assert.equal(changes.fromCursor, snapshot.snapshotCursor);
   assert.ok(changes.nextCursor > snapshot.snapshotCursor);
+  changes.changes.forEach(assertAndroidSyncChange);
   assert.ok(changes.changes.some((change) =>
     change.entityType === 'note' && change.entityId === changedNoteId && change.payload.title === 'server-after-bootstrap'
   ));


### PR DESCRIPTION
## Root cause\nThe Android client strictly rejects every SyncChange with changedAt <= 0. The main-end bootstrap boundary used row.updatedAt || row.createdAt || 0. Canonical fileSyncConfig rows expose neither timestamp and activityEvent uses row.time, so a normal bootstrap page contained changedAt=0 and the whole page became malformed_response.\n\n## Fix\n- normalize bootstrap changedAt at the sync wire boundary from updatedAt, createdAt, time, occurredAt, finishedAt or startedAt\n- use stable legacy epoch 1 only when no canonical timestamp exists; never wall-clock now, so pagination stays deterministic\n- add an Android-equivalent strict validator for every bootstrap and changes row in the real enrollment/bidirectional loop\n\n## Reproduction locked\nThe strict gate first failed with fileSyncConfig has invalid changedAt 0; after addressing that class it exposed activityEvent has invalid changedAt 0. The unified wire fix makes the full page pass.\n\n## Validation\n- Enrollment/full bidirectional loop 7/7\n- bootstrap/config/server metadata regression 17/17