### PR TITLE
fix(web): complete desktop panel pin layout regions

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.css
+++ b/public/panel-pin.css
@@ -1,7 +1,7 @@
 /* Desktop secondary-panel side pinning.
  * `.tgl.panel-pin-btn` intentionally starts from the exact 18px component in
- * tgl-pin.html, then adapts only its palette to Zephyr's active theme. The
- * demo geometry and spring remain byte-identical. */
+ * tgl-pin.html. RELEASED state is byte-identical to the demo; only ON state
+ * follows Zephyr's active accent so it remains legible in both themes. */
 .tgl.panel-pin-btn {
     --s: 18px;
     position: absolute;
@@ -11,8 +11,8 @@
     height: var(--s);
     padding: 0;
     border-radius: 50%;
-    border: 1.5px solid color-mix(in srgb, var(--text) 27%, var(--border));
-    background: color-mix(in srgb, var(--surface) 88%, var(--bg));
+    border: 1.5px solid #4a4f5a;
+    background: #1e2025;
     cursor: pointer;
     outline: none;
     display: inline-flex;
@@ -32,17 +32,21 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: var(--accent);
+    background: #dfe3ea;
     transform: scale(0);
     transition: transform .28s cubic-bezier(.34, 1.56, .64, 1), box-shadow .2s ease;
 }
-.panel-pin-btn:hover { border-color: color-mix(in srgb, var(--text) 39%, var(--border)); }
+.panel-pin-btn:hover { border-color: #5d6372; }
 .panel-pin-btn:active { transform: scale(.85); }
 .panel-pin-btn.on {
     border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
     background: color-mix(in srgb, var(--accent) 14%, var(--surface));
 }
-.panel-pin-btn.on::after { transform: scale(1); box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent); }
+.panel-pin-btn.on::after {
+    background: var(--accent);
+    transform: scale(1);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
+}
 
 /* Every top-level secondary panel may be pinned. */
 .file-manager.pin-animating, .info-modal.pin-animating, .docker-panel.pin-animating,
