### PR TITLE
fix(web): align pin buttons, island morph, and dock seams

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.css
+++ b/public/panel-pin.css
@@ -1,7 +1,7 @@
 /* Desktop secondary-panel side pinning.
- * `.tgl.panel-pin-btn` intentionally starts from the exact 18px component in
- * tgl-pin.html. RELEASED state is byte-identical to the demo; only ON state
- * follows Zephyr's active accent so it remains legible in both themes. */
+ * Released state keeps the exact tgl-pin.html 18px geometry and spring, but its
+ * neutral gray ring/body tracks the active theme so it never becomes a black
+ * blob in light mode. LOCKED state intentionally uses Zephyr accent. */
 .tgl.panel-pin-btn {
     --s: 18px;
     position: absolute;
@@ -11,8 +11,8 @@
     height: var(--s);
     padding: 0;
     border-radius: 50%;
-    border: 1.5px solid #4a4f5a;
-    background: #1e2025;
+    border: 1.5px solid color-mix(in srgb, var(--text-secondary) 72%, transparent);
+    background: color-mix(in srgb, var(--surface) 92%, var(--bg));
     cursor: pointer;
     outline: none;
     display: inline-flex;
@@ -32,21 +32,20 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #dfe3ea;
+    background: color-mix(in srgb, var(--text-secondary) 84%, transparent);
     transform: scale(0);
     transition: transform .28s cubic-bezier(.34, 1.56, .64, 1), box-shadow .2s ease;
 }
