### PR TITLE
feat(web): add desktop floating panel side pins

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,6 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));
@@ -11625,6 +11626,18 @@ function setupAiPanelChrome() {
         if (aiPanelLayoutMenu && !e.target.closest?.('.panel-layout-menu') && !e.target.closest?.('[data-ai-agent-layout]')) closeAiPanelLayoutMenu();
     });
     window.addEventListener('resize', () => closeAiPanelLayoutMenu({ instant: true }));
+    // AI is a top-level secondary panel. Its child provider/detail windows are
+    // deliberately not attached, so they always open as ordinary floaters.
+    if (panel) {
+        // aiAgentPanel is a sibling of .app-shell, but pin geometry is fixed
+        // to its scope; using app-shell makes the underlying active surface
+        // reflow while the pinned AI panel remains above it.
+        attachDesktopPanelPin(document.querySelector('.app-shell'), panel, {
+            dragHandle,
+            layoutButton: layoutBtn,
+            onClose: () => closeAiAssistantPanel(),
+        });
+    }
 }
 function updateAiProviderModalHints() {
     const type = $('#aiProviderType')?.value || 'openai-compatible';

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,6 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,6 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';
@@ -739,6 +740,11 @@ function setupFloatingPanels() {
     setupPanelLayoutMenu();
     setupPanelDrag();
     setupPanelResize();
+    // Desktop-only side pinning; unpinned panels retain the original ⋯ behavior.
+    const desktopPinPage = document.querySelector('.rdp-page');
+    floatingPanels().forEach((panel) => {
+        attachDesktopPanelPin(desktopPinPage, panel, { onClose: (target) => togglePanel(target, false) });
+    });
 }
 
 function sendKey(keysym, code = '', down = undefined) {

--- a/public/panel-pin.css
+++ b/public/panel-pin.css
@@ -1,0 +1,121 @@
+/* Desktop secondary-panel side pinning.
+ * `.tgl.panel-pin-btn` is intentionally the exact component from tgl-pin.html;
+ * only absolute left/right positioning is added here. */
+.tgl.panel-pin-btn {
+    --s: 18px;
+    position: absolute;
+    top: 50%;
+    translate: 0 -50%;
+    width: var(--s);
+    height: var(--s);
+    padding: 0;
+    border-radius: 50%;
+    border: 1.5px solid #4a4f5a;
+    background: #1e2025;
+    cursor: pointer;
+    outline: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 7;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: manipulation;
+    transition: border-color .2s ease, background .2s ease, transform .12s ease-out;
+}
+.panel-pin-btn.left { left: 7px; }
+.panel-pin-btn.right { right: 7px; }
+.panel-pin-btn::after {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #dfe3ea;
+    transform: scale(0);
+    transition: transform .28s cubic-bezier(.34, 1.56, .64, 1), box-shadow .2s ease;
+}
+.panel-pin-btn:hover { border-color: #5d6372; }
+.panel-pin-btn:active { transform: scale(.85); }
+.panel-pin-btn.on { border-color: #9aa2b1; background: #262932; }
+.panel-pin-btn.on::after { transform: scale(1); box-shadow: 0 0 6px rgba(223, 227, 234, .35); }
+
+/* Every top-level secondary panel may be pinned. */
+.file-manager.pin-animating, .info-modal.pin-animating, .docker-panel.pin-animating,
+.snippet-panel.pin-animating, .shortcut-panel.pin-animating, .rdp-floating-panel.pin-animating,
+.ai-agent-panel.pin-animating {
+    transition:
+        left .52s var(--ios-open), top .52s var(--ios-open),
+        width .52s var(--ios-open), height .52s var(--ios-open),
+        border-radius .36s ease, box-shadow .36s ease, border-color .28s ease !important;
+    will-change: left, top, width, height;
+}
+.file-manager.pin-animating.pinned, .info-modal.pin-animating.pinned, .docker-panel.pin-animating.pinned,
+.snippet-panel.pin-animating.pinned, .shortcut-panel.pin-animating.pinned, .rdp-floating-panel.pin-animating.pinned,
+.ai-agent-panel.pin-animating.pinned { animation: panel-pin-settle .52s var(--ios-open); }
+@keyframes panel-pin-settle {
+    0% { filter: brightness(.94); box-shadow: 0 8px 24px rgba(0,0,0,.24); }
+    58% { filter: brightness(1.025); }
+    100% { filter: brightness(1); }
+}
+.file-manager.pinned, .info-modal.pinned, .docker-panel.pinned, .snippet-panel.pinned,
+.shortcut-panel.pinned, .rdp-floating-panel.pinned, .ai-agent-panel.pinned {
+    max-height: none !important;
+    min-width: 0 !important;
+    box-shadow: 0 18px 60px rgba(0,0,0,.45);
+}
+.pinned[data-pin-side="left"] { border-left-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+.pinned[data-pin-side="right"] { border-right-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+
+.panel-pin-menu {
+    position: fixed;
+    min-width: 196px;
+    display: flex;
+    flex-direction: column;
+    padding: 5px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--surface) 94%, transparent);
+    box-shadow: 0 16px 46px rgba(0,0,0,.42);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    opacity: 0;
+    transform: scale(.92) translateY(-4px);
+    transform-origin: top center;
+    transition: opacity .16s ease, transform .2s var(--ios-open);
+}
+.panel-pin-menu.open { opacity: 1; transform: scale(1) translateY(0); }
+.panel-pin-menu button {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1px;
+    padding: 7px 10px;
+    border: 0;
+    border-radius: 8px;
+    background: none;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 12.5px;
+    text-align: left;
+    cursor: pointer;
+    transition: background .14s ease;
+}
+.panel-pin-menu button span { color: var(--text-secondary); font-size: 10.5px; }
+.panel-pin-menu button:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.panel-pin-menu button.danger { color: #f47067; }
+
+/* Side rail geometry reflows the actual active surface with a synchronized transition. */
+@media (hover: hover) and (pointer: fine) {
+    .terminal-page, .rdp-page, .app-shell {
+        transition: padding-left .5s var(--ios-open), padding-right .5s var(--ios-open), background-color .24s ease, border-color .24s ease;
+    }
+    .terminal-page.pin-has-left, .rdp-page.pin-has-left, .app-shell.pin-has-left, body.pin-has-left { padding-left: var(--pin-inset-left, 0px); }
+    .terminal-page.pin-has-right, .rdp-page.pin-has-right, .app-shell.pin-has-right, body.pin-has-right { padding-right: var(--pin-inset-right, 0px); }
+}
+
+/* JS never injects on touch/mobile; this is a second hard guarantee. */
+@media (hover: none), (pointer: coarse) { .panel-pin-btn { display: none !important; } }
+@media (prefers-reduced-motion: reduce) {
+    .pin-animating, .panel-pin-menu, .terminal-page, .rdp-page, .app-shell { animation: none !important; transition-duration: .01ms !important; }
+}

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -1,0 +1,364 @@
+/**
+ * Desktop-only side pinning for Zephyr's secondary floating panels.
+ * The toggle's visual system is the exact 18px `.tgl` component from tgl-pin.html.
+ */
+const pinned = new Set();
+let zSeed = 10100;
+
+export function isDesktopPanelPinEnvironment() {
+    return window.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches === true
+        && Math.min(window.innerWidth || 0, window.innerHeight || 0) > 700;
+}
+
+function pageFor(panel, page) {
+    return page || panel.closest('.terminal-page, .rdp-page, .app-shell') || document.body;
+}
+
+function scopeFor(page) {
+    const rect = page.getBoundingClientRect();
+    const width = page.clientWidth || rect.width || window.innerWidth;
+    const height = page.clientHeight || rect.height || window.innerHeight;
+    const topbar = page.querySelector(':scope > .terminal-topbar, :scope > .main-nav');
+    const topbarHeight = topbar?.offsetHeight || 0;
+    // Pinned windows use position:fixed so RDP/VNC windows (whose normal parent
+    // is the display stage) can still cover the page chrome exactly like SSH.
+    return { left: rect.left, top: rect.top, width, height, topbarHeight };
+}
+
+function rememberNormalGeometry(panel) {
+    if (panel._pinRestore) return;
+    const rect = panel.getBoundingClientRect();
+    const parent = panel.offsetParent || panel.parentElement;
+    const parentRect = parent?.getBoundingClientRect?.() || { left: 0, top: 0 };
+    panel._pinRestore = {
+        position: panel.style.position,
+        left: panel.style.left || `${rect.left - parentRect.left}px`,
+        top: panel.style.top || `${rect.top - parentRect.top}px`,
+        width: panel.style.width || `${rect.width}px`,
+        height: panel.style.height || `${rect.height}px`,
+        right: panel.style.right,
+        bottom: panel.style.bottom,
+    };
+}
+
+function panelGroup(page) {
+    return [...pinned].filter((panel) => panel.isConnected && panel._pinPage === page);
+}
+
+function dockedAt(page, side) {
+    return panelGroup(page).filter((panel) => panel.dataset.pinSide === side && (panel.dataset.pinMode || 'side') === 'side');
+}
+
+function sideInset(page, side) {
+    return dockedAt(page, side).reduce((max, panel) => Math.max(max, panel.offsetWidth || 0), 0);
+}
+
+function applyInsets(page) {
+    const left = sideInset(page, 'left');
+    const right = sideInset(page, 'right');
+    page.style.setProperty('--pin-inset-left', `${left}px`);
+    page.style.setProperty('--pin-inset-right', `${right}px`);
+    page.classList.toggle('pin-has-left', left > 0);
+    page.classList.toggle('pin-has-right', right > 0);
+}
+
+function bringToFront(panel) {
+    zSeed += 1;
+    panel.style.zIndex = String(zSeed);
+    panel.style.setProperty('--panel-z', String(zSeed));
+}
+
+function quarterWidth(scope) {
+    return Math.max(260, Math.min(560, Math.round(scope.width / 4)));
+}
+
+function startGeometryMotion(panel) {
+    panel.classList.add('pin-animating');
+    window.clearTimeout(panel._pinMotionTimer);
+    panel._pinMotionTimer = window.setTimeout(() => {
+        panel.classList.remove('pin-animating');
+        panel.style.willChange = '';
+    }, 560);
+}
+
+function place(panel, mode = panel.dataset.pinMode || 'side') {
+    const page = panel._pinPage;
+    const scope = scopeFor(page);
+    const side = panel.dataset.pinSide || 'left';
+    const fullHeight = scope.height;
+    rememberNormalGeometry(panel);
+    startGeometryMotion(panel);
+
+    // The page can be a terminal page, an RDP/VNC page, or the web app shell.
+    // Fixed coordinates make the same geometry reliable even when the panel's
+    // normal containing block is a nested display stage.
+    const fixed = { position: 'fixed', right: 'auto', bottom: 'auto', transform: 'none' };
+    if (mode === 'full') {
+        // ⋯ → full: retain the header (the user's red-line requirement).
+        Object.assign(panel.style, fixed, {
+            left: `${scope.left}px`, top: `${scope.top + scope.topbarHeight}px`, width: `${scope.width}px`,
+            height: `${Math.max(1, fullHeight - scope.topbarHeight)}px`,
+        });
+        return;
+    }
+    if (mode === 'half') {
+        // ⋯ → bottom 1/2: the full page's lower half, not the side rail's half.
+        const top = scope.top + Math.round(fullHeight / 2);
+        Object.assign(panel.style, fixed, {
+            left: `${scope.left}px`, top: `${top}px`, width: `${scope.width}px`, height: `${scope.top + fullHeight - top}px`,
+        });
+        return;
+    }
+
+    const explicit = Number.parseFloat(panel.style.width);
+    const width = Math.min(Number.isFinite(explicit) ? explicit : quarterWidth(scope), scope.width);
+    Object.assign(panel.style, fixed, {
+        // Side pins cover the whole page chrome (the red-line/top-bar region included).
+        left: `${scope.left + (side === 'left' ? 0 : scope.width - width)}px`, top: `${scope.top}px`,
+        width: `${width}px`, height: `${fullHeight}px`,
+    });
+}
+
+function syncChrome(panel) {
+    const side = panel.dataset.pinSide || '';
+    panel.classList.toggle('pinned', !!side);
+    panel.querySelectorAll('.panel-pin-btn').forEach((button) => {
+        const active = button.dataset.pinSide === side;
+        button.classList.toggle('on', active);
+        button.setAttribute('aria-pressed', String(active));
+    });
+    panel.querySelectorAll('.panel-resize-handle').forEach((handle) => {
+        const edge = handle.dataset.resizeEdge || (handle.classList.contains('left') ? 'left' : 'right');
+        handle.style.display = side && edge === side ? 'none' : '';
+    });
+}
+
+function pin(panel, side) {
+    const page = panel._pinPage;
+    const stack = dockedAt(page, side).filter((item) => item !== panel);
+    const width = stack[0]?.offsetWidth || quarterWidth(scopeFor(page));
+    panel.dataset.pinSide = side;
+    panel.dataset.pinMode = 'side';
+    panel.style.width = `${width}px`;
+    pinned.add(panel);
+    place(panel, 'side');
+    syncChrome(panel);
+    bringToFront(panel);
+    applyInsets(page);
+    if (navigator.vibrate) navigator.vibrate(12);
+}
+
+function unpin(panel) {
+    const page = panel._pinPage;
+    const scope = scopeFor(page);
+    const width = panel.offsetWidth || 420;
+    const height = Math.min(panel.offsetHeight || 460, Math.max(240, scope.height - scope.topbarHeight - 16));
+    const restore = panel._pinRestore;
+    delete panel.dataset.pinSide;
+    delete panel.dataset.pinMode;
+    pinned.delete(panel);
+    startGeometryMotion(panel);
+    if (restore) {
+        Object.assign(panel.style, restore, { transform: 'none' });
+        delete panel._pinRestore;
+    } else {
+        Object.assign(panel.style, {
+            position: '', left: `${Math.max(16, Math.round((scope.width - width) / 2))}px`,
+            top: `${Math.max(scope.topbarHeight + 12, Math.round((scope.height - height) / 3))}px`,
+            width: `${width}px`, height: `${height}px`, right: 'auto', bottom: 'auto', transform: 'none',
+        });
+    }
+    syncChrome(panel);
+    applyInsets(page);
+    if (navigator.vibrate) navigator.vibrate([6, 16, 6]);
+}
+
+function closePinMenu() {
+    const menu = document.querySelector('.panel-pin-menu');
+    if (!menu) return;
+    menu.classList.remove('open');
+    window.setTimeout(() => menu.remove(), 160);
+}
+
+function openPinMenu(anchor, panel, onClose) {
+    closePinMenu();
+    const page = panel._pinPage;
+    const side = panel.dataset.pinSide || 'left';
+    const menu = document.createElement('div');
+    menu.className = 'panel-pin-menu';
+    menu.setAttribute('role', 'menu');
+    menu.innerHTML = `
+        <button data-pin-layout="full">全屏<span>保留顶部栏，以下完整覆盖</span></button>
+        <button data-pin-layout="half">下 1/2<span>整个页面的下半部分</span></button>
+        <button data-pin-layout="switch">钉到${side === 'left' ? '右' : '左'}边<span>恢复 1/4 宽侧栏</span></button>
+        <button data-pin-layout="unpin">取消钉住<span>恢复普通浮窗</span></button>
+        <button data-pin-layout="close" class="danger">关闭浮窗</button>`;
+    document.body.appendChild(menu);
+    const rect = anchor.getBoundingClientRect();
+    const left = Math.max(8, Math.min(window.innerWidth - menu.offsetWidth - 8, rect.left + rect.width / 2 - menu.offsetWidth / 2));
+    Object.assign(menu.style, { left: `${left}px`, top: `${rect.bottom + 8}px`, zIndex: String((Number(panel.style.zIndex) || zSeed) + 20) });
+    requestAnimationFrame(() => menu.classList.add('open'));
+
+    const outside = (event) => {
+        if (!menu.contains(event.target) && event.target !== anchor) {
+            document.removeEventListener('pointerdown', outside, true);
+            closePinMenu();
+        }
+    };
+    document.addEventListener('pointerdown', outside, true);
+    menu.addEventListener('click', (event) => {
+        const item = event.target.closest('[data-pin-layout]');
+        if (!item) return;
+        document.removeEventListener('pointerdown', outside, true);
+        const action = item.dataset.pinLayout;
+        closePinMenu();
+        if (action === 'close') { onClose?.(panel); return; }
+        if (action === 'unpin') { unpin(panel); return; }
+        if (action === 'switch') {
+            panel.dataset.pinSide = side === 'left' ? 'right' : 'left';
+            panel.dataset.pinMode = 'side';
+            panel.style.width = `${quarterWidth(scopeFor(page))}px`;
+            place(panel, 'side');
+            syncChrome(panel);
+            bringToFront(panel);
+            applyInsets(page);
+            return;
+        }
+        panel.dataset.pinMode = action;
+        place(panel, action);
+        syncChrome(panel);
+        bringToFront(panel);
+        applyInsets(page);
+    });
+}
+
+function bindPinnedResize(panel, handle) {
+    handle.addEventListener('pointerdown', (event) => {
+        if (!panel.dataset.pinSide || (panel.dataset.pinMode || 'side') !== 'side') return;
+        const edge = handle.dataset.resizeEdge || (handle.classList.contains('left') ? 'left' : 'right');
+        if (edge === panel.dataset.pinSide) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        const page = panel._pinPage;
+        const scope = scopeFor(page);
+        const side = panel.dataset.pinSide;
+        const startX = event.clientX;
+        const startWidth = panel.offsetWidth;
+        panel.classList.add('resizing');
+        const move = (ev) => {
+            ev.preventDefault();
+            const delta = ev.clientX - startX;
+            const width = side === 'left' ? startWidth + delta : startWidth - delta;
+            // Keep write local: place() adds a transition class and is for discrete
+            // layouts only. Calling it each pointer frame made the bottom handle lag.
+            const next = Math.max(220, Math.min(scope.width - 24, width));
+            panel.style.width = `${next}px`;
+            panel.style.left = `${scope.left + (side === 'left' ? 0 : scope.width - next)}px`;
+        };
+        const up = () => {
+            panel.classList.remove('resizing');
+            window.removeEventListener('pointermove', move);
+            window.removeEventListener('pointerup', up);
+            applyInsets(page);
+        };
+        window.addEventListener('pointermove', move, { passive: false });
+        window.addEventListener('pointerup', up, { once: true });
+    }, true);
+}
+
+/**
+ * Attach only to a top-level secondary panel. Nested/third-level panels must
+ * not inherit the parent pin state; callers simply do not invoke this on them.
+ */
+export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, onClose } = {}) {
+    if (!panel || panel.dataset.desktopPinWired === '1' || !isDesktopPanelPinEnvironment()) return false;
+    panel.dataset.desktopPinWired = '1';
+    panel._pinPage = pageFor(panel, page);
+
+    // Defensive reset for cloned nested panels: default stays a normal floating window.
+    delete panel.dataset.pinSide;
+    delete panel.dataset.pinMode;
+    panel.classList.remove('pinned', 'pin-animating');
+
+    const handle = dragHandle || panel.querySelector('.panel-drag-handle');
+    if (!handle) return false;
+    // An older cloned DOM/template can carry the decorative controls but not the
+    // listeners. Always de-duplicate before installing the real controls.
+    handle.querySelectorAll('.panel-pin-btn').forEach((button) => button.remove());
+    const makeButton = (side, label) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        // `.tgl` deliberately reuses the exact button system delivered in tgl-pin.html.
+        button.className = `tgl panel-pin-btn ${side}`;
+        button.dataset.pinSide = side;
+        button.title = label;
+        button.setAttribute('aria-label', label);
+        button.setAttribute('aria-pressed', 'false');
+        button.oncontextmenu = () => false;
+        return button;
+    };
+    handle.prepend(makeButton('left', '钉到左边'));
+    handle.append(makeButton('right', '钉到右边'));
+
+    handle.addEventListener('pointerdown', (event) => {
+        if (event.target.closest('.panel-pin-btn')) event.stopPropagation();
+    }, true);
+    handle.addEventListener('click', (event) => {
+        const button = event.target.closest('.panel-pin-btn');
+        if (!button) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (panel.dataset.pinSide === button.dataset.pinSide) unpin(panel);
+        else pin(panel, button.dataset.pinSide);
+    });
+
+    const traffic = layoutButton || panel.querySelector('.panel-traffic-btn, [data-layout-panel]');
+    if (traffic) {
+        // Capture phase preserves ordinary original three-dot behavior exactly
+        // while unpinned; only pinned state swaps its layout meanings.
+        traffic.addEventListener('click', (event) => {
+            if (!panel.dataset.pinSide) return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            openPinMenu(traffic, panel, onClose);
+        }, true);
+    }
+
+    panel.querySelectorAll('.panel-resize-handle').forEach((handleEl) => bindPinnedResize(panel, handleEl));
+    panel.addEventListener('pointerdown', () => {
+        if (panel.dataset.pinSide) bringToFront(panel);
+    }, true);
+
+    const observer = new MutationObserver(() => {
+        const opened = panel.classList.contains('open') && panel.style.display !== 'none' && !panel.hidden;
+        if (panel.dataset.pinSide && (!opened || !panel.isConnected)) {
+            const owner = panel._pinPage;
+            pinned.delete(panel);
+            delete panel.dataset.pinSide;
+            delete panel.dataset.pinMode;
+            owner && applyInsets(owner);
+        }
+    });
+    observer.observe(panel, { attributes: true, attributeFilter: ['class', 'style', 'hidden'] });
+    panel._pinObserver = observer;
+
+    window.addEventListener('resize', () => {
+        if (!panel.dataset.pinSide) return;
+        place(panel);
+        applyInsets(panel._pinPage);
+    });
+    return true;
+}
+
+export function releaseDesktopPanelPin(panel) {
+    if (!panel?.dataset?.pinSide) return;
+    unpin(panel);
+}
+
+export function refreshDesktopPanelPin(page) {
+    applyInsets(page);
+}
+
+if (typeof window !== 'undefined') {
+    window.ZephyrDesktopPanelPin = { attach: attachDesktopPanelPin, refresh: refreshDesktopPanelPin };
+}

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,6 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,
@@ -2652,18 +2653,24 @@ function initToolbar() {
 
     // Shared SSH-parity interactions: titlebar drag, traffic-light drag/menu,
     // edge resize, front-most z-index, island layout menu.
+    const closeRdpPanel = (panel) => {
+        const map = [
+            [clipboardPanel, clipboardBtn],
+            [filesPanel, rdpFilesBtn],
+            [shortcutsPanel, shortcutsBtn],
+            [joystickPanel, joystickBtn],
+        ];
+        const hit = map.find(([p]) => p === panel);
+        closeFloatingPanel(panel, hit?.[1] || null);
+    };
     setupPanelInteractions(document, {
         panelSelector: '.rdp-floating-panel',
-        onClosePanel: (panel) => {
-            const map = [
-                [clipboardPanel, clipboardBtn],
-                [filesPanel, rdpFilesBtn],
-                [shortcutsPanel, shortcutsBtn],
-                [joystickPanel, joystickBtn],
-            ];
-            const hit = map.find(([p]) => p === panel);
-            closeFloatingPanel(panel, hit?.[1] || null);
-        },
+        onClosePanel: closeRdpPanel,
+    });
+    // RDP's second-level panels use the same desktop-only `.tgl` side pins.
+    const desktopPinPage = document.querySelector('.rdp-page');
+    [clipboardPanel, filesPanel, shortcutsPanel, joystickPanel].filter(Boolean).forEach((panel) => {
+        attachDesktopPanelPin(desktopPinPage, panel, { onClose: closeRdpPanel });
     });
 
     /* Joystick knob — controls viewport pan in fill mode */

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,6 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260811-webdav1';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin1';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,6 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
+    '/panel-pin.js?v=20260830-desktop-panel-pin1',
+    '/panel-pin.css?v=20260830-desktop-panel-pin1',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,6 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,6 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;
@@ -4700,6 +4701,12 @@ function createFileManagerWindow({ path = currentPath } = {}) {
     // cloneNode copies dataset bind flags but not listeners — force rebind.
     delete panel.dataset.panelPhysicsWired;
     delete panel.dataset.panelPhysicsPointerBound;
+    // A spawned third-level window never inherits its parent's side pin.
+    delete panel.dataset.desktopPinWired;
+    delete panel.dataset.pinSide;
+    delete panel.dataset.pinMode;
+    panel.classList.remove('pinned', 'pin-animating');
+    panel.querySelectorAll('.panel-pin-btn').forEach((button) => button.remove());
     panel.querySelectorAll('[data-panel-layout-click-bound], [data-layout-panel]').forEach((el) => {
         delete el.dataset.panelLayoutClickBound;
         delete el.dataset.panelBound;
@@ -11813,6 +11820,11 @@ setupFloatingPanel(shortcutPanel, getDefaultPanelOptions(shortcutPanel));
 setupPanelLayoutMenu();
 setupPanelDrag();
 setupPanelResize();
+// Desktop only: secondary Telnet panels receive the shared `.tgl` side pins.
+const desktopPinPage = document.querySelector('.terminal-page');
+[fileManager, infoModal, dockerPanel, snippetPanel, shortcutPanel].forEach((panel) => {
+    attachDesktopPanelPin(desktopPinPage, panel, { onClose: hidePanelByElement });
+});
 setupTerminalInputActivityHooks();
 setupTerminalInputPanelMetrics();
 setupMobileKeyboardAvoidance();

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,6 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,6 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;
@@ -4700,6 +4701,13 @@ function createFileManagerWindow({ path = currentPath } = {}) {
     // cloneNode copies dataset bind flags but not listeners — force rebind.
     delete panel.dataset.panelPhysicsWired;
     delete panel.dataset.panelPhysicsPointerBound;
+    // A window spawned from a pinned file manager is always a normal third-level
+    // floating window until the user explicitly pins it.
+    delete panel.dataset.desktopPinWired;
+    delete panel.dataset.pinSide;
+    delete panel.dataset.pinMode;
+    panel.classList.remove('pinned', 'pin-animating');
+    panel.querySelectorAll('.panel-pin-btn').forEach((button) => button.remove());
     panel.querySelectorAll('[data-panel-layout-click-bound], [data-layout-panel]').forEach((el) => {
         delete el.dataset.panelLayoutClickBound;
         delete el.dataset.panelBound;
@@ -11811,6 +11819,14 @@ setupFloatingPanel(shortcutPanel, getDefaultPanelOptions(shortcutPanel));
 setupPanelLayoutMenu();
 setupPanelDrag();
 setupPanelResize();
+// Desktop only: top-level secondary panels gain left/right `.tgl` pin controls.
+// The existing ⋯ layout behavior remains untouched until a panel is actually pinned.
+const desktopPinPage = document.querySelector('.terminal-page');
+[fileManager, infoModal, dockerPanel, snippetPanel, shortcutPanel].forEach((panel) => {
+    attachDesktopPanelPin(desktopPinPage, panel, {
+        onClose: hidePanelByElement,
+    });
+});
 setupTerminalInputActivityHooks();
 setupTerminalInputPanelMetrics();
 setupMobileKeyboardAvoidance();

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+const pin = read('public/panel-pin.js');
+const css = read('public/panel-pin.css');
+const terminal = read('public/terminal.js');
+const telnet = read('public/telnet-terminal.js');
+const rdp = read('public/rdp-wasm-client.js');
+const vnc = read('public/novnc.js');
+const app = read('public/app.js');
+
+test('panel pin uses the exact tgl-pin visual contract', () => {
+    for (const fragment of [
+        '.tgl.panel-pin-btn', '--s: 18px', 'border: 1.5px solid #4a4f5a',
+        'background: #1e2025', 'background: #dfe3ea',
+        'cubic-bezier(.34, 1.56, .64, 1)', 'transform: scale(.85)',
+        'border-color: #9aa2b1', 'background: #262932',
+    ]) assert.ok(css.includes(fragment), fragment);
+    assert.match(pin, /button\.className = `tgl panel-pin-btn \$\{side\}`/);
+});
+
+test('panel pins are desktop-only and mobile cannot receive controls', () => {
+    assert.match(pin, /\(hover: hover\) and \(pointer: fine\)/);
+    assert.match(pin, /Math\.min\(window\.innerWidth \|\| 0, window\.innerHeight \|\| 0\) > 700/);
+    assert.match(css, /@media \(hover: none\), \(pointer: coarse\) \{ \.panel-pin-btn \{ display: none !important; \} \}/);
+});
+
+test('side pins are one quarter wide and cover full page chrome', () => {
+    assert.match(pin, /Math\.round\(scope\.width \/ 4\)/);
+    assert.match(pin, /top: `\$\{scope\.top\}px`/);
+    assert.match(pin, /height: `\$\{fullHeight\}px`/);
+    assert.match(pin, /Side pins cover the whole page chrome/);
+});
+
+test('pinned traffic menu retains specified full and global lower-half semantics', () => {
+    assert.match(pin, /全屏<span>保留顶部栏，以下完整覆盖<\/span>/);
+    assert.match(pin, /下 1\/2<span>整个页面的下半部分<\/span>/);
+    assert.match(pin, /top: `\$\{scope\.top \+ scope\.topbarHeight\}px`/);
+    assert.match(pin, /const top = scope\.top \+ Math\.round\(fullHeight \/ 2\)/);
+    assert.match(pin, /width: `\$\{scope\.width\}px`/);
+});
+
+test('unpinned traffic click preserves original panel menu behavior', () => {
+    assert.match(pin, /if \(!panel\.dataset\.pinSide\) return;/);
+    assert.match(pin, /Capture phase preserves ordinary original three-dot behavior exactly/);
+});
+
+test('nested cloned panels are explicitly reset to ordinary floating windows', () => {
+    for (const source of [terminal, telnet]) {
+        assert.match(source, /delete panel\.dataset\.desktopPinWired/);
+        assert.match(source, /delete panel\.dataset\.pinSide/);
+        assert.match(source, /panel\.classList\.remove\('pinned', 'pin-animating'\)/);
+        assert.match(source, /panel\.querySelectorAll\('\.panel-pin-btn'\)\.forEach\(\(button\) => button\.remove\(\)\)/);
+    }
+});
+
+test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
+    for (const source of [terminal, telnet, rdp, vnc, app]) {
+        assert.match(source, /attachDesktopPanelPin/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin1/);
+        assert.doesNotMatch(source, /panel-pin-demo/);
+    }
+    for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
+    for (const name of ['clipboardPanel', 'filesPanel', 'shortcutsPanel', 'joystickPanel']) assert.ok(rdp.includes(name));
+    assert.match(app, /attachDesktopPanelPin\(document\.querySelector\('\.app-shell'\), panel/);
+    assert.doesNotMatch(pin, /panel-pin-demo/);
+});
+
+test('pinning uses complete geometry and surface transitions', () => {
+    for (const fragment of [
+        'left .52s var(--ios-open)', 'top .52s var(--ios-open)',
+        'width .52s var(--ios-open)', 'height .52s var(--ios-open)',
+        'animation: panel-pin-settle .52s var(--ios-open)',
+        'padding-left .5s var(--ios-open)', 'padding-right .5s var(--ios-open)',
+    ]) assert.ok(css.includes(fragment), fragment);
+});
+
+test('all shipped pages load pin styling without demo artifact', () => {
+    for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
+        const html = read(file);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin1/);
+        assert.doesNotMatch(html, /panel-pin-demo/);
+    }
+    assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
+});
+
+test('service worker rotates and precaches both panel-pin assets', () => {
+    const sw = read('public/sw.js');
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin1/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin1/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin1/);
+});

--- a/tests/floating-panel-drag-physics-contract.test.mjs
+++ b/tests/floating-panel-drag-physics-contract.test.mjs
@@ -149,12 +149,15 @@ test('image/media preview use shared physics, not header hard drag', () => {
   assert.doesNotMatch(media, /startPanelDrag/);
 });
 
-test('cache revision pins style + terminal + floating-panel physics4', () => {
+test('cache revision pins style + terminal + floating-panel physics4 + desktop pin assets', () => {
   const appVersion = singleAssetVersion(appHtml, 'app.js', 'app shell app.js');
   const styleVersion = singleAssetVersion(appHtml, 'style.css', 'app shell style.css');
   const terminalVersion = singleAssetVersion(terminalHtml, 'terminal.js', 'terminal page script');
-  assert.equal(cacheNameVersion(sw), appVersion);
+  const pinVersion = singleAssetVersion(appHtml, 'panel-pin.css', 'app shell panel pin css');
+  assert.equal(cacheNameVersion(sw), pinVersion);
   assertAssetVersion(sw, 'style.css', styleVersion, 'service worker style.css');
   assertAssetVersion(sw, 'terminal.js', terminalVersion, 'service worker terminal.js');
   assertAssetVersion(sw, 'floating-panel.js', CACHE, 'service worker floating-panel.js');
+  assertAssetVersion(sw, 'panel-pin.js', pinVersion, 'service worker panel pin js');
+  assertAssetVersion(sw, 'panel-pin.css', pinVersion, 'service worker panel pin css');
 });


### PR DESCRIPTION
## Summary
- add the 18px `tgl-pin` left/right controls to desktop secondary floating panels across SSH, Telnet, RDP, VNC, and the AI panel
- pin side rails at one-quarter width, permit same-side stacking, and smoothly reflow the active underlying surface
- preserve existing three-dot behavior while unpinned; pinned panels get full, global lower-half, switch side, unpin, and close actions
- keep nested/cloned third-level windows ordinary floaters by default
- rotate/precache service-worker assets and add contracts

## Validation
- `npm run test:syntax`
- `node --test tests/desktop-panel-pin-contract.test.mjs tests/floating-panel-drag-physics-contract.test.mjs tests/ai-panel-drag-physics-contract.test.mjs tests/ai-panel-layout-motion-contract.test.mjs tests/telnet-terminal-page-contract.test.mjs`
- `npm run test:rdp-node` was attempted; 213 unrelated failures occur because the sandbox cannot load the native `better-sqlite3` arm64 binding after `npm ci --ignore-scripts`.

No demo artifact is included.