@@ -66,58 +70,49 @@
 .shortcut-panel.pinned, .rdp-floating-panel.pinned, .ai-agent-panel.pinned {
     max-height: none !important;
     min-width: 0 !important;
-    /* A docked window is attached to the page; a floating drop shadow reads as
-       visual glue. Keep only the ordinary panel border while pinned. */
+    /* A docked window is attached to the page; floating transform/drop shadow
+       read as visual glue. Keep only the ordinary panel border while pinned. */
     box-shadow: none !important;
+    transform: none !important;
+    filter: none !important;
 }
 .pinned[data-pin-side="left"] { border-left-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 .pinned[data-pin-side="right"] { border-right-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 
-.panel-pin-menu {
-    position: fixed;
-    min-width: 196px;
-    display: flex;
-    flex-direction: column;
-    padding: 5px;
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    background: color-mix(in srgb, var(--surface) 94%, transparent);
-    box-shadow: 0 16px 46px rgba(0,0,0,.42);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-    opacity: 0;
-    transform: scale(.92) translateY(-4px);
-    transform-origin: top center;
-    transition: opacity .16s ease, transform .2s var(--ios-open);
-}
-.panel-pin-menu.open { opacity: 1; transform: scale(1) translateY(0); }
-.panel-pin-menu button {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1px;
-    padding: 7px 10px;
-    border: 0;
-    border-radius: 8px;
-    background: none;
-    color: var(--text-primary);
-    font: inherit;
-    font-size: 12.5px;
-    text-align: left;
-    cursor: pointer;
-    transition: background .14s ease;
-}
-.panel-pin-menu button span { color: var(--text-secondary); font-size: 10.5px; }
-.panel-pin-menu button:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); }
-.panel-pin-menu button.danger { color: #f47067; }
+/* Pinned ⋯ uses the exact unpinned Dynamic Island visual system. Only the
+   grid column count/contents differ; button size, icons, stagger, timing,
+   background, border and blur are inherited from .panel-layout-menu in style.css. */
+.panel-pin-menu { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.panel-pin-menu button:nth-child(1) { --item-index: 0; }
+.panel-pin-menu button:nth-child(2) { --item-index: 1; }
+.panel-pin-menu button:nth-child(3) { --item-index: 2; }
+.panel-pin-menu button:nth-child(4) { --item-index: 3; }
+.panel-pin-menu button:nth-child(5) { --item-index: 4; }
+.panel-pin-menu button:nth-child(6) { --item-index: 5; }
 
-/* Side rail geometry reflows the actual active surface with a synchronized transition. */
+.panel-layout-icon.unpin { border-style: dashed; }
+.panel-layout-icon.unpin::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 14px;
+    height: 2px;
+    border-radius: 999px;
+    background: var(--text-secondary);
+    transform: translate(-50%, -50%) rotate(45deg);
+}
+
+/* Dock geometry reflows the actual active surface with a synchronized transition. */
 @media (hover: hover) and (pointer: fine) {
     .terminal-page, .rdp-page, .app-shell {
-        transition: padding-left .5s var(--ios-open), padding-right .5s var(--ios-open), background-color .24s ease, border-color .24s ease;
+        transition:
+            padding-left .5s var(--ios-open), padding-right .5s var(--ios-open),
+            padding-bottom .5s var(--ios-open), background-color .24s ease, border-color .24s ease;
     }
     .terminal-page.pin-has-left, .rdp-page.pin-has-left, .app-shell.pin-has-left, body.pin-has-left { padding-left: var(--pin-inset-left, 0px); }
     .terminal-page.pin-has-right, .rdp-page.pin-has-right, .app-shell.pin-has-right, body.pin-has-right { padding-right: var(--pin-inset-right, 0px); }
+    .terminal-page.pin-has-bottom, .rdp-page.pin-has-bottom, .app-shell.pin-has-bottom, body.pin-has-bottom { padding-bottom: calc(max(4px, env(safe-area-inset-bottom)) + var(--pin-inset-bottom, 0px)); }
 }
 
 /* JS never injects on touch/mobile; this is a second hard guarantee. */

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -1,6 +1,7 @@
 /**
  * Desktop-only side pinning for Zephyr's secondary floating panels.
- * The toggle's visual system is the exact 18px `.tgl` component from tgl-pin.html.
+ * The toggle's geometry/motion are the exact 18px `.tgl` component from
+ * tgl-pin.html; its colors deliberately follow the active Zephyr theme.
  */
 const pinned = new Set();
 let zSeed = 10100;
@@ -18,7 +19,7 @@ function scopeFor(page) {
     const rect = page.getBoundingClientRect();
     const width = page.clientWidth || rect.width || window.innerWidth;
     const height = page.clientHeight || rect.height || window.innerHeight;
-    const topbar = page.querySelector(':scope > .terminal-topbar, :scope > .main-nav');
+    const topbar = page.querySelector(':scope > .terminal-topbar, :scope > .rdp-topbar, :scope > .main-nav');
     const topbarHeight = topbar?.offsetHeight || 0;
     // Pinned windows use position:fixed so RDP/VNC windows (whose normal parent
     // is the display stage) can still cover the page chrome exactly like SSH.
@@ -53,13 +54,23 @@ function sideInset(page, side) {
     return dockedAt(page, side).reduce((max, panel) => Math.max(max, panel.offsetWidth || 0), 0);
 }
 
+function halfInset(page) {
+    return panelGroup(page).reduce((max, panel) => {
+        if (panel.dataset.pinMode !== 'half') return max;
+        return Math.max(max, panel.offsetHeight || 0);
+    }, 0);
+}
+
 function applyInsets(page) {
     const left = sideInset(page, 'left');
     const right = sideInset(page, 'right');
+    const bottom = halfInset(page);
     page.style.setProperty('--pin-inset-left', `${left}px`);
     page.style.setProperty('--pin-inset-right', `${right}px`);
+    page.style.setProperty('--pin-inset-bottom', `${bottom}px`);
     page.classList.toggle('pin-has-left', left > 0);
     page.classList.toggle('pin-has-right', right > 0);
+    page.classList.toggle('pin-has-bottom', bottom > 0);
 }
 
 function bringToFront(panel) {
@@ -79,6 +90,10 @@ function startGeometryMotion(panel) {
         panel.classList.remove('pin-animating');
         panel.style.willChange = '';
     }, 560);
+}
+
+function clampHalfHeight(height, scope) {
+    return Math.max(160, Math.min(scope.height - scope.topbarHeight - 80, Math.round(height)));
 }
 
 function place(panel, mode = panel.dataset.pinMode || 'side') {
@@ -102,34 +117,42 @@ function place(panel, mode = panel.dataset.pinMode || 'side') {
         return;
     }
     if (mode === 'half') {
-        // ⋯ → bottom 1/2: the full page's lower half, not the side rail's half.
-        const top = scope.top + Math.round(fullHeight / 2);
+        // Bottom dock is genuinely a bottom band: the bottom row owns the full
+        // width, while side rails remain only in the row above it.
+        const height = clampHalfHeight(Number.parseFloat(panel.style.height) || Math.round(fullHeight / 2), scope);
+        panel._pinHalfHeight = height;
         Object.assign(panel.style, fixed, {
-            left: `${scope.left}px`, top: `${top}px`, width: `${scope.width}px`, height: `${scope.top + fullHeight - top}px`,
+            left: `${scope.left}px`, top: `${scope.top + fullHeight - height}px`, width: `${scope.width}px`, height: `${height}px`,
         });
         return;
     }
 
     const explicit = Number.parseFloat(panel.style.width);
     const width = Math.min(Number.isFinite(explicit) ? explicit : quarterWidth(scope), scope.width);
+    // Side rails stop above any bottom-docked panel; the bottom band is the
+    // only owner of the lower row, so the two modes never overlap.
+    const height = fullHeight - halfInset(page);
     Object.assign(panel.style, fixed, {
-        // Side pins cover the whole page chrome (the red-line/top-bar region included).
         left: `${scope.left + (side === 'left' ? 0 : scope.width - width)}px`, top: `${scope.top}px`,
-        width: `${width}px`, height: `${fullHeight}px`,
+        width: `${width}px`, height: `${Math.max(1, height)}px`,
     });
 }
 
 function syncChrome(panel) {
     const side = panel.dataset.pinSide || '';
+    const mode = panel.dataset.pinMode || 'side';
     panel.classList.toggle('pinned', !!side);
+    // A bottom dock is not a left/right rail. Both 18px toggles lock together,
+    // matching the demo's ON state while the panel is docked anywhere.
+    const buttonOn = (button) => side ? (mode === 'half' || button.dataset.pinSide === side) : false;
     panel.querySelectorAll('.panel-pin-btn').forEach((button) => {
-        const active = button.dataset.pinSide === side;
+        const active = buttonOn(button);
         button.classList.toggle('on', active);
         button.setAttribute('aria-pressed', String(active));
     });
     panel.querySelectorAll('.panel-resize-handle').forEach((handle) => {
         const edge = handle.dataset.resizeEdge || (handle.classList.contains('left') ? 'left' : 'right');
-        handle.style.display = side && edge === side ? 'none' : '';
+        handle.style.display = side && mode === 'side' && edge === side ? 'none' : '';
     });
     if (!side) {
         // Demo parity: once released, ⋯ must be an ordinary window-layout button
@@ -164,6 +187,7 @@ function unpin(panel) {
     const restore = panel._pinRestore;
     delete panel.dataset.pinSide;
     delete panel.dataset.pinMode;
+    delete panel._pinHalfHeight;
     pinned.delete(panel);
     startGeometryMotion(panel);
     if (restore) {
@@ -177,15 +201,48 @@ function unpin(panel) {
         });
     }
     syncChrome(panel);
+    panelGroup(page).forEach((other) => other !== panel && place(other));
     applyInsets(page);
     if (navigator.vibrate) navigator.vibrate([6, 16, 6]);
 }
 
-function closePinMenu() {
-    const menu = document.querySelector('.panel-pin-menu');
+function closePinMenu(anchor = null, panel = null, { instant = false } = {}) {
+    const menu = panel?._pinMenu || document.querySelector('.panel-pin-menu');
+    const traffic = anchor || panel?.querySelector?.('.panel-traffic-btn, [data-layout-panel], [data-ai-agent-layout]');
     if (!menu) return;
-    menu.classList.remove('open');
-    window.setTimeout(() => menu.remove(), 160);
+    window.clearTimeout(menu._closeTimer);
+    if (instant || !traffic?.isConnected) {
+        traffic?.classList.remove('active-layout');
+        traffic?.style.removeProperty('opacity');
+        menu.remove();
+        if (panel?._pinMenu === menu) delete panel._pinMenu;
+        return;
+    }
+    const rect = traffic.getBoundingClientRect();
+    menu.style.transition = 'none';
+    menu.style.setProperty('--panel-island-menu-width', `${Math.max(188, Number.parseFloat(menu.style.getPropertyValue('--panel-island-menu-width')) || 336)}px`);
+    menu.style.setProperty('--panel-island-menu-height', '50px');
+    menu.style.setProperty('--panel-island-radius', '18px');
+    void menu.offsetWidth;
+    menu.classList.remove('island-open');
+    menu.classList.add('island-closing', 'island-animating');
+    traffic.classList.remove('active-layout');
+    traffic.style.opacity = '0';
+    requestAnimationFrame(() => {
+        menu.style.removeProperty('transition');
+        menu.style.left = `${rect.left}px`;
+        menu.style.top = `${rect.top}px`;
+        menu.style.setProperty('--panel-island-menu-width', `${rect.width}px`);
+        menu.style.setProperty('--panel-island-menu-height', `${rect.height}px`);
+        menu.style.setProperty('--panel-island-radius', `${Math.round(rect.height / 2)}px`);
+    });
+    menu._closeTimer = window.setTimeout(() => {
+        traffic.classList.remove('active-layout');
+        traffic.style.opacity = '1';
+        requestAnimationFrame(() => traffic.style.removeProperty('opacity'));
+        menu.remove();
+        if (panel?._pinMenu === menu) delete panel._pinMenu;
+    }, 460);
 }
 
 function openPinMenu(anchor, panel, onClose) {
@@ -193,24 +250,46 @@ function openPinMenu(anchor, panel, onClose) {
     const page = panel._pinPage;
     const side = panel.dataset.pinSide || 'left';
     const menu = document.createElement('div');
-    menu.className = 'panel-pin-menu';
+    // Same host classes, icon spans, island-open animation and stagger timing as
+    // the ordinary unpinned ⋯ menu. Pinned state only changes available actions.
+    menu.className = 'panel-layout-menu panel-pin-menu';
     menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-label', '钉住布局');
     menu.innerHTML = `
-        <button data-pin-layout="full">全屏<span>保留顶部栏，以下完整覆盖</span></button>
-        <button data-pin-layout="half">下 1/2<span>整个页面的下半部分</span></button>
-        <button data-pin-layout="switch">钉到${side === 'left' ? '右' : '左'}边<span>恢复 1/4 宽侧栏</span></button>
-        <button data-pin-layout="unpin">取消钉住<span>恢复普通浮窗</span></button>
-        <button data-pin-layout="close" class="danger">关闭浮窗</button>`;
+        <button data-pin-layout="full" title="全屏" aria-label="全屏"><span class="panel-layout-icon full"></span></button>
+        <button data-pin-layout="half" title="下 1/2" aria-label="下 1/2"><span class="panel-layout-icon half"></span></button>
+        <button data-pin-layout="switch-left" title="钉到左边" aria-label="钉到左边"><span class="panel-layout-icon left"></span></button>
+        <button data-pin-layout="switch-right" title="钉到右边" aria-label="钉到右边"><span class="panel-layout-icon right"></span></button>
+        <button data-pin-layout="unpin" title="取消钉住" aria-label="取消钉住"><span class="panel-layout-icon unpin"></span></button>
+        <button data-pin-layout="close" class="panel-layout-close" title="关闭窗口" aria-label="关闭窗口"><span class="panel-layout-icon close"></span></button>`;
+    menu.style.transition = 'none';
+    menu.style.zIndex = String(Math.max(10000, (Number(panel.style.zIndex) || zSeed) + 20));
     document.body.appendChild(menu);
+    panel._pinMenu = menu;
+    anchor._pinMenuOpen = true;
     const rect = anchor.getBoundingClientRect();
-    const left = Math.max(8, Math.min(window.innerWidth - menu.offsetWidth - 8, rect.left + rect.width / 2 - menu.offsetWidth / 2));
-    Object.assign(menu.style, { left: `${left}px`, top: `${rect.bottom + 8}px`, zIndex: String((Number(panel.style.zIndex) || zSeed) + 20) });
-    requestAnimationFrame(() => menu.classList.add('open'));
+    const width = Math.min(336, Math.max(188, window.innerWidth - 16));
+    const left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.left + rect.width / 2 - width / 2));
+    menu.style.left = `${left}px`;
+    menu.style.top = `${rect.top}px`;
+    menu.style.setProperty('--panel-island-menu-width', `${width}px`);
+    menu.style.setProperty('--panel-island-menu-height', '50px');
+    menu.style.setProperty('--panel-island-radius', `${Math.round(rect.height / 2)}px`);
+    menu.style.opacity = '1';
+    menu.classList.add('island-animating');
+    void menu.offsetWidth;
+    requestAnimationFrame(() => {
+        menu.style.removeProperty('transition');
+        anchor.classList.add('active-layout');
+        menu.classList.add('island-open');
+        menu.style.setProperty('--panel-island-radius', '18px');
+        window.setTimeout(() => menu.classList.remove('island-animating'), 540);
+    });
 
     const outside = (event) => {
         if (!menu.contains(event.target) && event.target !== anchor) {
             document.removeEventListener('pointerdown', outside, true);
-            closePinMenu();
+            closePinMenu(anchor, panel);
         }
     };
     document.addEventListener('pointerdown', outside, true);
@@ -219,23 +298,26 @@ function openPinMenu(anchor, panel, onClose) {
         if (!item) return;
         document.removeEventListener('pointerdown', outside, true);
         const action = item.dataset.pinLayout;
-        closePinMenu();
+        closePinMenu(anchor, panel);
         if (action === 'close') { onClose?.(panel); return; }
         if (action === 'unpin') { unpin(panel); return; }
-        if (action === 'switch') {
-            panel.dataset.pinSide = side === 'left' ? 'right' : 'left';
+        if (action === 'switch-left' || action === 'switch-right') {
+            panel.dataset.pinSide = action === 'switch-left' ? 'left' : 'right';
             panel.dataset.pinMode = 'side';
             panel.style.width = `${quarterWidth(scopeFor(page))}px`;
             place(panel, 'side');
             syncChrome(panel);
             bringToFront(panel);
+            panelGroup(page).forEach((other) => other !== panel && place(other));
             applyInsets(page);
             return;
         }
         panel.dataset.pinMode = action;
+        if (action === 'half') panel.style.height = `${panel._pinHalfHeight || Math.round(scopeFor(page).height / 2)}px`;
         place(panel, action);
         syncChrome(panel);
         bringToFront(panel);
+        panelGroup(page).forEach((other) => other !== panel && place(other));
         applyInsets(page);
     });
 }
@@ -274,6 +356,38 @@ function bindPinnedResize(panel, handle) {
     }, true);
 }
 
+function bindPinnedVerticalDrag(panel, handle) {
+    handle.addEventListener('pointerdown', (event) => {
+        if (!panel.dataset.pinSide || panel.dataset.pinMode !== 'half') return;
+        if (event.target.closest('.panel-pin-btn, .panel-traffic-btn, [data-layout-panel], [data-ai-agent-layout]')) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        const page = panel._pinPage;
+        const scope = scopeFor(page);
+        const startY = event.clientY;
+        const startHeight = panel.offsetHeight;
+        panel.classList.add('resizing');
+        const move = (ev) => {
+            ev.preventDefault();
+            const next = clampHalfHeight(startHeight + (startY - ev.clientY), scope);
+            panel._pinHalfHeight = next;
+            panel.style.height = `${next}px`;
+            panel.style.top = `${scope.top + scope.height - next}px`;
+        };
+        const up = () => {
+            panel.classList.remove('resizing');
+            window.removeEventListener('pointermove', move);
+            window.removeEventListener('pointerup', up);
+            // The terminal/content area must own only the space above the dock.
+            // This reflow is what prevents the bottom band from covering it.
+            panelGroup(page).forEach((other) => other !== panel && place(other));
+            applyInsets(page);
+        };
+        window.addEventListener('pointermove', move, { passive: false });
+        window.addEventListener('pointerup', up, { once: true });
+    }, true);
+}
+
 /**
  * Attach only to a top-level secondary panel. Nested/third-level panels must
  * not inherit the parent pin state; callers simply do not invoke this on them.
@@ -286,6 +400,7 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
     // Defensive reset for cloned nested panels: default stays a normal floating window.
     delete panel.dataset.pinSide;
     delete panel.dataset.pinMode;
+    delete panel._pinHalfHeight;
     panel.classList.remove('pinned', 'pin-animating');
 
     const handle = dragHandle || panel.querySelector('.panel-drag-handle');
@@ -316,6 +431,9 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
         if (!button) return;
         event.preventDefault();
         event.stopPropagation();
+        // Bottom dock locks both toggles; while it is active, toggles stay ON
+        // rather than pretending to select a left/right rail. Use ⋯ to release.
+        if (panel.dataset.pinMode === 'half') return;
         if (panel.dataset.pinSide === button.dataset.pinSide) unpin(panel);
         else pin(panel, button.dataset.pinSide);
     });
@@ -333,6 +451,7 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
     }
 
     panel.querySelectorAll('.panel-resize-handle').forEach((handleEl) => bindPinnedResize(panel, handleEl));
+    bindPinnedVerticalDrag(panel, handle);
     panel.addEventListener('pointerdown', () => {
         if (panel.dataset.pinSide) bringToFront(panel);
     }, true);
@@ -344,9 +463,11 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
             pinned.delete(panel);
             delete panel.dataset.pinSide;
             delete panel.dataset.pinMode;
+            delete panel._pinHalfHeight;
             // Keep release semantics identical to the demo: a closed/docked panel
             // always comes back as an ordinary floating window with normal ⋯ chrome.
             syncChrome(panel);
+            panelGroup(owner).forEach((other) => place(other));
             owner && applyInsets(owner);
         }
     });
@@ -356,6 +477,7 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
     window.addEventListener('resize', () => {
         if (!panel.dataset.pinSide) return;
         place(panel);
+        panelGroup(panel._pinPage).forEach((other) => other !== panel && place(other));
         applyInsets(panel._pinPage);
     });
     return true;
@@ -367,6 +489,7 @@ export function releaseDesktopPanelPin(panel) {
 }
 
 export function refreshDesktopPanelPin(page) {
+    panelGroup(page).forEach((panel) => place(panel));
     applyInsets(page);
 }
 

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin2';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin3';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,8 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin2',
-    '/panel-pin.css?v=20260830-desktop-panel-pin2',
+    '/panel-pin.js?v=20260830-desktop-panel-pin3',
+    '/panel-pin.css?v=20260830-desktop-panel-pin3',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin2">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin2';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -12,35 +12,30 @@ const telnet = read('public/telnet-terminal.js');
 const rdp = read('public/rdp-wasm-client.js');
 const vnc = read('public/novnc.js');
 const app = read('public/app.js');
+const sw = read('public/sw.js');
 
-test('panel pin keeps the exact tgl-pin geometry and motion contract', () => {
+test('panel pin uses the exact tgl-pin released visual and motion contract', () => {
     for (const fragment of [
-        '.tgl.panel-pin-btn', '--s: 18px', 'width: 8px;', 'height: 8px;',
+        '.tgl.panel-pin-btn', '--s: 18px', 'border: 1.5px solid #4a4f5a',
+        'background: #1e2025', 'background: #dfe3ea', 'border-color: #5d6372',
         'cubic-bezier(.34, 1.56, .64, 1)', 'transform: scale(.85)',
     ]) assert.ok(css.includes(fragment), fragment);
     assert.match(pin, /button\.className = `tgl panel-pin-btn \$\{side\}`/);
 });
 
-test('panel pin colors follow the active Zephyr theme instead of demo dark constants', () => {
+test('only the pinned ON state follows the active Zephyr accent', () => {
     for (const fragment of [
-        'color-mix(in srgb, var(--text) 27%, var(--border))',
-        'background: color-mix(in srgb, var(--surface) 88%, var(--bg))',
-        'background: var(--accent)',
         'border-color: color-mix(in srgb, var(--accent) 72%, var(--border))',
         'background: color-mix(in srgb, var(--accent) 14%, var(--surface))',
+        'background: var(--accent)',
     ]) assert.ok(css.includes(fragment), fragment);
-    assert.doesNotMatch(css, /border: 1\.5px solid #4a4f5a/);
-    assert.doesNotMatch(css, /background: #1e2025/);
-    assert.doesNotMatch(css, /background: #dfe3ea/);
-    assert.doesNotMatch(css, /border-color: #9aa2b1/);
-    assert.doesNotMatch(css, /background: #262932/);
 });
 
-test('pinned panels remove floating drop shadow and traffic chrome resets after release', () => {
-    assert.match(css, /box-shadow: none !important;/);
+test('pinned panels remove floating shadow/transform and traffic chrome resets after release', () => {
+    for (const fragment of ['box-shadow: none !important;', 'transform: none !important;', 'filter: none !important;']) assert.ok(css.includes(fragment), fragment);
     assert.match(pin, /button\.classList\.remove\('active-layout'\)/);
     assert.match(pin, /button\.style\.removeProperty\('opacity'\)/);
-    assert.match(pin, /syncChrome\(panel\);\n            owner && applyInsets\(owner\);/);
+    assert.match(pin, /syncChrome\(panel\);\n            panelGroup\(owner\)\.forEach/);
 });
 
 test('panel pins are desktop-only and mobile cannot receive controls', () => {
@@ -49,19 +44,31 @@ test('panel pins are desktop-only and mobile cannot receive controls', () => {
     assert.match(css, /@media \(hover: none\), \(pointer: coarse\) \{ \.panel-pin-btn \{ display: none !important; \} \}/);
 });
 
-test('side pins are one quarter wide and cover full page chrome', () => {
-    assert.match(pin, /Math\.round\(scope\.width \/ 4\)/);
-    assert.match(pin, /top: `\$\{scope\.top\}px`/);
-    assert.match(pin, /height: `\$\{fullHeight\}px`/);
-    assert.match(pin, /Side pins cover the whole page chrome/);
+test('side rails stay above bottom dock while bottom dock owns the full lower row', () => {
+    assert.match(pin, /function halfInset\(page\)/);
+    assert.match(pin, /const height = fullHeight - halfInset\(page\)/);
+    assert.match(pin, /left: `\$\{scope\.left\}px`, top: `\$\{scope\.top \+ fullHeight - height\}px`, width: `\$\{scope\.width\}px`, height: `\$\{height\}px`/);
+    assert.match(css, /pin-has-bottom/);
+    assert.match(css, /var\(--pin-inset-bottom, 0px\)/);
 });
 
-test('pinned traffic menu retains specified full and global lower-half semantics', () => {
-    assert.match(pin, /全屏<span>保留顶部栏，以下完整覆盖<\/span>/);
-    assert.match(pin, /下 1\/2<span>整个页面的下半部分<\/span>/);
-    assert.match(pin, /top: `\$\{scope\.top \+ scope\.topbarHeight\}px`/);
-    assert.match(pin, /const top = scope\.top \+ Math\.round\(fullHeight \/ 2\)/);
-    assert.match(pin, /width: `\$\{scope\.width\}px`/);
+test('bottom dock locks both pin buttons and supports top-handle vertical resize', () => {
+    assert.match(pin, /mode === 'half' \|\| button\.dataset\.pinSide === side/);
+    assert.match(pin, /if \(panel\.dataset\.pinMode === 'half'\) return;/);
+    assert.match(pin, /function bindPinnedVerticalDrag\(panel, handle\)/);
+    assert.match(pin, /startHeight \+ \(startY - ev\.clientY\)/);
+    assert.match(pin, /panelGroup\(page\)\.forEach\(\(other\) => other !== panel && place\(other\)\);\n            applyInsets\(page\);/);
+});
+
+test('pinned traffic menu reuses the exact unpinned island host and icon contract', () => {
+    assert.match(pin, /menu\.className = 'panel-layout-menu panel-pin-menu'/);
+    for (const icon of ['full', 'half', 'left', 'right', 'unpin', 'close']) {
+        assert.match(pin, new RegExp(`<span class="panel-layout-icon ${icon}"></span>`), icon);
+    }
+    assert.match(pin, /menu\.classList\.add\('island-open'\)/);
+    assert.match(pin, /menu\.classList\.add\('island-closing', 'island-animating'\)/);
+    assert.match(css, /\.panel-pin-menu \{ grid-template-columns: repeat\(6, minmax\(0, 1fr\)\); \}/);
+    assert.doesNotMatch(css, /\.panel-pin-menu button \{[^}]*flex-direction: column/s);
 });
 
 test('unpinned traffic click preserves original panel menu behavior', () => {
@@ -81,7 +88,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin2/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin3/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -95,22 +102,21 @@ test('pinning uses complete geometry and surface transitions', () => {
         'left .52s var(--ios-open)', 'top .52s var(--ios-open)',
         'width .52s var(--ios-open)', 'height .52s var(--ios-open)',
         'animation: panel-pin-settle .52s var(--ios-open)',
-        'padding-left .5s var(--ios-open)', 'padding-right .5s var(--ios-open)',
+        'padding-left .5s var(--ios-open)', 'padding-right .5s var(--ios-open)', 'padding-bottom .5s var(--ios-open)',
     ]) assert.ok(css.includes(fragment), fragment);
 });
 
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin2/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin3/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
 });
 
 test('service worker rotates and precaches both panel-pin assets', () => {
-    const sw = read('public/sw.js');
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin2/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin2/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin2/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin3/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin3/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin3/);
 });


### PR DESCRIPTION
## 修复点
- 未选中的两个 18px 钉按钮恢复为  的原版视觉： 边框、 底、8px  内芯、原 spring；只有锁定态使用 Zephyr accent。
- 下 1/2 改为真正占据整个页面下排的 bottom dock；侧边钉只占用上方区域，不再和下 1/2 重叠。
- 下 1/2 时页面主体同步增加 bottom inset，终端/远程画面让位而不是被遮盖。
- 下 1/2 时两个钉按钮都锁定；下 1/2 面板顶部栏可上下拖动调整高度，并同步重排其它已钉面板和内容区。
- 钉住后的 ⋯ 菜单改用未钉住时完全相同的  Dynamic Island 宿主、图标、动画和逐项 stagger；仅菜单项变为全屏/下 1/2/左/右/解除/关闭。
- cache revision 升到 。

## 验证
- TAP version 13
# Subtest: panel pin uses the exact tgl-pin released visual and motion contract
ok 1 - panel pin uses the exact tgl-pin released visual and motion contract
  ---
  duration_ms: 3.595989
  type: 'test'
  ...
# Subtest: only the pinned ON state follows the active Zephyr accent
ok 2 - only the pinned ON state follows the active Zephyr accent
  ---
  duration_ms: 0.610885
  type: 'test'
  ...
# Subtest: pinned panels remove floating shadow/transform and traffic chrome resets after release
ok 3 - pinned panels remove floating shadow/transform and traffic chrome resets after release
  ---
  duration_ms: 0.405729
  type: 'test'
  ...
# Subtest: panel pins are desktop-only and mobile cannot receive controls
ok 4 - panel pins are desktop-only and mobile cannot receive controls
  ---
  duration_ms: 0.337708
  type: 'test'
  ...
# Subtest: side rails stay above bottom dock while bottom dock owns the full lower row
ok 5 - side rails stay above bottom dock while bottom dock owns the full lower row
  ---
  duration_ms: 0.681458
  type: 'test'
  ...
# Subtest: bottom dock locks both pin buttons and supports top-handle vertical resize
ok 6 - bottom dock locks both pin buttons and supports top-handle vertical resize
  ---
  duration_ms: 0.350364
  type: 'test'
  ...
# Subtest: pinned traffic menu reuses the exact unpinned island host and icon contract
ok 7 - pinned traffic menu reuses the exact unpinned island host and icon contract
  ---
  duration_ms: 0.889583
  type: 'test'
  ...
# Subtest: unpinned traffic click preserves original panel menu behavior
ok 8 - unpinned traffic click preserves original panel menu behavior
  ---
  duration_ms: 0.284063
  type: 'test'
  ...
# Subtest: nested cloned panels are explicitly reset to ordinary floating windows
ok 9 - nested cloned panels are explicitly reset to ordinary floating windows
  ---
  duration_ms: 1.968229
  type: 'test'
  ...
# Subtest: all desktop top-level panel surfaces are wired; demo is not referenced
ok 10 - all desktop top-level panel surfaces are wired; demo is not referenced
  ---
  duration_ms: 3.446615
  type: 'test'
  ...
# Subtest: pinning uses complete geometry and surface transitions
ok 11 - pinning uses complete geometry and surface transitions
  ---
  duration_ms: 0.48125
  type: 'test'
  ...
# Subtest: all shipped pages load pin styling without demo artifact
ok 12 - all shipped pages load pin styling without demo artifact
  ---
  duration_ms: 6.60875
  type: 'test'
  ...
# Subtest: service worker rotates and precaches both panel-pin assets
ok 13 - service worker rotates and precaches both panel-pin assets
  ---
  duration_ms: 0.209844
  type: 'test'
  ...
1..13
# tests 13
# suites 0
# pass 13
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 260.320677 13/13
- TAP version 13
# Subtest: Motion.drag supports handle threshold dynamic bounds and filter veto
ok 1 - Motion.drag supports handle threshold dynamic bounds and filter veto
  ---
  duration_ms: 2.668177
  type: 'test'
  ...
# Subtest: AI panel uses Motion.drag only on top gray handle
ok 2 - AI panel uses Motion.drag only on top gray handle
  ---
  duration_ms: 3.394843
  type: 'test'
  ...
# Subtest: traffic-light hard drag is precise; gray strip uses physics
ok 3 - traffic-light hard drag is precise; gray strip uses physics
  ---
  duration_ms: 2.390052
  type: 'test'
  ...
# Subtest: title bar and content are not bound as drag fallbacks
ok 4 - title bar and content are not bound as drag fallbacks
  ---
  duration_ms: 0.790521
  type: 'test'
  ...
# Subtest: AI layout buttons use Motion.morph FLIP geometry
ok 5 - AI layout buttons use Motion.morph FLIP geometry
  ---
  duration_ms: 3.841718
  type: 'test'
  ...
# Subtest: AI layout animation supports interruption and retargeting
ok 6 - AI layout animation supports interruption and retargeting
  ---
  duration_ms: 1.405573
  type: 'test'
  ...
# Subtest: layout menu closes independently before panel geometry morph
ok 7 - layout menu closes independently before panel geometry morph
  ---
  duration_ms: 0.837187
  type: 'test'
  ...
# Subtest: legacy CSS geometry transition is disabled for AI panel only
ok 8 - legacy CSS geometry transition is disabled for AI panel only
  ---
  duration_ms: 1.486146
  type: 'test'
  ...
# Subtest: motion engine exposes shape morph primitive
ok 9 - motion engine exposes shape morph primitive
  ---
  duration_ms: 0.538698
  type: 'test'
  ...
# Subtest: panel pin uses the exact tgl-pin released visual and motion contract
ok 10 - panel pin uses the exact tgl-pin released visual and motion contract
  ---
  duration_ms: 3.025364
  type: 'test'
  ...
# Subtest: only the pinned ON state follows the active Zephyr accent
ok 11 - only the pinned ON state follows the active Zephyr accent
  ---
  duration_ms: 0.536197
  type: 'test'
  ...
# Subtest: pinned panels remove floating shadow/transform and traffic chrome resets after release
ok 12 - pinned panels remove floating shadow/transform and traffic chrome resets after release
  ---
  duration_ms: 0.359896
  type: 'test'
  ...
# Subtest: panel pins are desktop-only and mobile cannot receive controls
ok 13 - panel pins are desktop-only and mobile cannot receive controls
  ---
  duration_ms: 0.264791
  type: 'test'
  ...
# Subtest: side rails stay above bottom dock while bottom dock owns the full lower row
ok 14 - side rails stay above bottom dock while bottom dock owns the full lower row
  ---
  duration_ms: 0.575
  type: 'test'
  ...
# Subtest: bottom dock locks both pin buttons and supports top-handle vertical resize
ok 15 - bottom dock locks both pin buttons and supports top-handle vertical resize
  ---
  duration_ms: 0.312656
  type: 'test'
  ...
# Subtest: pinned traffic menu reuses the exact unpinned island host and icon contract
ok 16 - pinned traffic menu reuses the exact unpinned island host and icon contract
  ---
  duration_ms: 0.775782
  type: 'test'
  ...
# Subtest: unpinned traffic click preserves original panel menu behavior
ok 17 - unpinned traffic click preserves original panel menu behavior
  ---
  duration_ms: 0.244271
  type: 'test'
  ...
# Subtest: nested cloned panels are explicitly reset to ordinary floating windows
ok 18 - nested cloned panels are explicitly reset to ordinary floating windows
  ---
  duration_ms: 1.877813
  type: 'test'
  ...
# Subtest: all desktop top-level panel surfaces are wired; demo is not referenced
ok 19 - all desktop top-level panel surfaces are wired; demo is not referenced
  ---
  duration_ms: 3.273594
  type: 'test'
  ...
# Subtest: pinning uses complete geometry and surface transitions
ok 20 - pinning uses complete geometry and surface transitions
  ---
  duration_ms: 0.554323
  type: 'test'
  ...
# Subtest: all shipped pages load pin styling without demo artifact
ok 21 - all shipped pages load pin styling without demo artifact
  ---
  duration_ms: 7.28651
  type: 'test'
  ...
# Subtest: service worker rotates and precaches both panel-pin assets
ok 22 - service worker rotates and precaches both panel-pin assets
  ---
  duration_ms: 0.180052
  type: 'test'
  ...
# Subtest: shared floating-panel exposes AI-parity physics + hard drag
ok 23 - shared floating-panel exposes AI-parity physics + hard drag
  ---
  duration_ms: 2.383073
  type: 'test'
  ...
# Subtest: bring-to-front never runs CSS transform animation (AI parity)
ok 24 - bring-to-front never runs CSS transform animation (AI parity)
  ---
  duration_ms: 3.146093
  type: 'test'
  ...
# Subtest: CSS frees transform for Motion.drag while open/dragging
ok 25 - CSS frees transform for Motion.drag while open/dragging
  ---
  duration_ms: 1.759166
  type: 'test'
  ...
# Subtest: SSH terminal wires physics drag, not titlebar hard drag
ok 26 - SSH terminal wires physics drag, not titlebar hard drag
  ---
  duration_ms: 0.848646
  type: 'test'
  ...
# Subtest: Telnet terminal mirrors SSH physics wiring
ok 27 - Telnet terminal mirrors SSH physics wiring
  ---
  duration_ms: 0.75948
  type: 'test'
  ...
# Subtest: RDP imports physics-capable floating-panel revision
ok 28 - RDP imports physics-capable floating-panel revision
  ---
  duration_ms: 0.187291
  type: 'test'
  ...
# Subtest: noVNC uses shared physics drag helpers
ok 29 - noVNC uses shared physics drag helpers
  ---
  duration_ms: 0.196979
  type: 'test'
  ...
# Subtest: image/media preview use shared physics, not header hard drag
ok 30 - image/media preview use shared physics, not header hard drag
  ---
  duration_ms: 0.166823
  type: 'test'
  ...
# Subtest: cache revision pins style + terminal + floating-panel physics4 + desktop pin assets
ok 31 - cache revision pins style + terminal + floating-panel physics4 + desktop pin assets
  ---
  duration_ms: 1.871302
  type: 'test'
  ...
1..31
# tests 31
# suites 0
# pass 31
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 283.400365 31/31
-  所有改动 JS
- 
- 浏览器 runtime harness 在 main 基线同失败（沙箱 Chromium harness not ready），与本改动无关。