### PR TITLE
fix(web): restore exact pin states and layout motion

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.css
+++ b/public/panel-pin.css
@@ -38,33 +38,29 @@
 }
 .panel-pin-btn:hover { border-color: #5d6372; }
 .panel-pin-btn:active { transform: scale(.85); }
+/* LOCKED state must stay byte-identical to the demo: bright ring + silver core.
+   No product accent substitution here; the animation carries the state. */
 .panel-pin-btn.on {
-    border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
-    background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+    border-color: #9aa2b1;
+    background: #262932;
 }
 .panel-pin-btn.on::after {
-    background: var(--accent);
     transform: scale(1);
-    box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
+    box-shadow: 0 0 6px rgba(223, 227, 234, .35);
 }
 
 /* Every top-level secondary panel may be pinned. */
+/* Resting panels intentionally have `transition: none !important` so Motion.drag
+   can bake geometry without a jump. Pinning is a discrete layout morph, not a
+   drag; pin-animating must explicitly win over that resting ban. */
 .file-manager.pin-animating, .info-modal.pin-animating, .docker-panel.pin-animating,
 .snippet-panel.pin-animating, .shortcut-panel.pin-animating, .rdp-floating-panel.pin-animating,
 .ai-agent-panel.pin-animating {
     transition:
-        left .52s var(--ios-open), top .52s var(--ios-open),
-        width .52s var(--ios-open), height .52s var(--ios-open),
-        border-radius .36s ease, box-shadow .36s ease, border-color .28s ease !important;
+        left .52s var(--ios-open) !important, top .52s var(--ios-open) !important,
+        width .52s var(--ios-open) !important, height .52s var(--ios-open) !important,
+        border-radius .36s ease !important, box-shadow .36s ease !important, border-color .28s ease !important;
     will-change: left, top, width, height;
-}
-.file-manager.pin-animating.pinned, .info-modal.pin-animating.pinned, .docker-panel.pin-animating.pinned,
-.snippet-panel.pin-animating.pinned, .shortcut-panel.pin-animating.pinned, .rdp-floating-panel.pin-animating.pinned,
-.ai-agent-panel.pin-animating.pinned { animation: panel-pin-settle .52s var(--ios-open); }
-@keyframes panel-pin-settle {
-    0% { filter: brightness(.94); box-shadow: 0 8px 24px rgba(0,0,0,.24); }
-    58% { filter: brightness(1.025); }
-    100% { filter: brightness(1); }
 }
 .file-manager.pinned, .info-modal.pinned, .docker-panel.pinned, .snippet-panel.pinned,
 .shortcut-panel.pinned, .rdp-floating-panel.pinned, .ai-agent-panel.pinned {

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -19,7 +19,11 @@ function scopeFor(page) {
     const rect = page.getBoundingClientRect();
     const width = page.clientWidth || rect.width || window.innerWidth;
     const height = page.clientHeight || rect.height || window.innerHeight;
-    const topbar = page.querySelector(':scope > .terminal-topbar, :scope > .rdp-topbar, :scope > .main-nav');
+    // `.main-nav` is a direct child of .app-shell, but a `.terminal-page` can be
+    // embedded inside another shell. Use local chrome only and never climb out
+    // into an ancestor nav; that only creates a bogus white band above docks.
+    const topbar = page.querySelector(':scope > .terminal-topbar, :scope > .rdp-topbar, :scope > .main-nav')
+        || page.querySelector(':scope > * > .terminal-topbar, :scope > * > .rdp-topbar, :scope > * > .main-nav');
     const topbarHeight = topbar?.offsetHeight || 0;
     // Pinned windows use position:fixed so RDP/VNC windows (whose normal parent
     // is the display stage) can still cover the page chrome exactly like SSH.
@@ -220,7 +224,7 @@ function closePinMenu(anchor = null, panel = null, { instant = false } = {}) {
     }
     const rect = traffic.getBoundingClientRect();
     menu.style.transition = 'none';
-    menu.style.setProperty('--panel-island-menu-width', `${Math.max(188, Number.parseFloat(menu.style.getPropertyValue('--panel-island-menu-width')) || 336)}px`);
+    menu.style.setProperty('--panel-island-menu-width', `${Math.min(284, Math.max(160, window.innerWidth - 16))}px`);
     menu.style.setProperty('--panel-island-menu-height', '50px');
     menu.style.setProperty('--panel-island-radius', '18px');
     void menu.offsetWidth;
@@ -268,7 +272,8 @@ function openPinMenu(anchor, panel, onClose) {
     panel._pinMenu = menu;
     anchor._pinMenuOpen = true;
     const rect = anchor.getBoundingClientRect();
-    const width = Math.min(336, Math.max(188, window.innerWidth - 16));
+    // Match the ordinary floating-panel island exactly: 284px cap / 50px tall.
+    const width = Math.min(284, Math.max(160, window.innerWidth - 16));
     const left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.left + rect.width / 2 - width / 2));
     menu.style.left = `${left}px`;
     menu.style.top = `${rect.top}px`;

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin3';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin4';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,8 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin3',
-    '/panel-pin.css?v=20260830-desktop-panel-pin3',
+    '/panel-pin.js?v=20260830-desktop-panel-pin4',
+    '/panel-pin.css?v=20260830-desktop-panel-pin4',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin3">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin3';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -23,12 +23,13 @@ test('panel pin uses the exact tgl-pin released visual and motion contract', () 
     assert.match(pin, /button\.className = `tgl panel-pin-btn \$\{side\}`/);
 });
 