-.panel-pin-btn:hover { border-color: #5d6372; }
+.panel-pin-btn:hover { border-color: color-mix(in srgb, var(--text-secondary) 88%, transparent); }
 .panel-pin-btn:active { transform: scale(.85); }
-/* LOCKED state must stay byte-identical to the demo: bright ring + silver core.
-   No product accent substitution here; the animation carries the state. */
 .panel-pin-btn.on {
-    border-color: #9aa2b1;
-    background: #262932;
+    border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+    background: color-mix(in srgb, var(--accent) 14%, var(--surface));
 }
 .panel-pin-btn.on::after {
+    background: var(--accent);
     transform: scale(1);
-    box-shadow: 0 0 6px rgba(223, 227, 234, .35);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 /* Every top-level secondary panel may be pinned. */

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -17,8 +17,11 @@ function pageFor(panel, page) {
 
 function scopeFor(page) {
     const rect = page.getBoundingClientRect();
-    const width = page.clientWidth || rect.width || window.innerWidth;
-    const height = page.clientHeight || rect.height || window.innerHeight;
+    const style = getComputedStyle(page);
+    const borderX = (Number.parseFloat(style.borderLeftWidth) || 0) + (Number.parseFloat(style.borderRightWidth) || 0);
+    const borderY = (Number.parseFloat(style.borderTopWidth) || 0) + (Number.parseFloat(style.borderBottomWidth) || 0);
+    const width = (page.clientWidth || rect.width || window.innerWidth) + borderX;
+    const height = (page.clientHeight || rect.height || window.innerHeight) + borderY;
     // `.main-nav` is a direct child of .app-shell, but a `.terminal-page` can be
     // embedded inside another shell. Use local chrome only and never climb out
     // into an ancestor nav; that only creates a bogus white band above docks.
@@ -65,10 +68,18 @@ function halfInset(page) {
     }, 0);
 }
 
-function applyInsets(page) {
+function pageSafeInset(page, side) {
+    const value = Number.parseFloat(getComputedStyle(page)[`padding${side}`] || '0') || 0;
+    return Math.max(0, Math.round(value));
+}
+
+function applyInsets(page, { bottomOverride = null } = {}) {
     const left = sideInset(page, 'left');
     const right = sideInset(page, 'right');
-    const bottom = halfInset(page);
+    // A bottom dock covers the page's own bottom safe padding, so content must
+    // reserve dock height + that padding back to keep the terminal above it.
+    const dock = bottomOverride ?? halfInset(page);
+    const bottom = dock > 0 ? dock + pageSafeInset(page, 'Bottom') : 0;
     page.style.setProperty('--pin-inset-left', `${left}px`);
     page.style.setProperty('--pin-inset-right', `${right}px`);
     page.style.setProperty('--pin-inset-bottom', `${bottom}px`);
@@ -100,6 +111,16 @@ function clampHalfHeight(height, scope) {
     return Math.max(160, Math.min(scope.height - scope.topbarHeight - 80, Math.round(height)));
 }
 
+function edgeInset(page) {
+    const style = getComputedStyle(page);
+    return {
+        left: Number.parseFloat(style.borderLeftWidth) || 0,
+        right: Number.parseFloat(style.borderRightWidth) || 0,
+        top: Number.parseFloat(style.borderTopWidth) || 0,
+        bottom: Number.parseFloat(style.borderBottomWidth) || 0,
+    };
+}
+
 function place(panel, mode = panel.dataset.pinMode || 'side') {
     const page = panel._pinPage;
     const scope = scopeFor(page);
@@ -122,11 +143,15 @@ function place(panel, mode = panel.dataset.pinMode || 'side') {
     }
     if (mode === 'half') {
         // Bottom dock is genuinely a bottom band: the bottom row owns the full
-        // width, while side rails remain only in the row above it.
+        // width, while side rails remain only in the row above it. Extend one
+        // border-width past the page edge so the page's own 1px frame can never
+        // leave a white seam at the right/bottom edge.
+        const edge = edgeInset(page);
         const height = clampHalfHeight(Number.parseFloat(panel.style.height) || Math.round(fullHeight / 2), scope);
         panel._pinHalfHeight = height;
         Object.assign(panel.style, fixed, {
-            left: `${scope.left}px`, top: `${scope.top + fullHeight - height}px`, width: `${scope.width}px`, height: `${height}px`,
+            left: `${scope.left - edge.left}px`, top: `${scope.top + fullHeight - height}px`,
+            width: `${scope.width + edge.left + edge.right}px`, height: `${height + edge.bottom}px`,
         });
         return;
     }
@@ -275,10 +300,13 @@ function openPinMenu(anchor, panel, onClose) {
     // Match the ordinary floating-panel island exactly: 284px cap / 50px tall.
     const width = Math.min(284, Math.max(160, window.innerWidth - 16));
     const left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.left + rect.width / 2 - width / 2));
-    menu.style.left = `${left}px`;
+    // Start collapsed exactly on the ⋯ pill, then let the inherited
+    // `.panel-layout-menu.island-open` transition expand it to the normal
+    // 284×50 island. Starting pre-expanded was the visual mismatch.
+    menu.style.left = `${rect.left}px`;
     menu.style.top = `${rect.top}px`;
-    menu.style.setProperty('--panel-island-menu-width', `${width}px`);
-    menu.style.setProperty('--panel-island-menu-height', '50px');
+    menu.style.setProperty('--panel-island-menu-width', `${rect.width}px`);
+    menu.style.setProperty('--panel-island-menu-height', `${rect.height}px`);
     menu.style.setProperty('--panel-island-radius', `${Math.round(rect.height / 2)}px`);
     menu.style.opacity = '1';
     menu.classList.add('island-animating');
@@ -287,6 +315,10 @@ function openPinMenu(anchor, panel, onClose) {
         menu.style.removeProperty('transition');
         anchor.classList.add('active-layout');
         menu.classList.add('island-open');
+        menu.style.left = `${left}px`;
+        menu.style.top = `${rect.top}px`;
+        menu.style.setProperty('--panel-island-menu-width', `${width}px`);
+        menu.style.setProperty('--panel-island-menu-height', '50px');
         menu.style.setProperty('--panel-island-radius', '18px');
         window.setTimeout(() => menu.classList.remove('island-animating'), 540);
     });
@@ -374,10 +406,14 @@ function bindPinnedVerticalDrag(panel, handle) {
         panel.classList.add('resizing');
         const move = (ev) => {
             ev.preventDefault();
+            const edge = edgeInset(page);
             const next = clampHalfHeight(startHeight + (startY - ev.clientY), scope);
             panel._pinHalfHeight = next;
-            panel.style.height = `${next}px`;
+            panel.style.height = `${next + edge.bottom}px`;
             panel.style.top = `${scope.top + scope.height - next}px`;
+            // Content must move with the drag, not wait for pointerup; otherwise
+            // a live white band opens above the dock exactly like the screenshot.
+            applyInsets(page, { bottomOverride: next });
         };
         const up = () => {
             panel.classList.remove('resizing');

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin4';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin5';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,8 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin4',
-    '/panel-pin.css?v=20260830-desktop-panel-pin4',
+    '/panel-pin.js?v=20260830-desktop-panel-pin5',
+    '/panel-pin.css?v=20260830-desktop-panel-pin5',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin4">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin4';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -14,22 +14,27 @@ const vnc = read('public/novnc.js');
 const app = read('public/app.js');
 const sw = read('public/sw.js');
 
-test('panel pin uses the exact tgl-pin released visual and motion contract', () => {
+test('released pin keeps demo geometry but uses a themed gray ring, never a black blob', () => {
     for (const fragment of [
-        '.tgl.panel-pin-btn', '--s: 18px', 'border: 1.5px solid #4a4f5a',
-        'background: #1e2025', 'background: #dfe3ea', 'border-color: #5d6372',
+        '.tgl.panel-pin-btn', '--s: 18px', 'width: 8px;', 'height: 8px;',
+        'border: 1.5px solid color-mix(in srgb, var(--text-secondary) 72%, transparent)',
+        'background: color-mix(in srgb, var(--surface) 92%, var(--bg))',
+        'background: color-mix(in srgb, var(--text-secondary) 84%, transparent)',
         'cubic-bezier(.34, 1.56, .64, 1)', 'transform: scale(.85)',
     ]) assert.ok(css.includes(fragment), fragment);
+    assert.doesNotMatch(css, /border: 1\.5px solid #4a4f5a/);
+    assert.doesNotMatch(css, /background: #1e2025/);
+    assert.doesNotMatch(css, /background: #dfe3ea/);
     assert.match(pin, /button\.className = `tgl panel-pin-btn \$\{side\}`/);
 });
 
-test('the pinned ON state is also byte-identical to the demo', () => {
+test('locked pin follows the previous accent-filled state the user approved', () => {
     for (const fragment of [
-        'border-color: #9aa2b1',
-        'background: #262932',
-        'box-shadow: 0 0 6px rgba(223, 227, 234, .35)',
+        'border-color: color-mix(in srgb, var(--accent) 72%, var(--border))',
+        'background: color-mix(in srgb, var(--accent) 14%, var(--surface))',
+        'background: var(--accent)',
+        'box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent)',
     ]) assert.ok(css.includes(fragment), fragment);
-    assert.doesNotMatch(css, /\.panel-pin-btn\.on[^}]*var\(--accent/s);
 });
 
 test('pinned panels remove floating shadow/transform and traffic chrome resets after release', () => {
@@ -45,10 +50,11 @@ test('panel pins are desktop-only and mobile cannot receive controls', () => {
     assert.match(css, /@media \(hover: none\), \(pointer: coarse\) \{ \.panel-pin-btn \{ display: none !important; \} \}/);
 });
 
-test('side rails stay above bottom dock while bottom dock owns the full lower row', () => {
+test('side rails stay above bottom dock while bottom dock owns and covers the full lower row', () => {
     assert.match(pin, /function halfInset\(page\)/);
     assert.match(pin, /const height = fullHeight - halfInset\(page\)/);
-    assert.match(pin, /left: `\$\{scope\.left\}px`, top: `\$\{scope\.top \+ fullHeight - height\}px`, width: `\$\{scope\.width\}px`, height: `\$\{height\}px`/);
+    assert.match(pin, /left: `\$\{scope\.left - edge\.left\}px`, top: `\$\{scope\.top \+ fullHeight - height\}px`,\n            width: `\$\{scope\.width \+ edge\.left \+ edge\.right\}px`, height: `\$\{height \+ edge\.bottom\}px`/);
+    assert.match(pin, /applyInsets\(page, \{ bottomOverride: next \}\)/);
     assert.match(css, /pin-has-bottom/);
     assert.match(css, /var\(--pin-inset-bottom, 0px\)/);
 });
@@ -68,6 +74,10 @@ test('pinned traffic menu reuses the exact unpinned island host and icon contrac
     }
     assert.match(pin, /menu\.classList\.add\('island-open'\)/);
     assert.match(pin, /menu\.classList\.add\('island-closing', 'island-animating'\)/);
+    assert.match(pin, /menu\.style\.setProperty\('--panel-island-menu-width', `\$\{rect\.width\}px`\)/);
+    assert.match(pin, /menu\.style\.setProperty\('--panel-island-menu-height', `\$\{rect\.height\}px`\)/);
+    assert.match(pin, /menu\.style\.setProperty\('--panel-island-menu-width', `\$\{width\}px`\)/);
+    assert.match(pin, /menu\.style\.setProperty\('--panel-island-menu-height', '50px'\)/);
     assert.match(css, /\.panel-pin-menu \{ grid-template-columns: repeat\(6, minmax\(0, 1fr\)\); \}/);
     assert.doesNotMatch(css, /\.panel-pin-menu button \{[^}]*flex-direction: column/s);
 });
@@ -89,7 +99,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin4/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin5/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -110,14 +120,14 @@ test('pinning uses complete geometry and surface transitions without a flash ani
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin4/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin5/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
 });
 
 test('service worker rotates and precaches both panel-pin assets', () => {
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin4/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin4/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin4/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin5/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin5/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin5/);
 });


### PR DESCRIPTION
## 修复点
- 未钉住按钮不再使用黑色底：保持 demo 的 18px 几何和 spring，但改为跟随主题的灰圈/灰芯，浅色主题不再黑成一点。
- 钉住态恢复为用户认可的主题 accent 锁定态。
- 钉住 ⋯ 菜单从 ⋯ 自身尺寸开始膨胀，再过渡到普通浮窗相同的 284×50 island，避免“已经展开/未对齐”。
- bottom dock 向外覆盖页面自身 1px border，右/下边缘不再露白缝。
- 下 1/2 顶部拖动时 bottom inset 实时跟随，不再在拖动过程中出现上方空白带。
- cache revision 升到 `20260830-desktop-panel-pin5`。

## 验证
- `node --test tests/desktop-panel-pin-contract.test.mjs` 13/13
- `node --test tests/*panel*contract.test.mjs` 31/31
- `node --check` 所有改动 JS
- `git diff --check`
