### PR TITLE
fix(one): drop card strokes, unclip island labels, defer cold-start sockets

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/AndroidManifest.xml
+++ b/zephyr_one/mobile/android/app/src/main/AndroidManifest.xml
@@ -121,6 +121,13 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- 后台保持连接 stays online while the user is away. Same dataSync type as the file
+             bridge: both disclose via an ongoing notification with a stop action. -->
+        <service
+            android:name=".app.sync.ConnectionKeepAliveService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
         <!-- WorkManager's own initialiser is removed because ZephyrApplication supplies a
              Configuration; leaving both would race two WorkManager instances on first launch. -->
         <provider

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
@@ -1,5 +1,10 @@
 package one.zephyr.mobile.app
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -8,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import one.zephyr.mobile.R
@@ -362,7 +368,9 @@ internal fun AppLockDestination(account: AccountContainer, container: one.zephyr
 @Composable
 internal fun NetworkDestination(account: AccountContainer, onBack: () -> Unit) {
     val settings by account.syncSettingsState.collectAsState()
+    val keepAlive by account.appContainer().keepAlive.collectAsState()
     val scope = rememberCoroutineScope()
+    val onKeepAlive = rememberKeepAliveToggle(account)
     NetworkSettingsScreen(
         policy = settings.networkPolicy,
         onPolicy = { policy ->
@@ -376,6 +384,9 @@ internal fun NetworkDestination(account: AccountContainer, onBack: () -> Unit) {
             }
         },
         onBack = onBack,
+        keepAlive = keepAlive,
+        onKeepAlive = onKeepAlive,
+        localMode = account.isLocalMode,
     )
 }
 
@@ -392,6 +403,8 @@ internal fun FileSyncDestination(
 ) {
     val status by account.syncEngine.status.collectAsState(initial = one.zephyr.mobile.model.SyncStatus.unbound())
     val settings by account.syncSettingsState.collectAsState()
+    val keepAlive by account.appContainer().keepAlive.collectAsState()
+    val onKeepAlive = rememberKeepAliveToggle(account)
     FileSyncScreen(
         status = status,
         settings = settings,
@@ -399,6 +412,8 @@ internal fun FileSyncDestination(
         onAutomatic = { enabled -> account.updateSyncSettings { it.copy(automaticEnabled = enabled) } },
         onInterval = { seconds -> account.updateSyncSettings { it.copy(intervalSec = seconds) } },
         onPolicy = { policy -> account.updateSyncSettings { it.copy(networkPolicy = policy) } },
+        keepAlive = keepAlive,
+        onKeepAlive = onKeepAlive,
         onSyncNow = onSyncNow,
         onOpenConflicts = onOpenConflicts,
         onOpenDevices = onOpenDevices,
@@ -668,3 +683,33 @@ internal class AiModelDiscoverer(account: AccountContainer) {
 
 internal fun diagnosticExport(account: AccountContainer): String =
     "one=${BuildConfig.VERSION_NAME} mode=${if (account.isLocalMode) "local" else "bound"} state=${account.binding.state.name} device=${account.binding.deviceId.take(8)}"
+
+@Composable
+private fun rememberKeepAliveToggle(account: AccountContainer): (Boolean) -> Unit {
+    val context = LocalContext.current
+    var awaitingPermission by remember { mutableStateOf(false) }
+    val permission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (!awaitingPermission) return@rememberLauncherForActivityResult
+        awaitingPermission = false
+        if (!granted) return@rememberLauncherForActivityResult
+        account.appContainer().setKeepAliveEnabled(true)
+    }
+    return { enabled ->
+        if (enabled && Build.VERSION.SDK_INT >= 33) {
+            val granted = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!granted) {
+                awaitingPermission = true
+                permission.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                account.appContainer().setKeepAliveEnabled(true)
+            }
+        } else {
+            account.appContainer().setKeepAliveEnabled(enabled)
+        }
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt
@@ -52,11 +52,13 @@ class ZephyrOneApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-        RdpAndroidRuntime.installHome(filesDir)
         container = AppContainer(this)
         WorkManager.initialize(this, workManagerConfiguration)
         ProcessLifecycleOwner.get().lifecycle.addObserver(LockLifecycleObserver())
         applicationScope.launch {
+            // RDP home is a process env write. It is not needed to paint the dashboard, so it
+            // stays off the first-frame path and only has to land before an RDP session opens.
+            runCatching { RdpAndroidRuntime.installHome(filesDir) }
             try {
                 // Pending password/TOTP state is process-local and cannot resume after death. Clear
                 // its durable crumbs off Main together with the rest of startup recovery.
@@ -96,14 +98,18 @@ class ZephyrOneApplication : Application(), Configuration.Provider {
                 if (workspace != null && workspace.isLocalMode) {
                     runCatching { workspace.activate() }
                 }
-                if (!container.isLocalMode) {
-                    launch {
-                        runCatching { container.bindingCoordinator.bootstrapRestoredBinding() }
-                    }
-                }
             } finally {
                 // No recovery failure may leave MainActivity on its same-colour placeholder forever.
                 readyState.value = true
+            }
+            // Sockets, wake, Link and the first sync round stay off the ready gate. The dashboard
+            // can paint from the restored mirror; producers catch up after the first frame.
+            if (container.shouldHoldAlive()) {
+                one.zephyr.mobile.app.sync.ConnectionKeepAliveService.start(this@ZephyrOneApplication)
+            }
+            if (!container.isLocalMode) {
+                runCatching { container.account?.startNetworkProducers() }
+                runCatching { container.bindingCoordinator.bootstrapRestoredBinding() }
             }
         }
     }

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
@@ -713,6 +713,7 @@ class BindingCoordinator internal constructor(
             // Publication is the durable hand-off. The UI tree that called us may be replaced at
             // this exact point, so make workers eligible before awaiting network bootstrap.
             if (host.currentGraph() === prepared.graph) workersMayRun = true
+            prepared.graph.startNetworkProducers()
             val bootstrap = prepared.graph.bootstrapAfterBind()
             val bootstrapSucceeded = bootstrap.lastOrNull()?.takeIf { it.complete }?.let { round ->
                 markBootstrapReadyIfCurrent(prepared.graph, prepared.binding, round.endState)

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
@@ -189,6 +189,11 @@ interface ManagedBindingGraph {
     fun storeCredentials(access: String, accessExpiresAt: Long?, refresh: String)
     /** Performs platform reconciliation and starts producers after durable ownership is committed. */
     suspend fun activate()
+    /**
+     * Starts sync/wake collectors. Separate from [activate] so process restore can paint the first
+     * frame before opening sockets. Bind completion still calls this before bootstrap.
+     */
+    fun startNetworkProducers() {}
     /** Discards an unpublished generation without touching application-wide platform grants. */
     fun discardPreparedState()
     suspend fun bootstrapAfterBind(): List<SyncRoundResult>
@@ -357,6 +362,7 @@ class BindingCoordinator internal constructor(
         // Bootstrap can perform network I/O. Keep it outside the coordinator mutex so unbind or a
         // revoke can cancel the graph, join the round, and erase the database immediately.
         preparation.restoredGraph?.takeIf { bootstrap }?.let { graph ->
+            graph.startNetworkProducers()
             if (preparation.requiresBootstrap) {
                 graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
                     markBootstrapReadyIfCurrent(graph, checkNotNull(preparation.binding), round.endState)
@@ -372,6 +378,7 @@ class BindingCoordinator internal constructor(
     /** Retries a restored account's initial sync without blocking process startup. */
     suspend fun bootstrapRestoredBinding() {
         val graph = mutex.withLock { host.currentGraph() ?: return }
+        graph.startNetworkProducers()
         if (graph.accountDatabaseRequiresBootstrap()) {
             graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
                 markBootstrapReadyIfCurrent(graph, graph.binding, round.endState)
@@ -521,6 +528,7 @@ class BindingCoordinator internal constructor(
                 // acquire it, cancel this graph's SupervisorJob and join the round immediately. Publication
                 // is already durable, so a cancelled UI caller must not strand persisted background work.
                 if (host.currentGraph() === prepared.graph) workersMayRun = true
+                prepared.graph.startNetworkProducers()
                 val bootstrap = prepared.graph.bootstrapAfterBind()
                 val bootstrapSucceeded = bootstrap.lastOrNull()?.takeIf { it.complete }?.let { round ->
                     markBootstrapReadyIfCurrent(prepared.graph, prepared.binding, round.endState)

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
@@ -167,8 +167,10 @@ class AccountContainer(
     private val wakeJob = SupervisorJob(accountJob)
     private val wakeScope = CoroutineScope(wakeJob + Dispatchers.Default)
     private val started = AtomicBoolean(false)
+    private val producersStarted = AtomicBoolean(false)
     private val preparedDiscarded = AtomicBoolean(false)
     private val networkEnabled = AtomicBoolean(false)
+    private val holdAlive = AtomicBoolean(false)
 
     /**
      * Scoped to the bound triple, not to the install.
@@ -638,6 +640,22 @@ class AccountContainer(
         if (localMode) return
         syncState.ensure(bindingKey)
         networkEnabled.set(true)
+    }
+
+    /**
+     * Opens the sync collectors and the wake stream.
+     *
+     * Kept off the restore critical path so the first frame can paint before sockets and the
+     * embedded Link process come up. Bind completion still calls this before bootstrap so the
+     * first owned-sync round has producers.
+     */
+    override fun startNetworkProducers() {
+        if (localMode || !started.get() || !networkEnabled.get()) return
+        if (!producersStarted.compareAndSet(false, true)) {
+            wakeCoordinator.onHoldAliveChanged(holdAlive.get())
+            wakeCoordinator.onForegroundChanged(appContainer.isProcessForeground())
+            return
+        }
         syncEngine.start(syncScope)
         syncScope.launch {
             syncEngine.lastRoundResult.collect { round ->
@@ -647,6 +665,7 @@ class AccountContainer(
             }
         }
         wakeCoordinator.start(wakeScope)
+        wakeCoordinator.onHoldAliveChanged(holdAlive.get())
         wakeCoordinator.onForegroundChanged(appContainer.isProcessForeground())
         wakeScope.launch {
             network.collect { state ->
@@ -654,6 +673,11 @@ class AccountContainer(
                 if (state.connected) runCatching { sharedResourceCoordinator.refresh() }
             }
         }
+    }
+
+    internal fun setHoldAlive(hold: Boolean) {
+        holdAlive.set(hold)
+        if (producersStarted.get()) wakeCoordinator.onHoldAliveChanged(hold)
     }
 
     /** Runs the first bootstrap inside this account's cancellable lifetime. */
@@ -702,6 +726,7 @@ class AccountContainer(
      */
     override suspend fun stopAndJoin() {
         networkEnabled.set(false)
+        holdAlive.set(false)
         wakeCoordinator.stopAndJoin()
         wakeJob.cancelAndJoin()
         syncJob.cancelAndJoin()

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AppContainer.kt
@@ -39,6 +39,7 @@ import one.zephyr.mobile.protocol.vnc.SocketVncEngine
 import one.zephyr.mobile.protocol.vnc.VncEngine
 import one.zephyr.mobile.app.session.WorkspaceStatePersistence
 import one.zephyr.mobile.app.security.BiometricDeviceAuthenticator
+import one.zephyr.mobile.app.sync.ConnectionKeepAliveService
 import one.zephyr.mobile.data.db.DatabaseFactory
 import one.zephyr.mobile.data.db.AccountDatabaseManager
 import one.zephyr.mobile.data.db.AccountDatabaseScope
@@ -218,8 +219,10 @@ class AppContainer(private val context: Context) {
         }
 
     private val accountState = MutableStateFlow<AccountContainer?>(null)
+    private val keepAliveState = MutableStateFlow(isKeepAliveEnabled())
 
     val accounts: StateFlow<AccountContainer?> = accountState.asStateFlow()
+    val keepAlive: StateFlow<Boolean> = keepAliveState.asStateFlow()
 
     val account: AccountContainer?
         get() = accountGraph as? AccountContainer
@@ -235,6 +238,7 @@ class AppContainer(private val context: Context) {
                     accountGraph = graph
                     (graph as? AccountContainer)?.let { account ->
                         accountState.value = account
+                        applyKeepAliveToCurrentAccount()
                         account.onProcessForegroundChanged(processForeground.get())
                     }
                 }
@@ -243,6 +247,7 @@ class AppContainer(private val context: Context) {
                     if (accountGraph === expected) {
                         accountGraph = null
                         accountState.value = null
+                        ConnectionKeepAliveService.stop(context)
                     }
                 }
 
@@ -254,6 +259,7 @@ class AppContainer(private val context: Context) {
                     // One StateFlow write: the UI never observes a null account between local and
                     // bound graphs, so its bind coroutine cannot cancel itself during commit.
                     accountState.value = account
+                    applyKeepAliveToCurrentAccount()
                     account.onProcessForegroundChanged(processForeground.get())
                 }
             },
@@ -357,6 +363,7 @@ class AppContainer(private val context: Context) {
         }
         accountGraph = container
         accountState.value = container
+        applyKeepAliveToCurrentAccount()
         container.onProcessForegroundChanged(processForeground.get())
         return container
     }
@@ -568,11 +575,42 @@ class AppContainer(private val context: Context) {
     fun onProcessForeground() {
         processForeground.set(true)
         account?.onProcessForegroundChanged(true)
+        if (shouldHoldAlive()) ConnectionKeepAliveService.start(context)
     }
 
     fun onProcessBackground() {
         processForeground.set(false)
         account?.onProcessForegroundChanged(false)
+    }
+
+    fun isKeepAliveEnabled(): Boolean =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getBoolean(KEY_KEEP_ALIVE, false)
+
+    fun shouldHoldAlive(): Boolean {
+        val current = account
+        return current != null && !current.isLocalMode && isKeepAliveEnabled()
+    }
+
+    fun setKeepAliveEnabled(enabled: Boolean) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_KEEP_ALIVE, enabled)
+            .apply()
+        keepAliveState.value = enabled
+        applyKeepAliveToCurrentAccount()
+    }
+
+    fun applyKeepAliveToCurrentAccount() {
+        applyKeepAliveTo(account)
+        if (shouldHoldAlive()) {
+            ConnectionKeepAliveService.start(context)
+        } else {
+            ConnectionKeepAliveService.stop(context)
+        }
+    }
+
+    private fun applyKeepAliveTo(account: AccountContainer?) {
+        account?.setHoldAlive(!account.isLocalMode && isKeepAliveEnabled())
     }
 
     /** Entry point for an optional payload-free push receiver. Cursor values are never trusted. */
@@ -585,6 +623,7 @@ class AppContainer(private val context: Context) {
         const val KEY_INSTALL_ID = "install-id"
         const val KEY_LOCAL_WORKSPACE_GENERATION = "local-workspace-generation"
         const val KEY_PAD_TERM_SIDE = "pad-term-side"
+        const val KEY_KEEP_ALIVE = "keep-alive"
         const val NO_ACCOUNT_TEARDOWN_OWNER = "no-account-teardown"
 
         /** Reserved scope segment: never a real server or user id, which are opaque server strings. */

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/sync/ConnectionKeepAliveService.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/sync/ConnectionKeepAliveService.kt
@@ -1,0 +1,143 @@
+package one.zephyr.mobile.app.sync
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import one.zephyr.mobile.R
+import one.zephyr.mobile.app.ZephyrOneApplication
+
+/**
+ * Discloses that the user asked One to keep the sync/wake channel online in the background.
+ *
+ * WakeCoordinator otherwise drops the socket on process background because Android will not keep a
+ * silent connection alive. Opting in starts this foreground service: the ongoing notification is
+ * the disclosure, and its stop action is the off switch. SCREEN_CATALOG.md 22 uses the same shape
+ * for the file bridge; this is that shape for the account channel.
+ */
+class ConnectionKeepAliveService : LifecycleService() {
+
+    override fun onBind(intent: Intent): IBinder? {
+        super.onBind(intent)
+        return null
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        val app = application as? ZephyrOneApplication
+        if (intent?.action == ACTION_STOP) {
+            app?.container?.setKeepAliveEnabled(false)
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        createChannel()
+        try {
+            val notification = buildNotification()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (_: RuntimeException) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        if (app == null) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        lifecycleScope.launch {
+            app.ready.first { it }
+            if (!app.container.shouldHoldAlive()) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+                return@launch
+            }
+            app.container.applyKeepAliveToCurrentAccount()
+        }
+        return START_STICKY
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.keep_alive_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = getString(R.string.keep_alive_channel_description)
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification {
+        val stop = PendingIntent.getService(
+            this,
+            REQUEST_STOP,
+            Intent(this, ConnectionKeepAliveService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val open = packageManager.getLaunchIntentForPackage(packageName)?.let { launch ->
+            PendingIntent.getActivity(
+                this,
+                REQUEST_OPEN,
+                launch,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.keep_alive_notification_title))
+            .setContentText(getString(R.string.keep_alive_notification_text))
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .setContentIntent(open)
+            .addAction(0, getString(R.string.keep_alive_stop), stop)
+            .build()
+    }
+
+    companion object {
+        const val ACTION_STOP = "one.zephyr.mobile.action.STOP_KEEP_ALIVE"
+
+        private const val CHANNEL_ID = "zephyr-one-keep-alive"
+        private const val NOTIFICATION_ID = 4202
+        private const val REQUEST_STOP = 1
+        private const val REQUEST_OPEN = 2
+
+        fun start(context: Context) {
+            val app = context.applicationContext
+            try {
+                app.startForegroundService(Intent(app, ConnectionKeepAliveService::class.java))
+            } catch (_: RuntimeException) {
+                // Missing notification permission or a background-start restriction: the preference
+                // stays so a later foreground attempt can start the disclosure. The wake stream
+                // still drops on background until the service actually runs.
+            }
+        }
+
+        fun stop(context: Context) {
+            val app = context.applicationContext
+            app.stopService(Intent(app, ConnectionKeepAliveService::class.java))
+        }
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/res/values-en/strings.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/values-en/strings.xml
@@ -7,6 +7,11 @@
     <string name="file_bridge_notification_title">File bridge is online</string>
     <string name="file_bridge_notification_text">%1$s · transferred %2$s</string>
     <string name="file_bridge_stop">Stop</string>
+    <string name="keep_alive_channel_name">Background connection</string>
+    <string name="keep_alive_channel_description">Shown while the sync and wake channel is kept online. Stop it any time.</string>
+    <string name="keep_alive_notification_title">Keeping connection alive</string>
+    <string name="keep_alive_notification_text">The sync and wake channel stays online. This uses more battery.</string>
+    <string name="keep_alive_stop">Stop</string>
     <string name="unlock_title">Unlock Zephyr One</string>
     <string name="unlock_subtitle">Continue with the device credential</string>
     <string name="unlock_locked_message">Locked</string>

--- a/zephyr_one/mobile/android/app/src/main/res/values/strings.xml
+++ b/zephyr_one/mobile/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,12 @@
     <string name="file_bridge_notification_text">%1$s · 已传输 %2$s</string>
     <string name="file_bridge_stop">停止</string>
 
+    <string name="keep_alive_channel_name">后台连接</string>
+    <string name="keep_alive_channel_description">保持同步与唤醒通道在线时显示，可随时停止。</string>
+    <string name="keep_alive_notification_title">后台保持连接中</string>
+    <string name="keep_alive_notification_text">同步与唤醒通道保持在线，会更耗电。</string>
+    <string name="keep_alive_stop">停止</string>
+
     <string name="unlock_title">解锁 Zephyr One</string>
     <string name="unlock_subtitle">使用设备凭据继续</string>
     <string name="unlock_locked_message">已锁定</string>

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/StartupThemeTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/StartupThemeTest.kt
@@ -41,8 +41,17 @@ class StartupThemeTest {
         assertTrue(source.contains("readyState.value = true"))
         assertTrue(source.contains("TimeoutCancellationException"))
         val onCreate = source.substringAfter("override fun onCreate()")
-        assertFalse(onCreate.substringBefore("applicationScope.launch").contains("clearPendingBindingAuthentication"))
-        assertTrue(onCreate.substringAfter("applicationScope.launch").contains("clearPendingBindingAuthentication"))
+        val beforeLaunch = onCreate.substringBefore("applicationScope.launch")
+        val afterLaunch = onCreate.substringAfter("applicationScope.launch")
+        val afterReady = afterLaunch.substringAfter("readyState.value = true")
+        assertFalse(beforeLaunch.contains("clearPendingBindingAuthentication"))
+        assertFalse(beforeLaunch.contains("RdpAndroidRuntime.installHome"))
+        assertTrue(afterLaunch.contains("clearPendingBindingAuthentication"))
+        assertTrue(afterLaunch.contains("RdpAndroidRuntime.installHome"))
+        assertTrue(afterReady.contains("startNetworkProducers"))
+        assertTrue(afterReady.contains("bootstrapRestoredBinding"))
+        assertFalse(afterLaunch.substringBefore("readyState.value = true").contains("startNetworkProducers"))
+        assertFalse(afterLaunch.substringBefore("readyState.value = true").contains("bootstrapRestoredBinding"))
     }
 
     @Test

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
@@ -73,6 +73,7 @@ class BindingCoordinatorTest {
         assertTrue(result.bootstrapSucceeded)
         assertEquals(BindingState.IDLE, storage.active?.binding?.state)
         assertEquals(1, graphs.single().bootstrapCalls)
+        assertEquals(1, graphs.single().producerCalls)
         assertEquals("access-1", graphs.single().storedAccess)
         assertEquals("refresh-1", graphs.single().storedRefresh)
         assertTrue(gateway.authenticationCleared)
@@ -138,11 +139,12 @@ class BindingCoordinatorTest {
                 "storage.save",
                 "graph.activate",
                 "host.attach",
+                "graph.producers",
                 "graph.bootstrap",
                 "graph.database.ready",
                 "storage.ready",
             ),
-            events.takeLast(6),
+            events.takeLast(7),
         )
     }
 
@@ -342,10 +344,12 @@ class BindingCoordinatorTest {
         val graph = graphs.single()
         assertEquals(0, graph.bootstrapCalls)
         assertEquals(0, graph.foregroundCalls)
+        assertEquals(0, graph.producerCalls)
 
         coordinator.bootstrapRestoredBinding()
         assertEquals(0, graph.bootstrapCalls)
         assertEquals(1, graph.foregroundCalls)
+        assertEquals(1, graph.producerCalls)
     }
 
     @Test
@@ -365,6 +369,7 @@ class BindingCoordinatorTest {
         coordinator.bootstrapRestoredBinding()
         assertEquals(1, graphs.single().bootstrapCalls)
         assertEquals(0, graphs.single().foregroundCalls)
+        assertEquals(1, graphs.single().producerCalls)
     }
 
     @Test
@@ -390,11 +395,12 @@ class BindingCoordinatorTest {
             listOf(
                 "graph.activate",
                 "host.attach",
+                "graph.producers",
                 "graph.bootstrap",
                 "graph.database.ready",
                 "storage.ready",
             ),
-            events.takeLast(5),
+            events.takeLast(6),
         )
     }
 
@@ -437,8 +443,8 @@ class BindingCoordinatorTest {
         assertEquals(1, graphs.single().bootstrapCalls)
         assertEquals(1, graphs.single().databaseReadyCalls)
         assertEquals(
-            listOf("graph.bootstrap", "graph.database.ready", "storage.ready"),
-            events.takeLast(3),
+            listOf("graph.producers", "graph.bootstrap", "graph.database.ready", "storage.ready"),
+            events.takeLast(4),
         )
     }
 
@@ -1855,6 +1861,7 @@ private class FakeGraph(
     var wiped = false
     var preparedDiscarded = false
     var activationCalls = 0
+    var producerCalls = 0
     var stopFailures = 0
     var wipeFailures = 0
     var startFailures = 0
@@ -1874,6 +1881,11 @@ private class FakeGraph(
             startFailures -= 1
             error("simulated startup recovery failure")
         }
+    }
+
+    override fun startNetworkProducers() {
+        events += "graph.producers"
+        producerCalls += 1
     }
 
     override fun discardPreparedState() {

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/sync/ConnectionKeepAliveContractTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/sync/ConnectionKeepAliveContractTest.kt
@@ -1,0 +1,67 @@
+package one.zephyr.mobile.app.sync
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ConnectionKeepAliveContractTest {
+
+    private val androidRoot = File(".").canonicalFile.let { current ->
+        generateSequence(current) { it.parentFile }.first {
+            File(it, "app/src/main/AndroidManifest.xml").exists()
+        }
+    }
+
+    @Test
+    fun `keep alive is a disclosed dataSync foreground service`() {
+        val manifest = File(androidRoot, "app/src/main/AndroidManifest.xml").readText()
+        assertTrue(manifest.contains("android:name=\".app.sync.ConnectionKeepAliveService\""))
+        assertTrue(manifest.contains("android:foregroundServiceType=\"dataSync\""))
+
+        val source = File(
+            androidRoot,
+            "app/src/main/kotlin/one/zephyr/mobile/app/sync/ConnectionKeepAliveService.kt",
+        ).readText()
+        assertTrue(source.contains("startForeground"))
+        assertTrue(source.contains("ACTION_STOP"))
+        assertTrue(source.contains("keep_alive_stop"))
+        assertTrue(source.contains("setKeepAliveEnabled(false)"))
+    }
+
+    @Test
+    fun `wake stream hold alive is wired through the account graph`() {
+        val wake = File(
+            androidRoot,
+            "core-sync/src/main/kotlin/one/zephyr/mobile/sync/WakeCoordinator.kt",
+        ).readText()
+        assertTrue(wake.contains("fun onHoldAliveChanged"))
+        assertTrue(wake.contains("foreground || holdAlive"))
+
+        val account = File(
+            androidRoot,
+            "app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt",
+        ).readText()
+        assertTrue(account.contains("fun startNetworkProducers"))
+        assertTrue(account.contains("fun setHoldAlive"))
+        assertTrue(account.contains("wakeCoordinator.onHoldAliveChanged"))
+
+        val coordinator = File(
+            androidRoot,
+            "app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt",
+        ).readText()
+        assertTrue(coordinator.contains("prepared.graph.startNetworkProducers()"))
+
+        val application = File(
+            androidRoot,
+            "app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt",
+        ).readText()
+        val afterReady = application.substringAfter("readyState.value = true")
+        assertTrue(afterReady.contains("startNetworkProducers"))
+        assertTrue(afterReady.contains("ConnectionKeepAliveService.start"))
+        assertTrue(afterReady.contains("shouldHoldAlive"))
+        assertTrue(
+            afterReady.indexOf("ConnectionKeepAliveService.start") <
+                afterReady.indexOf("startNetworkProducers"),
+        )
+    }
+}

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/ui/CardOutlineTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/ui/CardOutlineTest.kt
@@ -1,0 +1,37 @@
+package one.zephyr.mobile.app.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+
+class CardOutlineTest {
+
+    private val androidRoot = File(".").canonicalFile.let { current ->
+        generateSequence(current) { it.parentFile }.first {
+            File(it, "app/src/main/AndroidManifest.xml").exists()
+        }
+    }
+
+    @Test
+    fun `root list cards do not draw a stroke`() {
+        val files = listOf(
+            "feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt",
+            "feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ProtocolPickerScreen.kt",
+            "feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/LibraryRootScreen.kt",
+            "feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt",
+            "feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionListScreen.kt",
+        )
+        for (relative in files) {
+            val source = File(androidRoot, relative).readText()
+            assertFalse(
+                relative + " still draws a card stroke",
+                source.contains("BorderStroke") || Regex("""\.border\(""").containsMatchIn(source),
+            )
+        }
+        val groupCard = File(
+            androidRoot,
+            "core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Widgets.kt",
+        ).readText().substringAfter("fun GroupCard").substringBefore("fun SettingsRow")
+        assertFalse("GroupCard still draws a stroke", groupCard.contains(".border("))
+    }
+}

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/WakeCoordinator.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/WakeCoordinator.kt
@@ -62,8 +62,10 @@ object WakeReconnectPolicy {
  *
  * Wake cursors are used only to coalesce hints. They never advance local state; [requestSync]
  * always performs the authenticated change-feed pull and validates the real server response.
- * Android cannot keep an arbitrary socket alive in the background, so the stream is cancelled
- * there and periodic/expedited WorkManager work remains the correctness fallback.
+ * Android cannot keep an arbitrary socket alive in the background by default, so the stream is
+ * cancelled there and periodic/expedited WorkManager work remains the correctness fallback.
+ * When the user opts into 后台保持连接, [onHoldAliveChanged] keeps the stream running across
+ * process backgrounding; a foreground service is the disclosure for that choice.
  */
 class WakeCoordinator(
     val identity: WakeBindingIdentity,
@@ -84,6 +86,7 @@ class WakeCoordinator(
 
     private var managerJob: Job? = null
     private var foreground = false
+    private var holdAlive = false
     private var connected = false
     private var invalidated = false
     private var lifecycleVersion = 0L
@@ -104,9 +107,19 @@ class WakeCoordinator(
     fun onForegroundChanged(isForeground: Boolean) {
         synchronized(lock) {
             if (invalidated || foreground == isForeground) return
-            foreground = isForeground
-            lifecycleVersion += 1
-            if (!isForeground) invalidateAttemptLocked()
+            applyRunFlagLocked { foreground = isForeground }
+        }
+        stateChanges.trySend(Unit)
+    }
+
+    /**
+     * User-opted background hold. When true the live stream survives process backgrounding;
+     * turning it off while backgrounded tears the socket down the same way leaving the app does.
+     */
+    fun onHoldAliveChanged(hold: Boolean) {
+        synchronized(lock) {
+            if (invalidated || holdAlive == hold) return
+            applyRunFlagLocked { holdAlive = hold }
         }
         stateChanges.trySend(Unit)
     }
@@ -127,6 +140,7 @@ class WakeCoordinator(
             if (!invalidated) {
                 invalidated = true
                 foreground = false
+                holdAlive = false
                 connected = false
                 invalidateAttemptLocked()
             }
@@ -264,7 +278,16 @@ class WakeCoordinator(
     private fun shouldRun(): Boolean = synchronized(lock) { shouldRunLocked() }
 
     private fun shouldRunLocked(): Boolean =
-        managerJob != null && !invalidated && foreground && connected
+        managerJob != null && !invalidated && connected && (foreground || holdAlive)
+
+    private inline fun applyRunFlagLocked(update: () -> Unit) {
+        val wasRunning = shouldRunLocked()
+        update()
+        val nowRunning = shouldRunLocked()
+        if (wasRunning == nowRunning) return
+        lifecycleVersion += 1
+        if (!nowRunning) invalidateAttemptLocked()
+    }
 
     private fun invalidateAttemptLocked() {
         currentAttempt = attemptSequence.incrementAndGet()

--- a/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/WakeCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/WakeCoordinatorTest.kt
@@ -200,6 +200,63 @@ class WakeCoordinatorTest {
     }
 
     @Test
+    fun `enabling hold alive in foreground does not reconnect`() = runTest {
+        val identity = identity()
+        val transport = ScriptedWakeTransport()
+        val coordinator = coordinator(identity, IdentityHolder(identity), transport) { }
+        coordinator.start(backgroundScope)
+        coordinator.activate()
+        transport.nextOpen()
+
+        coordinator.onHoldAliveChanged(true)
+        runCurrent()
+
+        assertEquals(0, transport.cancellations.get())
+        assertEquals(1, transport.openCount.get())
+        coordinator.stopAndJoin()
+    }
+
+    @Test
+    fun `hold alive keeps the stream across backgrounding`() = runTest {
+        val identity = identity()
+        val transport = ScriptedWakeTransport()
+        val coordinator = coordinator(identity, IdentityHolder(identity), transport) { }
+        coordinator.start(backgroundScope)
+        coordinator.activate()
+        transport.nextOpen()
+
+        coordinator.onHoldAliveChanged(true)
+        coordinator.onForegroundChanged(false)
+        runCurrent()
+
+        assertEquals(0, transport.cancellations.get())
+        assertEquals(1, transport.openCount.get())
+        coordinator.stopAndJoin()
+    }
+
+    @Test
+    fun `turning hold alive off in background cancels the socket`() = runTest {
+        val identity = identity()
+        val transport = ScriptedWakeTransport()
+        val coordinator = coordinator(identity, IdentityHolder(identity), transport) { }
+        coordinator.start(backgroundScope)
+        coordinator.activate()
+        coordinator.onHoldAliveChanged(true)
+        transport.nextOpen()
+
+        coordinator.onForegroundChanged(false)
+        runCurrent()
+        coordinator.onHoldAliveChanged(false)
+        runCurrent()
+
+        assertEquals(1, transport.cancellations.get())
+        coordinator.onHoldAliveChanged(true)
+        val replacement = transport.nextOpen()
+        assertEquals(null, replacement.lastEventId)
+        coordinator.stopAndJoin()
+    }
+
+    @Test
     fun `teardown joins transport and coordinator cannot resurrect`() = runTest {
         val identity = identity()
         val transport = ScriptedWakeTransport()

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Widgets.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Widgets.kt
@@ -413,8 +413,7 @@ fun GroupCard(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(ZephyrRadius.md))
-            .background(palette.surfaces.content)
-            .border(1.dp, palette.surfaces.outlineSoft, RoundedCornerShape(ZephyrRadius.md)),
+            .background(palette.surfaces.content),
         content = content,
     )
 }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
@@ -151,14 +151,6 @@ fun FloatingIsland(
                         animationSpec = tween(motion.scale(IslandSpec.LABEL_CROSSFADE_MS)),
                         label = "islandLabel",
                     )
-                    val labelHeight by animateDpAsState(
-                        targetValue = if (isSelected) 11.dp else 0.dp,
-                        animationSpec = tween(
-                            motion.scale(ZephyrMotionTokens.MED_MS),
-                            easing = ZephyrMotionTokens.easeOut,
-                        ),
-                        label = "islandLabelH",
-                    )
 
                     Column(
                         modifier = Modifier
@@ -187,16 +179,16 @@ fun FloatingIsland(
                             tint = if (isSelected) palette.brand.accent else palette.onFloatingSubtle,
                             modifier = Modifier.size(iconSize),
                         )
-                        if (labelHeight > 0.dp) {
+                        if (isSelected) {
                             Text(
                                 text = labels[index],
                                 style = ZephyrTextStyles.islandLabel,
                                 color = palette.brand.accent,
                                 maxLines = 1,
-                                overflow = TextOverflow.Clip,
+                                softWrap = false,
+                                overflow = TextOverflow.Visible,
                                 modifier = Modifier
                                     .padding(top = IslandSpec.iconLabelGap)
-                                    .height(labelHeight)
                                     .alpha(labelAlpha),
                             )
                         }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
@@ -185,7 +185,6 @@ fun FloatingIsland(
                                 style = ZephyrTextStyles.islandLabel,
                                 color = palette.brand.accent,
                                 maxLines = 1,
-                                softWrap = false,
                                 overflow = TextOverflow.Visible,
                                 modifier = Modifier
                                     .padding(top = IslandSpec.iconLabelGap)

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/theme/Typography.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/theme/Typography.kt
@@ -100,8 +100,12 @@ object ZephyrTextStyles {
     val islandLabel: TextStyle = TextStyle(
         fontSize = 10.sp,
         fontWeight = FontWeight.SemiBold,
+        lineHeight = 13.sp,
         platformStyle = noPad,
-        lineHeightStyle = line,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment.Center,
+            trim = LineHeightStyle.Trim.Both,
+        ),
     )
 
     val stat: TextStyle = TextStyle(

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/island/FloatingIslandLabelTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/island/FloatingIslandLabelTest.kt
@@ -23,7 +23,7 @@ class FloatingIslandLabelTest {
         assertFalse(source.contains("11.dp"))
         assertTrue(source.contains("if (isSelected)"))
         assertTrue(source.contains("overflow = TextOverflow.Visible"))
-        assertTrue(source.contains("softWrap = false"))
+        assertFalse(source.contains("softWrap"))
     }
 
     @Test

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/island/FloatingIslandLabelTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/island/FloatingIslandLabelTest.kt
@@ -1,0 +1,40 @@
+package one.zephyr.mobile.ui.island
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class FloatingIslandLabelTest {
+
+    private val androidRoot = File(".").canonicalFile.let { current ->
+        generateSequence(current) { it.parentFile }.first {
+            File(it, "core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt").exists()
+        }
+    }
+
+    @Test
+    fun `selected label is not clipped to a fixed height`() {
+        val source = File(
+            androidRoot,
+            "core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt",
+        ).readText()
+        assertFalse(source.contains("labelHeight"))
+        assertFalse(source.contains("11.dp"))
+        assertTrue(source.contains("if (isSelected)"))
+        assertTrue(source.contains("overflow = TextOverflow.Visible"))
+        assertTrue(source.contains("softWrap = false"))
+    }
+
+    @Test
+    fun `island label style keeps full glyphs`() {
+        val source = File(
+            androidRoot,
+            "core-ui/src/main/kotlin/one/zephyr/mobile/ui/theme/Typography.kt",
+        ).readText()
+        val island = source.substringAfter("val islandLabel").substringBefore("val stat")
+        assertTrue(island.contains("lineHeight = 13.sp"))
+        assertTrue(island.contains("LineHeightStyle.Trim.Both"))
+        assertFalse(island.contains("Trim.None"))
+    }
+}

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt
@@ -2,7 +2,6 @@ package one.zephyr.mobile.feature.connections
 
 import one.zephyr.mobile.ui.icon.ZephyrIcons
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -407,7 +406,6 @@ private fun ConnectionCard(
             ) { onAction(ConnectionAction.USE) },
         shape = RoundedCornerShape(14.dp),
         color = palette.surfaces.content,
-        border = BorderStroke(1.dp, palette.surfaces.outline.copy(alpha = 0.55f)),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(14.dp),
@@ -672,7 +670,6 @@ private fun StatCard(value: String, label: String, modifier: Modifier, valueColo
     Surface(
         modifier = modifier,
         color = ZephyrTheme.palette.surfaces.content,
-        border = BorderStroke(1.dp, ZephyrTheme.palette.surfaces.outline.copy(alpha = 0.55f)),
         shape = RoundedCornerShape(14.dp),
     ) {
         Column(Modifier.padding(14.dp)) {

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ProtocolPickerScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ProtocolPickerScreen.kt
@@ -2,7 +2,6 @@ package one.zephyr.mobile.feature.connections
 
 import one.zephyr.mobile.ui.icon.ZephyrIcons
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -111,7 +110,6 @@ private fun ProtocolCard(protocol: Protocol, onClick: () -> Unit) {
             ),
         color = palette.surfaces.content,
         shape = RoundedCornerShape(ZephyrRadius.md),
-        border = BorderStroke(1.dp, palette.surfaces.outline.copy(alpha = 0.35f)),
     ) {
         Row(
             Modifier.padding(14.dp),

--- a/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/LibraryRootScreen.kt
+++ b/zephyr_one/mobile/android/feature-notes/src/main/kotlin/one/zephyr/mobile/feature/notes/LibraryRootScreen.kt
@@ -2,7 +2,6 @@ package one.zephyr.mobile.feature.notes
 
 import one.zephyr.mobile.ui.icon.ZephyrIcons
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -292,7 +291,6 @@ private fun LibraryEntryCard(
         modifier = modifier.heightIn(min = 72.dp).clickable(onClick = onClick),
         color = ZephyrTheme.palette.surfaces.content,
         shape = RoundedCornerShape(ZephyrRadius.md),
-        border = BorderStroke(1.dp, ZephyrTheme.palette.surfaces.outline.copy(alpha = .35f)),
     ) {
         Row(Modifier.padding(ZephyrSpacing.md), verticalAlignment = Alignment.CenterVertically) {
             Surface(shape = RoundedCornerShape(10.dp), color = tint.copy(alpha = .15f)) {
@@ -377,7 +375,6 @@ private fun RowGroup(content: @Composable () -> Unit) {
     Surface(
         color = ZephyrTheme.palette.surfaces.content,
         shape = RoundedCornerShape(ZephyrRadius.md),
-        border = BorderStroke(1.dp, ZephyrTheme.palette.surfaces.outline.copy(alpha = .35f)),
     ) { Column { content() } }
 }
 

--- a/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionListScreen.kt
+++ b/zephyr_one/mobile/android/feature-sessions/src/main/kotlin/one/zephyr/mobile/feature/sessions/SessionListScreen.kt
@@ -4,7 +4,6 @@ import one.zephyr.mobile.ui.icon.ZephyrIcons
 import one.zephyr.mobile.ui.theme.ZephyrTextStyles
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -215,7 +214,6 @@ private fun SessionRowCard(
             .pressScale(0.98f)
             .clip(RoundedCornerShape(ZephyrRadius.md))
             .background(if (selected) palette.surfaces.elevated else palette.surfaces.content)
-            .border(1.dp, palette.surfaces.outlineSoft, RoundedCornerShape(ZephyrRadius.md))
             .clickable(enabled = restoreGate.isAllowed) { onAction(SessionAction.RESTORE) }
             .padding(horizontal = 14.dp, vertical = 13.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolScreens.kt
@@ -317,6 +317,9 @@ fun NetworkSettingsScreen(
     policy: NetworkPolicy,
     onPolicy: (NetworkPolicy) -> Unit,
     onBack: () -> Unit,
+    keepAlive: Boolean = false,
+    onKeepAlive: ((Boolean) -> Unit)? = null,
+    localMode: Boolean = false,
 ) {
     Column(Modifier.fillMaxSize()) {
         PushedPageHeader(title = "网络", onBack = onBack)
@@ -327,6 +330,24 @@ fun NetworkSettingsScreen(
                 FilterChip(selected = policy == NetworkPolicy.WIFI_ONLY, onClick = { onPolicy(NetworkPolicy.WIFI_ONLY) }, label = { Text("仅 Wi-Fi") })
             }
             Text("大文件和备份走该策略。立即同步在绑定存活时始终可用。", color = ZephyrTheme.palette.onFloatingMuted, fontSize = 12.sp)
+            if (onKeepAlive != null) {
+                SectionLabel("后台")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text("后台保持连接")
+                        Text(
+                            if (localMode) {
+                                "绑定主端后可在离开应用时保持同步通道"
+                            } else {
+                                "离开应用后仍保持同步与唤醒通道，会更耗电"
+                            },
+                            color = ZephyrTheme.palette.onFloatingMuted,
+                            fontSize = 12.sp,
+                        )
+                    }
+                    Switch(checked = keepAlive, onCheckedChange = onKeepAlive, enabled = !localMode)
+                }
+            }
         }
     }
 }
@@ -356,6 +377,8 @@ fun FileSyncScreen(
     onAutomatic: (Boolean) -> Unit,
     onInterval: (Int) -> Unit,
     onPolicy: (NetworkPolicy) -> Unit,
+    keepAlive: Boolean = false,
+    onKeepAlive: ((Boolean) -> Unit)? = null,
     onSyncNow: () -> Unit,
     onOpenConflicts: () -> Unit = {},
     onOpenDevices: () -> Unit = {},
@@ -484,6 +507,24 @@ fun FileSyncScreen(
                         onPolicy(if (settings.networkPolicy == NetworkPolicy.WIFI_ONLY) NetworkPolicy.ANY else NetworkPolicy.WIFI_ONLY)
                     },
                 )
+                if (onKeepAlive != null) {
+                    one.zephyr.mobile.ui.component.SettingsRow(
+                        title = "后台保持连接",
+                        subtitle = if (localMode) {
+                            "绑定主端后可在离开应用时保持同步通道"
+                        } else {
+                            "离开应用后仍保持同步与唤醒通道，会更耗电"
+                        },
+                        showDivider = onBind != null || onUnbind != null,
+                        trailing = {
+                            Switch(
+                                checked = keepAlive,
+                                onCheckedChange = onKeepAlive,
+                                enabled = !localMode,
+                            )
+                        },
+                    )
+                }
                 if (onBind != null) {
                     one.zephyr.mobile.ui.component.SettingsRow(
                         title = "绑定主端",

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ToolsRootScreen.kt
@@ -2,7 +2,6 @@ package one.zephyr.mobile.feature.tools
 
 import one.zephyr.mobile.ui.icon.ZephyrIcons
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -178,7 +177,6 @@ private fun ToolsGroup(content: @Composable () -> Unit) {
     Surface(
         color = ZephyrTheme.palette.surfaces.content,
         shape = RoundedCornerShape(ZephyrRadius.md),
-        border = BorderStroke(1.dp, ZephyrTheme.palette.surfaces.outline.copy(alpha = .35f)),
     ) { Column { content() } }
 }
 

--- a/zephyr_one/mobile/ios/Sources/ZephyrUI/Views/RootSurfaces.swift
+++ b/zephyr_one/mobile/ios/Sources/ZephyrUI/Views/RootSurfaces.swift
@@ -75,11 +75,12 @@ struct ZephyrRootIsland: View {
                         : ZephyrRootIslandMetrics.iconSize, weight: .semibold))
                     .frame(height: selected ? 19 : 25)
 
-                Text(destination.title)
-                    .font(.system(size: 10, weight: .semibold))
-                    .lineLimit(1)
-                    .frame(height: selected ? 11 : 0)
-                    .opacity(selected ? 1 : 0)
+                if selected {
+                    Text(destination.title)
+                        .font(.system(size: 10, weight: .semibold))
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: true)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .foregroundColor(selected ? ZephyrStyle.accent : ZephyrStyle.tertiaryText(colorScheme))

--- a/zephyr_one/mobile/ios/Sources/ZephyrUI/Views/ZephyrStyle.swift
+++ b/zephyr_one/mobile/ios/Sources/ZephyrUI/Views/ZephyrStyle.swift
@@ -66,10 +66,6 @@ struct ZephyrCardModifier: ViewModifier {
         content
             .background(ZephyrStyle.surface(colorScheme))
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(ZephyrStyle.separator(colorScheme), lineWidth: 1)
-            }
     }
 }
 

--- a/zephyr_one/mobile/ios/Tests/ZephyrUITests/RootSurfaceStyleTests.swift
+++ b/zephyr_one/mobile/ios/Tests/ZephyrUITests/RootSurfaceStyleTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import ZephyrUI
+
+final class RootSurfaceStyleTests: XCTestCase {
+
+    func testCardModifierHasNoStroke() throws {
+        let source = try readSource("ZephyrStyle.swift")
+        XCTAssertFalse(source.contains(".stroke(ZephyrStyle.separator"))
+        XCTAssertTrue(source.contains("func zephyrCard()"))
+    }
+
+    func testIslandLabelIsNotHeightClipped() throws {
+        let source = try readSource("RootSurfaces.swift")
+        XCTAssertFalse(source.contains(".frame(height: selected ? 11 : 0)"))
+        XCTAssertTrue(source.contains("if selected {"))
+        XCTAssertTrue(source.contains(".fixedSize(horizontal: true, vertical: true)"))
+    }
+
+    private func readSource(_ name: String) throws -> String {
+        let here = URL(fileURLWithPath: #filePath)
+        let views = here
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/ZephyrUI/Views")
+        return try String(contentsOf: views.appendingPathComponent(name), encoding: .utf8)
+    }
+}

--- a/zephyr_one/mobile/tests/android-cold-start-producers.test.mjs
+++ b/zephyr_one/mobile/tests/android-cold-start-producers.test.mjs
@@ -35,6 +35,9 @@ test('restore paints before sockets and keep-alive is a disclosed dataSync servi
   assert.match(wake, /foreground \|\| holdAlive/);
 
   const coordinator = read('android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt');
-  assert.match(coordinator, /prepared\.graph\.startNetworkProducers\(\)/);
-  assert.match(coordinator, /graph\.startNetworkProducers\(\)/);
+  assert.equal(
+    (coordinator.match(/startNetworkProducers\(\)/g) || []).length,
+    5,
+    'activate contract, restore, bind, enrollment consume, and deferred bootstrap must all start producers',
+  );
 });

--- a/zephyr_one/mobile/tests/android-cold-start-producers.test.mjs
+++ b/zephyr_one/mobile/tests/android-cold-start-producers.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const mobile = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relative) => fs.readFileSync(path.join(mobile, relative), 'utf8');
+
+test('restore paints before sockets and keep-alive is a disclosed dataSync service', () => {
+  const application = read('android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneApplication.kt');
+  const onCreate = application.slice(application.indexOf('override fun onCreate()'));
+  const afterLaunch = onCreate.slice(onCreate.indexOf('applicationScope.launch'));
+  const beforeReady = afterLaunch.slice(0, afterLaunch.indexOf('readyState.value = true'));
+  const afterReady = afterLaunch.slice(afterLaunch.indexOf('readyState.value = true'));
+
+  assert.match(afterLaunch, /RdpAndroidRuntime\.installHome\(filesDir\)/);
+  assert.doesNotMatch(onCreate.slice(0, onCreate.indexOf('applicationScope.launch')), /RdpAndroidRuntime\.installHome/);
+  assert.doesNotMatch(beforeReady, /startNetworkProducers/);
+  assert.doesNotMatch(beforeReady, /bootstrapRestoredBinding/);
+  assert.match(afterReady, /startNetworkProducers/);
+  assert.match(afterReady, /bootstrapRestoredBinding/);
+  assert.match(afterReady, /ConnectionKeepAliveService\.start/);
+  assert.ok(
+    afterReady.indexOf('ConnectionKeepAliveService.start') < afterReady.indexOf('startNetworkProducers'),
+    'keep-alive disclosure must start before sockets',
+  );
+
+  const manifest = read('android/app/src/main/AndroidManifest.xml');
+  assert.match(manifest, /android:name="\.app\.sync\.ConnectionKeepAliveService"/);
+  assert.match(manifest, /android:foregroundServiceType="dataSync"/);
+
+  const wake = read('android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/WakeCoordinator.kt');
+  assert.match(wake, /fun onHoldAliveChanged/);
+  assert.match(wake, /foreground \|\| holdAlive/);
+
+  const coordinator = read('android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt');
+  assert.match(coordinator, /prepared\.graph\.startNetworkProducers\(\)/);
+  assert.match(coordinator, /graph\.startNetworkProducers\(\)/);
+});


### PR DESCRIPTION
## 用户反馈

1. 首页 / 会话 / 资料 / 工具 的卡片黑色描边去掉，不要框。
2. 底部药丸导航切换时，「首页 / 会话 / 资料 / 工具」下半部被挡住。
3. 优化冷启动。
4. 支持后台保持连接。

## 改动

**描边**
- Android `GroupCard` 以及连接 / 会话 / 资料 / 工具根列表卡片不再画 1dp stroke。
- iOS `zephyrCard()` 去掉 separator overlay。

**药丸导航裁字**
- 选中标签不再用 11dp 固定高度裁切；只在选中时画完整文字。
- `islandLabel` 使用 13sp lineHeight + `Trim.Both`。

**冷启动**
- `RdpAndroidRuntime.installHome` 挪到 `applicationScope`，不再挡 `onCreate`。
- 绑定恢复只 restore 图并翻 ready gate；sync / wake / Link 生产者在首帧之后启动。
- 绑定完成 / 默认 restore bootstrap 仍会在 bootstrap 前 `startNetworkProducers()`。

**后台保持连接**
- 设备级开关（Zephyr Link / 网络设置），默认关。
- 绑定账号开启后走 `ConnectionKeepAliveService`（`dataSync` 前台服务 + 通知停止按钮）。
- `WakeCoordinator` 在 hold-alive 时后台不拆 socket；前台开开关不重连。
- 本地模式不可开；解绑停服务。Android 13+ 开开关会要通知权限。

## 验证

本地（沙箱无 JVM，Kotlin 单测靠 CI）：
- `node --test` `android-cold-start-producers` / `android-cold-start-ai-runtime` / `rdp-local-engine` / `kotlin-symbols`：18/18
- Python 复现卡片描边 / 药丸裁字 / 启动顺序 / keep-alive 源码扫描：全过

CI 需要过：contracts / Android / iOS。