-test('only the pinned ON state follows the active Zephyr accent', () => {
+test('the pinned ON state is also byte-identical to the demo', () => {
     for (const fragment of [
-        'border-color: color-mix(in srgb, var(--accent) 72%, var(--border))',
-        'background: color-mix(in srgb, var(--accent) 14%, var(--surface))',
-        'background: var(--accent)',
+        'border-color: #9aa2b1',
+        'background: #262932',
+        'box-shadow: 0 0 6px rgba(223, 227, 234, .35)',
     ]) assert.ok(css.includes(fragment), fragment);
+    assert.doesNotMatch(css, /\.panel-pin-btn\.on[^}]*var\(--accent/s);
 });
 
 test('pinned panels remove floating shadow/transform and traffic chrome resets after release', () => {
@@ -88,7 +89,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin3/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin4/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -97,26 +98,26 @@ test('all desktop top-level panel surfaces are wired; demo is not referenced', (
     assert.doesNotMatch(pin, /panel-pin-demo/);
 });
 
-test('pinning uses complete geometry and surface transitions', () => {
+test('pinning uses complete geometry and surface transitions without a flash animation', () => {
     for (const fragment of [
-        'left .52s var(--ios-open)', 'top .52s var(--ios-open)',
-        'width .52s var(--ios-open)', 'height .52s var(--ios-open)',
-        'animation: panel-pin-settle .52s var(--ios-open)',
+        'left .52s var(--ios-open) !important', 'top .52s var(--ios-open) !important',
+        'width .52s var(--ios-open) !important', 'height .52s var(--ios-open) !important',
         'padding-left .5s var(--ios-open)', 'padding-right .5s var(--ios-open)', 'padding-bottom .5s var(--ios-open)',
     ]) assert.ok(css.includes(fragment), fragment);
+    assert.doesNotMatch(css, /panel-pin-settle/);
 });
 
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin3/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin4/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
 });
 
 test('service worker rotates and precaches both panel-pin assets', () => {
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin3/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin3/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin3/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin4/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin4/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin4/);
 });


### PR DESCRIPTION
## 修复点
- 未选中/选中钉按钮都恢复为  的原版视觉：灰圈/银芯/原 spring，不再把未选中渲染成黑点，也不再给选中态替换主题 accent。
- 修正  等嵌入场景的 topbar scope：只识别本页 topbar，不再把外层  误算进去导致 bottom dock 上方出现白区。
- 钉住/切换/解除的形态变换现在显式覆盖 resting ，left/top/width/height 会按  动画过渡。
- 删除  闪光动画；钉住状态不再出现一闪的亮斑。
- 钉住 ⋯ 菜单宽度/高度继续与普通  284×50 island 对齐。
- cache revision 升到 。

## 验证
- TAP version 13
# Subtest: panel pin uses the exact tgl-pin released visual and motion contract
ok 1 - panel pin uses the exact tgl-pin released visual and motion contract
  ---
  duration_ms: 3.025364
  type: 'test'
  ...
# Subtest: the pinned ON state is also byte-identical to the demo
ok 2 - the pinned ON state is also byte-identical to the demo
  ---
  duration_ms: 0.853125
  type: 'test'
  ...
# Subtest: pinned panels remove floating shadow/transform and traffic chrome resets after release
ok 3 - pinned panels remove floating shadow/transform and traffic chrome resets after release
  ---
  duration_ms: 0.351823
  type: 'test'
  ...
# Subtest: panel pins are desktop-only and mobile cannot receive controls
ok 4 - panel pins are desktop-only and mobile cannot receive controls
  ---
  duration_ms: 0.292708
  type: 'test'
  ...
# Subtest: side rails stay above bottom dock while bottom dock owns the full lower row
ok 5 - side rails stay above bottom dock while bottom dock owns the full lower row
  ---
  duration_ms: 0.5425
  type: 'test'
  ...
# Subtest: bottom dock locks both pin buttons and supports top-handle vertical resize
ok 6 - bottom dock locks both pin buttons and supports top-handle vertical resize
  ---
  duration_ms: 0.275521
  type: 'test'
  ...
# Subtest: pinned traffic menu reuses the exact unpinned island host and icon contract
ok 7 - pinned traffic menu reuses the exact unpinned island host and icon contract
  ---
  duration_ms: 0.736666
  type: 'test'
  ...
# Subtest: unpinned traffic click preserves original panel menu behavior
ok 8 - unpinned traffic click preserves original panel menu behavior
  ---
  duration_ms: 0.24375
  type: 'test'
  ...
# Subtest: nested cloned panels are explicitly reset to ordinary floating windows
ok 9 - nested cloned panels are explicitly reset to ordinary floating windows
  ---
  duration_ms: 1.867761
  type: 'test'
  ...
# Subtest: all desktop top-level panel surfaces are wired; demo is not referenced
ok 10 - all desktop top-level panel surfaces are wired; demo is not referenced
  ---
  duration_ms: 3.249791
  type: 'test'
  ...
# Subtest: pinning uses complete geometry and surface transitions without a flash animation
ok 11 - pinning uses complete geometry and surface transitions without a flash animation
  ---
  duration_ms: 0.480105
  type: 'test'
  ...
# Subtest: all shipped pages load pin styling without demo artifact
ok 12 - all shipped pages load pin styling without demo artifact
  ---
  duration_ms: 5.509896
  type: 'test'
  ...
# Subtest: service worker rotates and precaches both panel-pin assets
ok 13 - service worker rotates and precaches both panel-pin assets
  ---
  duration_ms: 0.164584
  type: 'test'
  ...
1..13
# tests 13
# suites 0
# pass 13
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 302.022552 13/13
- TAP version 13
# Subtest: Motion.drag supports handle threshold dynamic bounds and filter veto
ok 1 - Motion.drag supports handle threshold dynamic bounds and filter veto
  ---
  duration_ms: 2.495313
  type: 'test'
  ...
# Subtest: AI panel uses Motion.drag only on top gray handle
ok 2 - AI panel uses Motion.drag only on top gray handle
  ---
  duration_ms: 5.094688
  type: 'test'
  ...
# Subtest: traffic-light hard drag is precise; gray strip uses physics
ok 3 - traffic-light hard drag is precise; gray strip uses physics
  ---
  duration_ms: 2.180678
  type: 'test'
  ...
# Subtest: title bar and content are not bound as drag fallbacks
ok 4 - title bar and content are not bound as drag fallbacks
  ---
  duration_ms: 0.632448
  type: 'test'
  ...
# Subtest: AI layout buttons use Motion.morph FLIP geometry
ok 5 - AI layout buttons use Motion.morph FLIP geometry
  ---
  duration_ms: 3.334271
  type: 'test'
  ...
# Subtest: AI layout animation supports interruption and retargeting
ok 6 - AI layout animation supports interruption and retargeting
  ---
  duration_ms: 1.197083
  type: 'test'
  ...
# Subtest: layout menu closes independently before panel geometry morph
ok 7 - layout menu closes independently before panel geometry morph
  ---
  duration_ms: 0.67776
  type: 'test'
  ...
# Subtest: legacy CSS geometry transition is disabled for AI panel only
ok 8 - legacy CSS geometry transition is disabled for AI panel only
  ---
  duration_ms: 1.16375
  type: 'test'
  ...
# Subtest: motion engine exposes shape morph primitive
ok 9 - motion engine exposes shape morph primitive
  ---
  duration_ms: 0.350572
  type: 'test'
  ...
# Subtest: panel pin uses the exact tgl-pin released visual and motion contract
ok 10 - panel pin uses the exact tgl-pin released visual and motion contract
  ---
  duration_ms: 2.910208
  type: 'test'
  ...
# Subtest: the pinned ON state is also byte-identical to the demo
ok 11 - the pinned ON state is also byte-identical to the demo
  ---
  duration_ms: 0.743698
  type: 'test'
  ...
# Subtest: pinned panels remove floating shadow/transform and traffic chrome resets after release
ok 12 - pinned panels remove floating shadow/transform and traffic chrome resets after release
  ---
  duration_ms: 0.496719
  type: 'test'
  ...
# Subtest: panel pins are desktop-only and mobile cannot receive controls
ok 13 - panel pins are desktop-only and mobile cannot receive controls
  ---
  duration_ms: 0.358438
  type: 'test'
  ...
# Subtest: side rails stay above bottom dock while bottom dock owns the full lower row
ok 14 - side rails stay above bottom dock while bottom dock owns the full lower row
  ---
  duration_ms: 0.867657
  type: 'test'
  ...
# Subtest: bottom dock locks both pin buttons and supports top-handle vertical resize
ok 15 - bottom dock locks both pin buttons and supports top-handle vertical resize
  ---
  duration_ms: 0.939792
  type: 'test'
  ...
# Subtest: pinned traffic menu reuses the exact unpinned island host and icon contract
ok 16 - pinned traffic menu reuses the exact unpinned island host and icon contract
  ---
  duration_ms: 0.697604
  type: 'test'
  ...
# Subtest: unpinned traffic click preserves original panel menu behavior
ok 17 - unpinned traffic click preserves original panel menu behavior
  ---
  duration_ms: 0.229375
  type: 'test'
  ...
# Subtest: nested cloned panels are explicitly reset to ordinary floating windows
ok 18 - nested cloned panels are explicitly reset to ordinary floating windows
  ---
  duration_ms: 1.79974
  type: 'test'
  ...
# Subtest: all desktop top-level panel surfaces are wired; demo is not referenced
ok 19 - all desktop top-level panel surfaces are wired; demo is not referenced
  ---
  duration_ms: 3.293125
  type: 'test'
  ...
# Subtest: pinning uses complete geometry and surface transitions without a flash animation
ok 20 - pinning uses complete geometry and surface transitions without a flash animation
  ---
  duration_ms: 0.471823
  type: 'test'
  ...
# Subtest: all shipped pages load pin styling without demo artifact
ok 21 - all shipped pages load pin styling without demo artifact
  ---
  duration_ms: 6.423437
  type: 'test'
  ...
# Subtest: service worker rotates and precaches both panel-pin assets
ok 22 - service worker rotates and precaches both panel-pin assets
  ---
  duration_ms: 0.191458
  type: 'test'
  ...
# Subtest: shared floating-panel exposes AI-parity physics + hard drag
ok 23 - shared floating-panel exposes AI-parity physics + hard drag
  ---
  duration_ms: 2.48224
  type: 'test'
  ...
# Subtest: bring-to-front never runs CSS transform animation (AI parity)
ok 24 - bring-to-front never runs CSS transform animation (AI parity)
  ---
  duration_ms: 3.10151
  type: 'test'
  ...
# Subtest: CSS frees transform for Motion.drag while open/dragging
ok 25 - CSS frees transform for Motion.drag while open/dragging
  ---
  duration_ms: 1.633073
  type: 'test'
  ...
# Subtest: SSH terminal wires physics drag, not titlebar hard drag
ok 26 - SSH terminal wires physics drag, not titlebar hard drag
  ---
  duration_ms: 0.805885
  type: 'test'
  ...
# Subtest: Telnet terminal mirrors SSH physics wiring
ok 27 - Telnet terminal mirrors SSH physics wiring
  ---
  duration_ms: 0.609584
  type: 'test'
  ...
# Subtest: RDP imports physics-capable floating-panel revision
ok 28 - RDP imports physics-capable floating-panel revision
  ---
  duration_ms: 0.148177
  type: 'test'
  ...
# Subtest: noVNC uses shared physics drag helpers
ok 29 - noVNC uses shared physics drag helpers
  ---
  duration_ms: 0.155365
  type: 'test'
  ...
# Subtest: image/media preview use shared physics, not header hard drag
ok 30 - image/media preview use shared physics, not header hard drag
  ---
  duration_ms: 0.164062
  type: 'test'
  ...
# Subtest: cache revision pins style + terminal + floating-panel physics4 + desktop pin assets
ok 31 - cache revision pins style + terminal + floating-panel physics4 + desktop pin assets
  ---
  duration_ms: 1.897083
  type: 'test'
  ...
1..31
# tests 31
# suites 0
# pass 31
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 340.616875 31/31
- 
- 