### PR TITLE
fix(web): repair pin menu ownership and pin geometry motion

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.css
+++ b/public/panel-pin.css
@@ -66,9 +66,9 @@
     max-height: none !important;
     min-width: 0 !important;
     /* A docked window is attached to the page; floating transform/drop shadow
-       read as visual glue. Keep only the ordinary panel border while pinned. */
+       read as visual glue. Keep only the ordinary panel border while pinned.
+       Do NOT force transform here: pin/unpin uses an inline FLIP transform. */
     box-shadow: none !important;
-    transform: none !important;
     filter: none !important;
 }
 .pinned[data-pin-side="left"] { border-left-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -5,6 +5,7 @@
  */
 const pinned = new Set();
 let zSeed = 10100;
+let activePinMenu = null;
 
 export function isDesktopPanelPinEnvironment() {
     return window.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches === true
@@ -121,27 +122,29 @@ function edgeInset(page) {
     };
 }
 
-function place(panel, mode = panel.dataset.pinMode || 'side') {
+function place(panel, mode = panel.dataset.pinMode || 'side', { animate = false } = {}) {
     const page = panel._pinPage;
     const scope = scopeFor(page);
     const side = panel.dataset.pinSide || 'left';
     const fullHeight = scope.height;
     rememberNormalGeometry(panel);
+    // Read the painted frame *before* changing layout. Rapid pin/unpin/mode
+    // changes therefore retarget from the current visual state, not from the
+    // last committed rectangle.
+    const fromRect = animate ? panel.getBoundingClientRect() : null;
     startGeometryMotion(panel);
 
     // The page can be a terminal page, an RDP/VNC page, or the web app shell.
     // Fixed coordinates make the same geometry reliable even when the panel's
     // normal containing block is a nested display stage.
-    const fixed = { position: 'fixed', right: 'auto', bottom: 'auto', transform: 'none' };
+    const fixed = { position: 'fixed', right: 'auto', bottom: 'auto' };
     if (mode === 'full') {
         // ⋯ → full: retain the header (the user's red-line requirement).
         Object.assign(panel.style, fixed, {
             left: `${scope.left}px`, top: `${scope.top + scope.topbarHeight}px`, width: `${scope.width}px`,
             height: `${Math.max(1, fullHeight - scope.topbarHeight)}px`,
         });
-        return;
-    }
-    if (mode === 'half') {
+    } else if (mode === 'half') {
         // Bottom dock is genuinely a bottom band: the bottom row owns the full
         // width, while side rails remain only in the row above it. Extend one
         // border-width past the page edge so the page's own 1px frame can never
@@ -153,17 +156,36 @@ function place(panel, mode = panel.dataset.pinMode || 'side') {
             left: `${scope.left - edge.left}px`, top: `${scope.top + fullHeight - height}px`,
             width: `${scope.width + edge.left + edge.right}px`, height: `${height + edge.bottom}px`,
         });
-        return;
+    } else {
+        const explicit = Number.parseFloat(panel.style.width);
+        const width = Math.min(Number.isFinite(explicit) ? explicit : quarterWidth(scope), scope.width);
+        // Side rails stop above any bottom-docked panel; the bottom band is the
+        // only owner of the lower row, so the two modes never overlap.
+        const height = fullHeight - halfInset(page);
+        Object.assign(panel.style, fixed, {
+            left: `${scope.left + (side === 'left' ? 0 : scope.width - width)}px`, top: `${scope.top}px`,
+            width: `${width}px`, height: `${Math.max(1, height)}px`,
+        });
     }
 
-    const explicit = Number.parseFloat(panel.style.width);
-    const width = Math.min(Number.isFinite(explicit) ? explicit : quarterWidth(scope), scope.width);
-    // Side rails stop above any bottom-docked panel; the bottom band is the
-    // only owner of the lower row, so the two modes never overlap.
-    const height = fullHeight - halfInset(page);
-    Object.assign(panel.style, fixed, {
-        left: `${scope.left + (side === 'left' ? 0 : scope.width - width)}px`, top: `${scope.top}px`,
-        width: `${width}px`, height: `${Math.max(1, height)}px`,
+    if (!animate || !fromRect || fromRect.width < 2 || fromRect.height < 2) return;
+    const toRect = panel.getBoundingClientRect();
+    const sx = Math.max(.001, fromRect.width / Math.max(1, toRect.width));
+    const sy = Math.max(.001, fromRect.height / Math.max(1, toRect.height));
+    window.clearTimeout(panel._pinFlipTimer);
+    panel.style.transition = 'none';
+    panel.style.transformOrigin = '0 0';
+    panel.style.transform = `translate3d(${fromRect.left - toRect.left}px, ${fromRect.top - toRect.top}px, 0) scale(${sx}, ${sy})`;
+    panel.style.pointerEvents = 'none';
+    void panel.offsetWidth;
+    requestAnimationFrame(() => {
+        panel.style.transition = `transform .52s var(--ios-open)`;
+        panel.style.transform = 'translate3d(0px, 0px, 0) scale(1, 1)';
+        panel._pinFlipTimer = window.setTimeout(() => {
+            panel.style.transform = '';
+            panel.style.transition = '';
+            panel.style.pointerEvents = '';
+        }, 560);
     });
 }
 
@@ -186,7 +208,7 @@ function syncChrome(panel) {
     if (!side) {
         // Demo parity: once released, ⋯ must be an ordinary window-layout button
         // again. Do not leave the pinned island's faded/hidden chrome behind.
-        panel.querySelectorAll('.panel-traffic-btn, [data-layout-panel], [data-ai-agent-layout]').forEach((button) => {
+        panel.querySelectorAll('.panel-traffic-btn:not(.panel-pin-btn), [data-layout-panel], [data-ai-agent-layout]').forEach((button) => {
             button.classList.remove('active-layout');
             button.style.removeProperty('opacity');
         });
@@ -201,7 +223,7 @@ function pin(panel, side) {
     panel.dataset.pinMode = 'side';
     panel.style.width = `${width}px`;
     pinned.add(panel);
-    place(panel, 'side');
+    place(panel, 'side', { animate: true });
     syncChrome(panel);
     bringToFront(panel);
     applyInsets(page);
@@ -214,6 +236,7 @@ function unpin(panel) {
     const width = panel.offsetWidth || 420;
     const height = Math.min(panel.offsetHeight || 460, Math.max(240, scope.height - scope.topbarHeight - 16));
     const restore = panel._pinRestore;
+    const fromRect = panel.getBoundingClientRect();
     delete panel.dataset.pinSide;
     delete panel.dataset.pinMode;
     delete panel._pinHalfHeight;
@@ -229,6 +252,26 @@ function unpin(panel) {
             width: `${width}px`, height: `${height}px`, right: 'auto', bottom: 'auto', transform: 'none',
         });
     }
+    if (fromRect.width >= 2 && fromRect.height >= 2) {
+        const toRect = panel.getBoundingClientRect();
+        const sx = Math.max(.001, fromRect.width / Math.max(1, toRect.width));
+        const sy = Math.max(.001, fromRect.height / Math.max(1, toRect.height));
+        window.clearTimeout(panel._pinFlipTimer);
+        panel.style.transition = 'none';
+        panel.style.transformOrigin = '0 0';
+        panel.style.transform = `translate3d(${fromRect.left - toRect.left}px, ${fromRect.top - toRect.top}px, 0) scale(${sx}, ${sy})`;
+        panel.style.pointerEvents = 'none';
+        void panel.offsetWidth;
+        requestAnimationFrame(() => {
+            panel.style.transition = `transform .52s var(--ios-open)`;
+            panel.style.transform = 'translate3d(0px, 0px, 0) scale(1, 1)';
+            panel._pinFlipTimer = window.setTimeout(() => {
+                panel.style.transform = '';
+                panel.style.transition = '';
+                panel.style.pointerEvents = '';
+            }, 560);
+        });
+    }
     syncChrome(panel);
     panelGroup(page).forEach((other) => other !== panel && place(other));
     applyInsets(page);
@@ -237,14 +280,16 @@ function unpin(panel) {
 
 function closePinMenu(anchor = null, panel = null, { instant = false } = {}) {
     const menu = panel?._pinMenu || document.querySelector('.panel-pin-menu');
-    const traffic = anchor || panel?.querySelector?.('.panel-traffic-btn, [data-layout-panel], [data-ai-agent-layout]');
+    const ownerPanel = panel || menu?._pinPanel || null;
+    const traffic = anchor || menu?._pinAnchor || ownerPanel?.querySelector?.('.panel-traffic-btn:not(.panel-pin-btn), [data-layout-panel], [data-ai-agent-layout]');
     if (!menu) return;
     window.clearTimeout(menu._closeTimer);
     if (instant || !traffic?.isConnected) {
         traffic?.classList.remove('active-layout');
         traffic?.style.removeProperty('opacity');
         menu.remove();
-        if (panel?._pinMenu === menu) delete panel._pinMenu;
+        if (ownerPanel?._pinMenu === menu) delete ownerPanel._pinMenu;
+        if (activePinMenu === menu) activePinMenu = null;
         return;
     }
     const rect = traffic.getBoundingClientRect();
@@ -270,12 +315,16 @@ function closePinMenu(anchor = null, panel = null, { instant = false } = {}) {
         traffic.style.opacity = '1';
         requestAnimationFrame(() => traffic.style.removeProperty('opacity'));
         menu.remove();
-        if (panel?._pinMenu === menu) delete panel._pinMenu;
+        if (ownerPanel?._pinMenu === menu) delete ownerPanel._pinMenu;
+        if (activePinMenu === menu) activePinMenu = null;
     }, 460);
 }
 
 function openPinMenu(anchor, panel, onClose) {
-    closePinMenu();
+    // There can be multiple pinned panels. QuerySelector alone can close the
+    // wrong stale menu and leave its ⋯ opacity at 0, which is the reported
+    // probabilistic disappearing-three-dots bug.
+    if (activePinMenu) closePinMenu(activePinMenu._pinAnchor, activePinMenu._pinPanel, { instant: true });
     const page = panel._pinPage;
     const side = panel.dataset.pinSide || 'left';
     const menu = document.createElement('div');
@@ -294,7 +343,10 @@ function openPinMenu(anchor, panel, onClose) {
     menu.style.transition = 'none';
     menu.style.zIndex = String(Math.max(10000, (Number(panel.style.zIndex) || zSeed) + 20));
     document.body.appendChild(menu);
+    menu._pinAnchor = anchor;
+    menu._pinPanel = panel;
     panel._pinMenu = menu;
+    activePinMenu = menu;
     anchor._pinMenuOpen = true;
     const rect = anchor.getBoundingClientRect();
     // Match the ordinary floating-panel island exactly: 284px cap / 50px tall.
@@ -342,7 +394,7 @@ function openPinMenu(anchor, panel, onClose) {
             panel.dataset.pinSide = action === 'switch-left' ? 'left' : 'right';
             panel.dataset.pinMode = 'side';
             panel.style.width = `${quarterWidth(scopeFor(page))}px`;
-            place(panel, 'side');
+            place(panel, 'side', { animate: true });
             syncChrome(panel);
             bringToFront(panel);
             panelGroup(page).forEach((other) => other !== panel && place(other));
@@ -351,7 +403,7 @@ function openPinMenu(anchor, panel, onClose) {
         }
         panel.dataset.pinMode = action;
         if (action === 'half') panel.style.height = `${panel._pinHalfHeight || Math.round(scopeFor(page).height / 2)}px`;
-        place(panel, action);
+        place(panel, action, { animate: true });
         syncChrome(panel);
         bringToFront(panel);
         panelGroup(page).forEach((other) => other !== panel && place(other));
@@ -479,7 +531,7 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
         else pin(panel, button.dataset.pinSide);
     });
 
-    const traffic = layoutButton || panel.querySelector('.panel-traffic-btn, [data-layout-panel]');
+    const traffic = layoutButton || panel.querySelector('.panel-traffic-btn:not(.panel-pin-btn), [data-layout-panel]');
     if (traffic) {
         // Capture phase preserves ordinary original three-dot behavior exactly
         // while unpinned; only pinned state swaps its layout meanings.

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin5';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin6';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,8 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin5',
-    '/panel-pin.css?v=20260830-desktop-panel-pin5',
+    '/panel-pin.js?v=20260830-desktop-panel-pin6',
+    '/panel-pin.css?v=20260830-desktop-panel-pin6',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin5">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin5';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -37,8 +37,10 @@ test('locked pin follows the previous accent-filled state the user approved', ()
     ]) assert.ok(css.includes(fragment), fragment);
 });
 
-test('pinned panels remove floating shadow/transform and traffic chrome resets after release', () => {
-    for (const fragment of ['box-shadow: none !important;', 'transform: none !important;', 'filter: none !important;']) assert.ok(css.includes(fragment), fragment);
+test('pinned panels remove floating shadow/filter and traffic chrome resets after release', () => {
+    for (const fragment of ['box-shadow: none !important;', 'filter: none !important;']) assert.ok(css.includes(fragment), fragment);
+    assert.doesNotMatch(css, /transform: none !important;/);
+    assert.match(css, /Do NOT force transform here: pin\/unpin uses an inline FLIP transform/);
     assert.match(pin, /button\.classList\.remove\('active-layout'\)/);
     assert.match(pin, /button\.style\.removeProperty\('opacity'\)/);
     assert.match(pin, /syncChrome\(panel\);\n            panelGroup\(owner\)\.forEach/);
@@ -82,6 +84,23 @@ test('pinned traffic menu reuses the exact unpinned island host and icon contrac
     assert.doesNotMatch(css, /\.panel-pin-menu button \{[^}]*flex-direction: column/s);
 });
 
+test('pin and unpin use FLIP geometry instead of jumping', () => {
+    assert.match(pin, /function place\(panel, mode = panel\.dataset\.pinMode \|\| 'side', \{ animate = false \} = \{\}\)/);
+    assert.match(pin, /place\(panel, 'side', \{ animate: true \}\)/);
+    assert.match(pin, /place\(panel, action, \{ animate: true \}\)/);
+    assert.match(pin, /translate3d\(\$\{fromRect\.left - toRect\.left\}px, \$\{fromRect\.top - toRect\.top\}px, 0\) scale\(\$\{sx\}, \$\{sy\}\)/);
+    assert.match(pin, /panel\.style\.transition = `transform \.52s var\(--ios-open\)`/);
+});
+
+test('opening another pinned menu closes the exact previous owner before it can hide the button', () => {
+    assert.match(pin, /let activePinMenu = null;/);
+    assert.match(pin, /menu\._pinAnchor = anchor;/);
+    assert.match(pin, /menu\._pinPanel = panel;/);
+    assert.match(pin, /activePinMenu = menu;/);
+    assert.match(pin, /if \(activePinMenu\) closePinMenu\(activePinMenu\._pinAnchor, activePinMenu\._pinPanel, \{ instant: true \}\)/);
+    assert.match(pin, /panel-traffic-btn:not\(\.panel-pin-btn\)/);
+});
+
 test('unpinned traffic click preserves original panel menu behavior', () => {
     assert.match(pin, /if \(!panel\.dataset\.pinSide\) return;/);
     assert.match(pin, /Capture phase preserves ordinary original three-dot behavior exactly/);
@@ -99,7 +118,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin5/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin6/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -120,14 +139,14 @@ test('pinning uses complete geometry and surface transitions without a flash ani
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin5/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin6/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
 });
 
 test('service worker rotates and precaches both panel-pin assets', () => {
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin5/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin5/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin5/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin6/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin6/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin6/);
 });


### PR DESCRIPTION
## 修复点
- 概率性 ⋯ 消失：多浮窗钉住时，打开另一个钉住菜单现在会通过 `activePinMenu` 精确关闭上一个菜单并恢复上一个 ⋯，不再误操作其它浮窗的按钮 opacity。
- 钉住 ⋯ 菜单继续严格复用普通浮窗 `.panel-layout-menu` 的 Dynamic Island 动画和图标；cache revision 升到 `20260830-desktop-panel-pin6`，避免旧 JS/CSS 混加载。
- 浮窗 → 钉住、钉住 → 浮窗、侧边/全屏/下 1/2 切换改为 FLIP 几何过渡：先按当前可视矩形逆变换，再在下一帧过渡到目标形态，不再直接跳变。
- 修复 pinned CSS 强制 `transform:none !important` 把 pin/unpin 的 FLIP transform 杀掉的问题。
- 锁定按钮不受普通 ⋯ chrome reset 影响。

## 验证
- `node --test tests/desktop-panel-pin-contract.test.mjs` 15/15
- `node --test tests/*panel*contract.test.mjs` 33/33
- `node --check public/panel-pin.js`
- `git diff --check`
