### PR TITLE
fix(web): polish desktop panel pin state and theming

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.css
+++ b/public/panel-pin.css
@@ -1,6 +1,7 @@
 /* Desktop secondary-panel side pinning.
- * `.tgl.panel-pin-btn` is intentionally the exact component from tgl-pin.html;
- * only absolute left/right positioning is added here. */
+ * `.tgl.panel-pin-btn` intentionally starts from the exact 18px component in
+ * tgl-pin.html, then adapts only its palette to Zephyr's active theme. The
+ * demo geometry and spring remain byte-identical. */
 .tgl.panel-pin-btn {
     --s: 18px;
     position: absolute;
@@ -10,8 +11,8 @@
     height: var(--s);
     padding: 0;
     border-radius: 50%;
-    border: 1.5px solid #4a4f5a;
-    background: #1e2025;
+    border: 1.5px solid color-mix(in srgb, var(--text) 27%, var(--border));
+    background: color-mix(in srgb, var(--surface) 88%, var(--bg));
     cursor: pointer;
     outline: none;
     display: inline-flex;
@@ -31,14 +32,17 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #dfe3ea;
+    background: var(--accent);
     transform: scale(0);
     transition: transform .28s cubic-bezier(.34, 1.56, .64, 1), box-shadow .2s ease;
 }
-.panel-pin-btn:hover { border-color: #5d6372; }
+.panel-pin-btn:hover { border-color: color-mix(in srgb, var(--text) 39%, var(--border)); }
 .panel-pin-btn:active { transform: scale(.85); }
-.panel-pin-btn.on { border-color: #9aa2b1; background: #262932; }
-.panel-pin-btn.on::after { transform: scale(1); box-shadow: 0 0 6px rgba(223, 227, 234, .35); }
+.panel-pin-btn.on {
+    border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+    background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+}
+.panel-pin-btn.on::after { transform: scale(1); box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent); }
 
 /* Every top-level secondary panel may be pinned. */
 .file-manager.pin-animating, .info-modal.pin-animating, .docker-panel.pin-animating,
@@ -62,7 +66,9 @@
 .shortcut-panel.pinned, .rdp-floating-panel.pinned, .ai-agent-panel.pinned {
     max-height: none !important;
     min-width: 0 !important;
-    box-shadow: 0 18px 60px rgba(0,0,0,.45);
+    /* A docked window is attached to the page; a floating drop shadow reads as
+       visual glue. Keep only the ordinary panel border while pinned. */
+    box-shadow: none !important;
 }
 .pinned[data-pin-side="left"] { border-left-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 .pinned[data-pin-side="right"] { border-right-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -131,6 +131,14 @@ function syncChrome(panel) {
         const edge = handle.dataset.resizeEdge || (handle.classList.contains('left') ? 'left' : 'right');
         handle.style.display = side && edge === side ? 'none' : '';
     });
+    if (!side) {
+        // Demo parity: once released, ⋯ must be an ordinary window-layout button
+        // again. Do not leave the pinned island's faded/hidden chrome behind.
+        panel.querySelectorAll('.panel-traffic-btn, [data-layout-panel], [data-ai-agent-layout]').forEach((button) => {
+            button.classList.remove('active-layout');
+            button.style.removeProperty('opacity');
+        });
+    }
 }
 
 function pin(panel, side) {
@@ -336,6 +344,9 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
             pinned.delete(panel);
             delete panel.dataset.pinSide;
             delete panel.dataset.pinMode;
+            // Keep release semantics identical to the demo: a closed/docked panel
+            // always comes back as an ordinary floating window with normal ⋯ chrome.
+            syncChrome(panel);
             owner && applyInsets(owner);
         }
     });

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin1';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin2';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,8 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin1',
-    '/panel-pin.css?v=20260830-desktop-panel-pin1',
+    '/panel-pin.js?v=20260830-desktop-panel-pin2',
+    '/panel-pin.css?v=20260830-desktop-panel-pin2',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin1">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin1';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -13,14 +13,34 @@ const rdp = read('public/rdp-wasm-client.js');
 const vnc = read('public/novnc.js');
 const app = read('public/app.js');
 
