### PR TITLE
fix(web): align pinned island open with floating panel island

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -360,7 +360,6 @@ function openPinMenu(anchor, panel, onClose) {
     menu.style.setProperty('--panel-island-menu-width', `${rect.width}px`);
     menu.style.setProperty('--panel-island-menu-height', `${rect.height}px`);
     menu.style.setProperty('--panel-island-radius', `${Math.round(rect.height / 2)}px`);
-    menu.style.opacity = '1';
     menu.classList.add('island-animating');
     void menu.offsetWidth;
     requestAnimationFrame(() => {

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin6';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin7';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -16,8 +16,8 @@ const PRECACHE = [
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin6',
-    '/panel-pin.css?v=20260830-desktop-panel-pin6',
+    '/panel-pin.js?v=20260830-desktop-panel-pin7',
+    '/panel-pin.css?v=20260830-desktop-panel-pin7',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
     <script type="importmap">
         {
             "imports": {

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin6">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin6';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -118,7 +118,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin6/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin7/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -139,14 +139,14 @@ test('pinning uses complete geometry and surface transitions without a flash ani
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin6/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin7/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
 });
 
 test('service worker rotates and precaches both panel-pin assets', () => {
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin6/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin6/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin6/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin7/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin7/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin7/);
 });


### PR DESCRIPTION
## 修复点
- 钉住 ⋯ 菜单不再在打开前强制 `opacity: 1`。`.panel-layout-menu` 默认是 `opacity: 0`，普通浮窗在 `island-open` 后由类名接管；钉住菜单此前强制 1，再经历 0→1，视觉上就是闪一下。
- 继续复用普通浮窗同一 Dynamic Island CSS、图标和 stagger，不新增另一套动画。
- cache revision 升到 `20260830-desktop-panel-pin7`，避免旧资源混缓存。

## 验证
- `node --test tests/desktop-panel-pin-contract.test.mjs` 15/15
- `node --test tests/*panel*contract.test.mjs` 33/33
- `node --check public/panel-pin.js`
- `git diff --check`
