### PR TITLE
fix(one): preserve and recover local workspace generation

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
@@ -1074,7 +1074,7 @@ class BindingCoordinator internal constructor(
             // cancels the very coroutine that is committing this replacement.
             host.replaceGraph(previous, next)
         }
-        if (previous != null) previous.wipeBindingState()
+        if (previous != null && !previous.isDeviceLocal) previous.wipeBindingState()
     }
 
     private suspend fun replaceGraphWithDurableReplacementLocked(

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
@@ -329,9 +329,16 @@ class AppContainer(private val context: Context) {
     fun ensureLocalWorkspace(): AccountContainer {
         (accountGraph as? AccountContainer)?.let { return it }
 
-        val binding = localBinding()
-        val databaseScope = AccountContainer.databaseScopeOf(binding)
-        val databaseHandle = accountDatabases.open(databaseScope)
+        var binding = localBinding()
+        var databaseScope = AccountContainer.databaseScopeOf(binding)
+        val databaseHandle = try {
+            accountDatabases.open(databaseScope)
+        } catch (erased: IllegalStateException) {
+            if (erased.message != "account database generation has been erased") throw erased
+            binding = rotateLocalWorkspaceGeneration()
+            databaseScope = AccountContainer.databaseScopeOf(binding)
+            accountDatabases.open(databaseScope)
+        }
         val container = try {
             AccountContainer(
                 context = context,
@@ -368,10 +375,32 @@ class AppContainer(private val context: Context) {
         tokenName = "local",
         state = BindingState.IDLE,
         registryHash = "",
-        boundAt = 0L,
+        boundAt = localWorkspaceGeneration(),
         lastSyncAt = null,
         instanceEpoch = 0L,
     )
+
+    private fun localWorkspaceGeneration(): Long {
+        val preferences = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        return preferences.getLong(KEY_LOCAL_WORKSPACE_GENERATION, 0L).takeIf { it > 0L }
+            ?: System.currentTimeMillis().coerceAtLeast(1L).also { generation ->
+                check(
+                    preferences.edit()
+                        .putLong(KEY_LOCAL_WORKSPACE_GENERATION, generation)
+                        .commit(),
+                ) { "local workspace generation could not be persisted" }
+            }
+    }
+
+    private fun rotateLocalWorkspaceGeneration(): AccountBinding {
+        val next = System.currentTimeMillis().coerceAtLeast(localWorkspaceGeneration() + 1L)
+        val persisted = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putLong(KEY_LOCAL_WORKSPACE_GENERATION, next)
+            .commit()
+        check(persisted) { "local workspace generation could not be rotated" }
+        return localBinding()
+    }
 
     /**
      * Idempotently erases a persisted account scope without opening its SQLCipher database.
@@ -554,6 +583,7 @@ class AppContainer(private val context: Context) {
     private companion object {
         const val PREFS = "zephyr-one-device"
         const val KEY_INSTALL_ID = "install-id"
+        const val KEY_LOCAL_WORKSPACE_GENERATION = "local-workspace-generation"
         const val KEY_PAD_TERM_SIDE = "pad-term-side"
         const val NO_ACCOUNT_TEARDOWN_OWNER = "no-account-teardown"
 

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
@@ -177,7 +177,7 @@ class BindingCoordinatorTest {
         assertTrue("graph.stop" in events)
         assertTrue("host.replace" in events)
         assertFalse("host.clear" in events)
-        assertFalse("graph.wipe" in events, "binding must not erase the device-local fallback workspace")
+        assertFalse("binding must not erase the device-local fallback workspace", "graph.wipe" in events)
         assertFalse(local.wiped)
     }
 

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
@@ -177,6 +177,8 @@ class BindingCoordinatorTest {
         assertTrue("graph.stop" in events)
         assertTrue("host.replace" in events)
         assertFalse("host.clear" in events)
+        assertFalse("graph.wipe" in events, "binding must not erase the device-local fallback workspace")
+        assertFalse(local.wiped)
     }
 
     @Test

--- a/zephyr_one/mobile/tests/android-local-generation-lifecycle.test.mjs
+++ b/zephyr_one/mobile/tests/android-local-generation-lifecycle.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mobile = path.resolve(here, '..');
+const read = (rel) => fs.readFileSync(path.join(mobile, rel), 'utf8');
+
+test('binding preserves local fallback and erased legacy generation self-heals', () => {
+  const coordinator = read('android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt');
+  const container = read('android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt');
+
+  assert.match(coordinator, /previous != null && !previous\.isDeviceLocal/);
+  assert.match(container, /KEY_LOCAL_WORKSPACE_GENERATION/);
+  assert.match(container, /boundAt = localWorkspaceGeneration\(\)/);
+  assert.match(container, /account database generation has been erased/);
+  assert.match(container, /binding = rotateLocalWorkspaceGeneration\(\)/);
+  assert.match(container, /preferences\.edit\(\)[\s\S]*putLong\(KEY_LOCAL_WORKSPACE_GENERATION, generation\)[\s\S]*commit\(\)/);
+});


### PR DESCRIPTION
## Confirmed failure
- local-only workspace used one permanent binding generation
- first bind replaced that graph and then wiped its database generation
- any later fallback/recovery reopened the same tombstoned generation and threw `account database generation has been erased`
- this produced the reported recovery page/crash while the server device remained at `lastSync=never`

## Fix
- local-to-bound replacement stops the local graph but never wipes the device-local fallback
- local generation is now durable and rotatable instead of the historical fixed value
- devices already damaged by pre48 detect the erased generation and atomically rotate to a fresh local generation
- binding coordinator test locks that first bind never calls `graph.wipe` on the local fallback

## Verification
- 453/453 mobile static contracts pass
- focused lifecycle/link/sync contracts 17/17
- GitHub Android compile/unit CI is required because local JVM is blocked by PaX