-test('panel pin uses the exact tgl-pin visual contract', () => {
+test('panel pin keeps the exact tgl-pin geometry and motion contract', () => {
     for (const fragment of [
-        '.tgl.panel-pin-btn', '--s: 18px', 'border: 1.5px solid #4a4f5a',
-        'background: #1e2025', 'background: #dfe3ea',
+        '.tgl.panel-pin-btn', '--s: 18px', 'width: 8px;', 'height: 8px;',
         'cubic-bezier(.34, 1.56, .64, 1)', 'transform: scale(.85)',
-        'border-color: #9aa2b1', 'background: #262932',
     ]) assert.ok(css.includes(fragment), fragment);
     assert.match(pin, /button\.className = `tgl panel-pin-btn \$\{side\}`/);
+});
+
+test('panel pin colors follow the active Zephyr theme instead of demo dark constants', () => {
+    for (const fragment of [
+        'color-mix(in srgb, var(--text) 27%, var(--border))',
+        'background: color-mix(in srgb, var(--surface) 88%, var(--bg))',
+        'background: var(--accent)',
+        'border-color: color-mix(in srgb, var(--accent) 72%, var(--border))',
+        'background: color-mix(in srgb, var(--accent) 14%, var(--surface))',
+    ]) assert.ok(css.includes(fragment), fragment);
+    assert.doesNotMatch(css, /border: 1\.5px solid #4a4f5a/);
+    assert.doesNotMatch(css, /background: #1e2025/);
+    assert.doesNotMatch(css, /background: #dfe3ea/);
+    assert.doesNotMatch(css, /border-color: #9aa2b1/);
+    assert.doesNotMatch(css, /background: #262932/);
+});
+
+test('pinned panels remove floating drop shadow and traffic chrome resets after release', () => {
+    assert.match(css, /box-shadow: none !important;/);
+    assert.match(pin, /button\.classList\.remove\('active-layout'\)/);
+    assert.match(pin, /button\.style\.removeProperty\('opacity'\)/);
+    assert.match(pin, /syncChrome\(panel\);\n            owner && applyInsets\(owner\);/);
 });
 
 test('panel pins are desktop-only and mobile cannot receive controls', () => {
@@ -61,7 +81,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin1/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin2/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -82,7 +102,7 @@ test('pinning uses complete geometry and surface transitions', () => {
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin1/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin2/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
@@ -90,7 +110,7 @@ test('all shipped pages load pin styling without demo artifact', () => {
 
 test('service worker rotates and precaches both panel-pin assets', () => {
     const sw = read('public/sw.js');
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin1/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin1/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin1/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin2/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin2/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin2/);
 });


### PR DESCRIPTION
## 修复点
- 两个 18px 钉按钮不再硬编码 demo 的深色常量；保留 demo 的 18px 几何和弹性动效，但颜色跟随当前 Zephyr 主题/强调色，浅色主题下不再全黑。
- 钉住浮窗后去掉浮窗式重阴影，只保留普通边框，让钉住状态读作附着在页面上。
- 解除钉住、浮窗关闭/断开时，会同步恢复 ⋯ 按钮的原始状态，避免 active-layout/opacity 残留导致和浮窗实际状态不一致。
- 旋转 service worker/cache revision 到 20260830-desktop-panel-pin2，确保已安装客户端拿到修复后的资源。

## 验证
- node --test tests/desktop-panel-pin-contract.test.mjs（12/12）
- node --check 所有变更 JS
- git diff --check
- node --test tests/*panel*contract.test.mjs（30/30；runtime 浏览器 harness 在当前沙箱基线同样失败，非本改动引入）