### PR TITLE
fix(link): bind owned-sync bridge to private loopback, not public PORT

### DIFF
--- a/link-v2-go-proxy.js
+++ b/link-v2-go-proxy.js
@@ -41,7 +41,7 @@ function resolveBin() {
 }
 
 class GoLinkProcess {
-    constructor({ log, adminToken = '', syncBridgeUrl = '', syncBridgeToken = '' } = {}) {
+    constructor({ log, adminToken = '', syncBridgeUrl = '', syncBridgeUrlReady = null, syncBridgeToken = '' } = {}) {
         this.log = log || (() => {});
         this.proc = null;
         this.addr = null;
@@ -50,6 +50,7 @@ class GoLinkProcess {
         if (!adminToken) throw new Error('link-admin-token-required');
         this.adminToken = adminToken;
         this.syncBridgeUrl = syncBridgeUrl;
+        this.syncBridgeUrlReady = syncBridgeUrlReady;
         this.syncBridgeToken = syncBridgeToken;
         this.starting = null;
     }
@@ -62,6 +63,9 @@ class GoLinkProcess {
     }
 
     async _start() {
+        if (this.syncBridgeUrlReady) {
+            this.syncBridgeUrl = await this.syncBridgeUrlReady;
+        }
         const bin = resolveBin();
         if (!bin) throw Object.assign(new Error('link-go-binary-missing'), { code: 'link_go_missing' });
         const proc = spawn(bin, [], {
@@ -119,8 +123,8 @@ function stopLinkV2Go() {
     if (shared.proc) { shared.proc.stop(); shared.proc = null; }
 }
 
-function createLinkV2GoProxy({ log, enrollments, adminToken, syncBridgeUrl, syncBridgeToken } = {}) {
-    const proc = sharedProcess(log, { adminToken, syncBridgeUrl, syncBridgeToken });
+function createLinkV2GoProxy({ log, enrollments, adminToken, syncBridgeUrl, syncBridgeUrlReady, syncBridgeToken } = {}) {
+    const proc = sharedProcess(log, { adminToken, syncBridgeUrl, syncBridgeUrlReady, syncBridgeToken });
     // Devices the Go service is known to hold this process lifetime, so we only
     // re-register once per device per restart instead of on every handshake.
     const registered = new Set();

--- a/server.js
+++ b/server.js
@@ -201,6 +201,7 @@ const { negotiateRdpTls } = require('./server/rdp-cert-probe');
 let mobileV1OutboxDispatcher = null;
 let mobileV1Api = null;
 let linkV2EnrollmentApi = null;
+let linkInternalServer = null;
 let webDavProduction = null;
 let webDavSensitiveRateLimiter = null;
 let backupImportSensitiveRateLimiter = null;
@@ -650,6 +651,7 @@ for (const signal of ['SIGTERM', 'SIGINT']) {
         try { appChangeWakeRuntime?.close(); } catch {}
         try { await webDavProduction?.close(); } catch {}
         try { stopLinkV2Go(); } catch {}
+        try { linkInternalServer?.close(); } catch {}
         flushAllSshSessionHistory();
         process.exit(signal === 'SIGTERM' ? 0 : 130);
     });
@@ -8991,12 +8993,50 @@ try {
             storage,
             adminToken: linkSyncAdminToken,
         });
-        app.use('/internal/link', express.json({ limit: '4mb' }));
-        app.post('/internal/link/sync', (req, res) => linkSyncBridge.handle(req, res));
+        /* Owned-sync is a private loopback listener. It must not reuse the public
+         * HTTP/HTTPS port: Docker sets HTTP_ENABLED=false so PORT (default 3000,
+         * or whatever the operator mapped) never listens, and HTTPS_PORT is TLS.
+         * Pointing Go at that URL used to make every SYNC_OP a dispatch_failed.
+         * ZEPHYR_LINK_INTERNAL_PORT pins the loopback port when the operator
+         * needs a stable one; otherwise we bind an ephemeral port. */
+        const linkInternalApp = express();
+        linkInternalApp.disable('x-powered-by');
+        linkInternalApp.use((req, res, next) => {
+            const ip = req.socket && req.socket.remoteAddress;
+            if (ip !== '127.0.0.1' && ip !== '::1' && ip !== '::ffff:127.0.0.1') {
+                res.status(403).json({ ok: false, error: { code: 'forbidden', message: 'loopback only' } });
+                return;
+            }
+            next();
+        });
+        linkInternalApp.use('/internal/link', express.json({ limit: '4mb' }));
+        linkInternalApp.post('/internal/link/sync', (req, res) => linkSyncBridge.handle(req, res));
+        linkInternalServer = http.createServer(linkInternalApp);
+        const requestedInternalPort = Number(process.env.ZEPHYR_LINK_INTERNAL_PORT);
+        const linkInternalPort = Number.isInteger(requestedInternalPort) && requestedInternalPort >= 0
+            ? requestedInternalPort
+            : 0;
+        if (linkInternalPort > 0 && (
+            (HTTP_ENABLED && Number(PORT) === linkInternalPort) ||
+            (HTTPS_ENABLED && Number(HTTPS_PORT) === linkInternalPort)
+        )) {
+            throw new Error('ZEPHYR_LINK_INTERNAL_PORT must not collide with the public HTTP/HTTPS port');
+        }
+        const linkInternalReady = new Promise((resolve, reject) => {
+            const onError = (err) => reject(err);
+            linkInternalServer.once('error', onError);
+            linkInternalServer.listen(linkInternalPort, '127.0.0.1', () => {
+                linkInternalServer.removeListener('error', onError);
+                const addr = linkInternalServer.address();
+                const url = `http://127.0.0.1:${addr.port}/internal/link/sync`;
+                console.log('[link-v2] owned-sync bridge listening at', url);
+                resolve(url);
+            });
+        });
         const linkGo = createLinkV2GoProxy({
             enrollments,
             adminToken: linkSyncAdminToken,
-            syncBridgeUrl: `http://127.0.0.1:${PORT}/internal/link/sync`,
+            syncBridgeUrlReady: linkInternalReady,
             syncBridgeToken: linkSyncAdminToken,
             log: (...args) => console.log('[link-v2]', ...args),
         });

--- a/tests/test-server.mjs
+++ b/tests/test-server.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import https from 'node:https';
 import net from 'node:net';
 import path from 'node:path';
 import { createSecureTestDataDir, removeSecureTestDataDir } from './helpers/secure-data-dir.mjs';
@@ -45,21 +46,71 @@ function isRetryableBindFailure(error) {
     return /listen E(?:ADDRINUSE|ACCES)\b/.test(String(error?.message || ''));
 }
 
+function httpsFetch(url, init = {}) {
+    const parsed = new URL(url);
+    const headers = { ...(init.headers || {}) };
+    const body = init.body == null ? null : (
+        typeof init.body === 'string' || Buffer.isBuffer(init.body)
+            ? init.body
+            : Buffer.from(String(init.body))
+    );
+    if (body && !headers['content-length'] && !headers['Content-Length']) {
+        headers['content-length'] = String(Buffer.byteLength(body));
+    }
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: parsed.hostname,
+            port: parsed.port,
+            path: parsed.pathname + parsed.search,
+            method: String(init.method || 'GET').toUpperCase(),
+            headers,
+            rejectUnauthorized: false,
+        }, (res) => {
+            const chunks = [];
+            res.on('data', (chunk) => chunks.push(chunk));
+            res.on('end', () => {
+                const buf = Buffer.concat(chunks);
+                const headerBag = new Headers();
+                for (const [name, value] of Object.entries(res.headers)) {
+                    if (value == null) continue;
+                    if (Array.isArray(value)) value.forEach((item) => headerBag.append(name, item));
+                    else headerBag.set(name, String(value));
+                }
+                resolve(new Response(buf, { status: res.statusCode, headers: headerBag }));
+            });
+        });
+        req.on('error', reject);
+        if (body) req.write(body);
+        req.end();
+    });
+}
+
 export class TestServer {
-    constructor() {
+    constructor({ httpsOnly = false, linkInternalPort = null } = {}) {
         this.dataFixture = createSecureTestDataDir('zephyr-test-');
         this.dir = this.dataFixture.dataDir;
         this.port = null;
+        this.httpsPort = null;
+        this.linkInternalPort = linkInternalPort;
         this.aiHostPort = null;
         this.proc = null;
         this.instanceId = null;
+        this.httpsOnly = httpsOnly;
+        this.log = '';
+        this.agent = null;
     }
 
     async start() {
         let lastBindError = null;
         for (let attempt = 1; attempt <= MAX_BIND_ATTEMPTS; attempt += 1) {
-            const reservation = await reserveLoopbackPorts(2);
-            [this.port, this.aiHostPort] = reservation.ports;
+            /* HTTPS-only still reserves a PORT so the env looks like Docker:
+             * HTTP_ENABLED=false, PORT assigned, nothing listening there. */
+            const reservation = await reserveLoopbackPorts(this.httpsOnly ? 3 : 2);
+            if (this.httpsOnly) {
+                [this.port, this.httpsPort, this.aiHostPort] = reservation.ports;
+            } else {
+                [this.port, this.aiHostPort] = reservation.ports;
+            }
             await reservation.release();
             try {
                 return await this.startOnce();
@@ -75,9 +126,10 @@ export class TestServer {
     async startOnce() {
         const env = {
             ...process.env,
-            HTTP_ENABLED: 'true',
-            HTTPS_ENABLED: 'false',
+            HTTP_ENABLED: this.httpsOnly ? 'false' : 'true',
+            HTTPS_ENABLED: this.httpsOnly ? 'true' : 'false',
             PORT: String(this.port),
+            HTTPS_PORT: String(this.httpsPort || 3443),
             ZEPHYR_BIND_HOST: '127.0.0.1',
             ZEPHYR_AI_HOST_LISTEN: `127.0.0.1:${this.aiHostPort}`,
             ZEPHYR_AI_PLATFORM_HOST_URL: `http://127.0.0.1:${this.aiHostPort}`,
@@ -86,10 +138,10 @@ export class TestServer {
             ENCRYPTION_KEY: 'integration-test-key',
             NODE_ENV: 'production',
         };
+        if (this.linkInternalPort != null) {
+            env.ZEPHYR_LINK_INTERNAL_PORT = String(this.linkInternalPort);
+        }
         this.proc = spawn(process.execPath, ['server.js'], { cwd: REPO, env, stdio: ['ignore', 'pipe', 'pipe'] });
-        // Safety net: if the test runner is killed (SIGKILL, timeout, Ctrl-C)
-        // before `after` runs, the spawned server.js must not become an orphan
-        // holding the port. Register on the process and on common fatal signals.
         const procRef = this.proc;
         const killHard = () => { try { procRef.kill('SIGKILL'); } catch {} };
         const fatalSignals = ['SIGINT', 'SIGTERM', 'SIGHUP'];
@@ -100,27 +152,23 @@ export class TestServer {
         process.once('exit', killHard);
         for (const sig of fatalSignals) process.once(sig, killHard);
         procRef.once('exit', removeParentHooks);
-        let log = '';
-        this.proc.stdout.on('data', (d) => { log += d; });
+        this.proc.stdout.on('data', (d) => { this.log += d; });
         this.proc.stderr.on('data', (d) => {
-            log += d;
-            // Forward server stderr to the test process so crashes are visible
-            // in test output instead of being swallowed.
+            this.log += d;
             process.stderr.write(`[server:${this.port}] ${d}`);
         });
-        // If the server dies unexpectedly, surface why.
         this.proc.on('exit', (code, signal) => {
             if (code !== null && code !== 0) {
-                process.stderr.write(`[server:${this.port}] exited code=${code}\n${log.slice(-1500)}\n`);
+                process.stderr.write(`[server:${this.port}] exited code=${code}\n${this.log.slice(-1500)}\n`);
             }
         });
         const deadline = Date.now() + 45000;
         while (true) {
             if (this.proc.exitCode !== null || this.proc.signalCode !== null) {
-                throw new Error(`server exited (${this.proc.exitCode ?? this.proc.signalCode}):\n${log.slice(-2000)}`);
+                throw new Error(`server exited (${this.proc.exitCode ?? this.proc.signalCode}):\n${this.log.slice(-2000)}`);
             }
             try {
-                const r = await fetch(this.url('/healthz'));
+                const r = await this.fetch('/healthz');
                 if (r.ok) {
                     this.instanceId = (await r.json()).instanceId;
                     return this;
@@ -128,13 +176,22 @@ export class TestServer {
             } catch {}
             if (Date.now() > deadline) {
                 await this.stop();
-                throw new Error(`server did not become healthy:\n${log.slice(-3000)}`);
+                throw new Error(`server did not become healthy:\n${this.log.slice(-3000)}`);
             }
             await new Promise((r) => setTimeout(r, 250));
         }
     }
 
-    url(p) { return `http://127.0.0.1:${this.port}${p}`; }
+    url(p) {
+        if (this.httpsOnly) return `https://127.0.0.1:${this.httpsPort}${p}`;
+        return `http://127.0.0.1:${this.port}${p}`;
+    }
+
+    fetch(p, init = {}) {
+        const url = this.url(p);
+        if (!this.httpsOnly) return fetch(url, init);
+        return httpsFetch(url, init);
+    }
 
     async stop() {
         const proc = this.proc;
@@ -151,9 +208,8 @@ export class TestServer {
         removeSecureTestDataDir(this.dataFixture);
     }
 
-    /* login helper: returns a cookie header value */
     async login(username, password) {
-        const res = await fetch(this.url('/api/auth/login'), {
+        const res = await this.fetch('/api/auth/login', {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify({ username, password }),
@@ -166,10 +222,9 @@ export class TestServer {
         return { cookie: `zephyr_sid=${m[1]}`, body };
     }
 
-    /* first-boot convenience: login admin/admin and set a real password */
     async bootstrapAdmin(newPassword = 'admin-test-pass-1') {
         const { cookie } = await this.login('admin', 'admin');
-        const res = await fetch(this.url('/api/auth/change-password'), {
+        const res = await this.fetch('/api/auth/change-password', {
             method: 'POST',
             headers: { 'content-type': 'application/json', cookie },
             body: JSON.stringify({ currentPassword: 'admin', newPassword }),
@@ -179,7 +234,7 @@ export class TestServer {
     }
 
     async api(cookie, method, p, body) {
-        const res = await fetch(this.url(p), {
+        const res = await this.fetch(p, {
             method,
             headers: { 'content-type': 'application/json', ...(cookie ? { cookie } : {}) },
             body: body === undefined ? undefined : JSON.stringify(body),

--- a/zephyr_one/mobile/tests/android-link-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/android-link-runtime.test.mjs
@@ -141,6 +141,20 @@ test('server never caches a failed Go device registration', () => {
   assert.match(proxy, /link_device_registration_failed/);
 });
 
+test('owned-sync bridge is a private loopback listener, not the public HTTP port', () => {
+  const server = readRepo('server.js');
+  const proxy = readRepo('link-v2-go-proxy.js');
+  assert.match(server, /ZEPHYR_LINK_INTERNAL_PORT/);
+  assert.match(server, /owned-sync bridge listening at/);
+  assert.match(server, /must not collide with the public HTTP\/HTTPS port/);
+  assert.match(server, /linkInternalServer\.listen\(linkInternalPort, '127\.0\.0\.1'/);
+  assert.doesNotMatch(server, /syncBridgeUrl: `http:\/\/127\.0\.0\.1:\$\{PORT\}\/internal\/link\/sync`/);
+  assert.match(proxy, /syncBridgeUrlReady/);
+  const enrollment = read('tests/link-v2-enrollment.test.mjs');
+  assert.match(enrollment, /HTTPS-only deploy with a custom public port still delivers Link bootstrap/);
+  assert.match(enrollment, /httpsOnly: true, linkInternalPort: internalPort/);
+});
+
 test('embedded Link runtime has a CI freshness gate like the AI runtime', () => {
   const workflow = readRepo('.github/workflows/zephyr-one-mobile.yml');
   assert.match(workflow, /libzephyr_link\.so/);

--- a/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
+++ b/zephyr_one/mobile/tests/link-v2-enrollment.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -432,10 +433,13 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     await server.cleanup();
   });
 
+  assert.match(server.log, /owned-sync bridge listening at http:\/\/127\.0\.0\.1:\d+\/internal\/link\/sync/);
+  assert.doesNotMatch(server.log, new RegExp(`owned-sync bridge listening at http://127\\.0\\.0\\.1:${server.port}/`));
+
   const signing = generateSigningKey();
   const keys = deviceKeys(signing.jwk, 31);
   const deviceId = 'device-android-loop-0001';
-  const create = await fetch(server.url('/api/link/v2/enrollments'), {
+  const create = await server.fetch('/api/link/v2/enrollments', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -450,7 +454,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
   const created = await create.json();
 
   const login = await server.bootstrapAdmin();
-  const approve = await fetch(server.url('/link/approve'), {
+  const approve = await server.fetch('/link/approve', {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded', cookie: login.cookie },
     body: new URLSearchParams({
@@ -469,7 +473,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     secretHash: sha256(created.enrollmentSecret),
     serverId: created.serverId,
   });
-  const consume = await fetch(server.url(`/api/link/v2/enrollments/${created.bindId}/consume`), {
+  const consume = await server.fetch(`/api/link/v2/enrollments/${created.bindId}/consume`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -493,6 +497,10 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
     access: binding.accessCredential,
     deviceId,
     privateKey: signing.privateKey,
+    request: (url, init) => {
+      const parsed = new URL(url);
+      return server.fetch(parsed.pathname + parsed.search, init);
+    },
   });
   let pageToken = null;
   let snapshot = null;
@@ -521,7 +529,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
   assert.ok(devices.body.clients.some((client) => client.clientId === deviceId));
 
   const init = zsl.handshakeInitiator();
-  const handshake = await fetch(server.url('/api/link/v2/handshake'), {
+  const handshake = await server.fetch('/api/link/v2/handshake', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -538,7 +546,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
   });
   async function syncOp(body) {
     const sealed = session.seal(codec.pack({ kind: codec.KIND.SYNC_OP, body }));
-    const push = await fetch(server.url('/api/link/v2/push'), {
+    const push = await server.fetch('/api/link/v2/push', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -563,7 +571,7 @@ test('real server closes enrollment -> device list -> Go handshake -> SYNC_ACK l
   }
   async function rejectedSyncOp(body) {
     const sealed = session.seal(codec.pack({ kind: codec.KIND.SYNC_OP, body }));
-    const push = await fetch(server.url('/api/link/v2/push'), {
+    const push = await server.fetch('/api/link/v2/push', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -696,13 +704,13 @@ test('real Link two devices converge through canonical change log', async (t) =>
     const signing = generateSigningKey();
     const keys = deviceKeys(signing.jwk, suffix);
     const deviceId = `device-link-multi-${suffix.toString().padStart(4, '0')}`;
-    const create = await fetch(server.url('/api/link/v2/enrollments'), {
+    const create = await server.fetch('/api/link/v2/enrollments', {
       method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ deviceId, deviceName: name, platform: 'android', appVersion: 'e2e', keys }),
     });
     assert.equal(create.status, 201, await create.clone().text());
     const created = await create.json();
-    const approve = await fetch(server.url('/link/approve'), {
+    const approve = await server.fetch('/link/approve', {
       method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded', cookie: login.cookie },
       body: new URLSearchParams({ bindId: created.bindId, userCode: created.userCode, decision: 'approve' }),
     });
@@ -711,7 +719,7 @@ test('real Link two devices converge through canonical change log', async (t) =>
       bindId: created.bindId, deviceId, userCode: created.userCode, sas: created.sas,
       secretHash: sha256(created.enrollmentSecret), serverId: created.serverId,
     });
-    const consume = await fetch(server.url(`/api/link/v2/enrollments/${created.bindId}/consume`), {
+    const consume = await server.fetch(`/api/link/v2/enrollments/${created.bindId}/consume`, {
       method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ userCode: created.userCode, enrollmentSecret: created.enrollmentSecret,
         proof: signProof(signing.privateKey, payload), keys, syncIntervalSec: 300 }),
@@ -719,7 +727,7 @@ test('real Link two devices converge through canonical change log', async (t) =>
     assert.equal(consume.status, 200, await consume.clone().text());
     const binding = await consume.json();
     const init = zsl.handshakeInitiator();
-    const handshake = await fetch(server.url('/api/link/v2/handshake'), {
+    const handshake = await server.fetch('/api/link/v2/handshake', {
       method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ deviceId, x25519Public: Buffer.from(init.x25519Public).toString('base64url'),
         mlkemPublic: Buffer.from(init.mlkemPublic).toString('base64url') }),
@@ -730,7 +738,7 @@ test('real Link two devices converge through canonical change log', async (t) =>
       mlkemCiphertext: Buffer.from(hello.mlkemCiphertext, 'base64url') });
     const syncOp = async (body) => {
       const sealed = session.seal(codec.pack({ kind: codec.KIND.SYNC_OP, body }));
-      const push = await fetch(server.url('/api/link/v2/push'), { method: 'POST', headers: { 'content-type': 'application/json' },
+      const push = await server.fetch('/api/link/v2/push', { method: 'POST', headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ sessionId: hello.sessionId, seq: sealed.seq,
           iv: Buffer.from(sealed.iv).toString('base64url'), ct: Buffer.from(sealed.ct).toString('base64url'),
           tag: Buffer.from(sealed.tag).toString('base64url') }) });
@@ -760,4 +768,128 @@ test('real Link two devices converge through canonical change log', async (t) =>
     change.payload.title === 'from device one'));
   const ack = await two.syncOp({ op: 'ack', cursor: pulled.nextCursor, appliedOpIds: [] });
   assert.equal(ack.ok, true);
+});
+
+async function reservePort() {
+  const reservation = net.createServer();
+  await new Promise((resolve, reject) => {
+    reservation.once('error', reject);
+    reservation.listen({ host: '127.0.0.1', port: 0, exclusive: true }, resolve);
+  });
+  const port = reservation.address().port;
+  await new Promise((resolve) => reservation.close(resolve));
+  return port;
+}
+
+async function enrollLinkDevice(server, login, { deviceId, deviceName, fill }) {
+  const signing = generateSigningKey();
+  const keys = deviceKeys(signing.jwk, fill);
+  const create = await server.fetch('/api/link/v2/enrollments', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ deviceId, deviceName, platform: 'android', appVersion: 'e2e', keys }),
+  });
+  assert.equal(create.status, 201, await create.clone().text());
+  const created = await create.json();
+  const approve = await server.fetch('/link/approve', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', cookie: login.cookie },
+    body: new URLSearchParams({ bindId: created.bindId, userCode: created.userCode, decision: 'approve' }),
+  });
+  assert.equal(approve.status, 200, await approve.clone().text());
+  const payload = proofPayload({
+    bindId: created.bindId, deviceId, userCode: created.userCode, sas: created.sas,
+    secretHash: sha256(created.enrollmentSecret), serverId: created.serverId,
+  });
+  const consume = await server.fetch(`/api/link/v2/enrollments/${created.bindId}/consume`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      userCode: created.userCode,
+      enrollmentSecret: created.enrollmentSecret,
+      proof: signProof(signing.privateKey, payload),
+      keys,
+      syncIntervalSec: 300,
+    }),
+  });
+  assert.equal(consume.status, 200, await consume.clone().text());
+  const binding = await consume.json();
+  const init = zsl.handshakeInitiator();
+  const handshake = await server.fetch('/api/link/v2/handshake', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      deviceId,
+      x25519Public: Buffer.from(init.x25519Public).toString('base64url'),
+      mlkemPublic: Buffer.from(init.mlkemPublic).toString('base64url'),
+    }),
+  });
+  assert.equal(handshake.status, 200, await handshake.clone().text());
+  const hello = await handshake.json();
+  assert.ok(hello.mlkemCiphertext, 'ZSL/2 responder must return an ML-KEM-768 ciphertext');
+  const session = zsl.handshakeFinish(init, {
+    x25519Public: Buffer.from(hello.x25519Public, 'base64url'),
+    mlkemCiphertext: Buffer.from(hello.mlkemCiphertext, 'base64url'),
+  });
+  const syncOp = async (body) => {
+    const sealed = session.seal(codec.pack({ kind: codec.KIND.SYNC_OP, body }));
+    const push = await server.fetch('/api/link/v2/push', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        sessionId: hello.sessionId,
+        seq: sealed.seq,
+        iv: Buffer.from(sealed.iv).toString('base64url'),
+        ct: Buffer.from(sealed.ct).toString('base64url'),
+        tag: Buffer.from(sealed.tag).toString('base64url'),
+      }),
+    });
+    assert.equal(push.status, 200, await push.clone().text());
+    const reply = await push.json();
+    assert.equal(reply.ok, true, JSON.stringify(reply));
+    const unpacked = codec.unpack(session.open({
+      seq: reply.seq,
+      iv: Buffer.from(reply.iv, 'base64url'),
+      ct: Buffer.from(reply.ct, 'base64url'),
+      tag: Buffer.from(reply.tag, 'base64url'),
+    }));
+    assert.equal(unpacked.kind, codec.KIND.SYNC_ACK);
+    return unpacked.body;
+  };
+  return { deviceId, binding, syncOp };
+}
+
+test('HTTPS-only deploy with a custom public port still delivers Link bootstrap', async (t) => {
+  process.env.ZEPHYR_ONE_USE_BUILTIN_SQLITE = '1';
+  process.env.ZEPHYR_LINK_GO_BIN = buildCurrentGoLinkServer(t);
+  const { TestServer } = await import(pathToFileURL(path.join(repoRoot, 'tests', 'test-server.mjs')).href);
+  const internalPort = await reservePort();
+  const server = await new TestServer({ httpsOnly: true, linkInternalPort: internalPort }).start();
+  t.after(async () => { try { stopLinkV2Go(); } catch {} await server.cleanup(); });
+  assert.match(server.url('/healthz'), /^https:\/\//);
+  assert.notEqual(Number(server.port), Number(server.httpsPort));
+  assert.notEqual(internalPort, Number(server.port));
+  assert.notEqual(internalPort, Number(server.httpsPort));
+  assert.match(server.log, new RegExp(`owned-sync bridge listening at http://127\\.0\\.0\\.1:${internalPort}/internal/link/sync`));
+  assert.doesNotMatch(server.log, new RegExp(`owned-sync bridge listening at http://127\\.0\\.0\\.1:${server.port}/`));
+
+  const login = await server.bootstrapAdmin();
+  const note = await server.api(login.cookie, 'POST', '/api/notes', {
+    title: 'https-only-bootstrap',
+    content: 'must arrive without public HTTP',
+  });
+  assert.equal(note.status, 200, JSON.stringify(note.body));
+  const noteId = note.body.note.noteId;
+  const { syncOp } = await enrollLinkDevice(server, login, {
+    deviceId: 'device-https-only-0001',
+    deviceName: 'Pixel HTTPS',
+    fill: 51,
+  });
+  const bootstrap = await syncOp({ op: 'bootstrap', pageSize: 100 });
+  assert.equal(bootstrap.ok, true, JSON.stringify(bootstrap));
+  assert.equal(bootstrap.complete, true, JSON.stringify(bootstrap));
+  bootstrap.entities.forEach(assertAndroidSyncChange);
+  assert.ok(bootstrap.entities.some((change) =>
+    change.entityType === 'note' && change.entityId === noteId && change.payload.title === 'https-only-bootstrap'
+  ), JSON.stringify(bootstrap.entities.map((change) => ({ type: change.entityType, id: change.entityId, title: change.payload?.title }))));
 });

--- a/zephyr_one/mobile/tests/mobile-v1-proof-client.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-proof-client.mjs
@@ -15,7 +15,7 @@ async function bodyBytes(body) {
  * Test-only HTTP client for the two-request proof protocol. Values are getters
  * because bind/refresh rotates credentials after the helper is constructed.
  */
-export function createProofClient({ base, access, deviceId, privateKey }) {
+export function createProofClient({ base, access, deviceId, privateKey, request = fetch } = {}) {
   return async function proofFetch(pathname, init = {}) {
     const origin = typeof base === 'function' ? base() : base;
     const credential = typeof access === 'function' ? access() : access;
@@ -24,7 +24,7 @@ export function createProofClient({ base, access, deviceId, privateKey }) {
     const method = String(init.method || 'GET').toUpperCase();
     const bytes = await bodyBytes(init.body);
     const digest = crypto.createHash('sha256').update(bytes).digest('base64');
-    const challengeResponse = await fetch(origin + '/api/mobile/v1/devices/proof-challenge', {
+    const challengeResponse = await request(origin + '/api/mobile/v1/devices/proof-challenge', {
       method: 'POST',
       headers: { authorization: 'Bearer ' + credential, 'content-type': 'application/json' },
       body: JSON.stringify({ method, path: pathname, bodySha256: digest }),
@@ -53,6 +53,6 @@ export function createProofClient({ base, access, deviceId, privateKey }) {
     headers.set('x-zephyr-device-proof', signature);
     headers.set('x-zephyr-proof-timestamp', String(challenge.timestamp));
     headers.set('x-zephyr-server-nonce', challenge.nonce);
-    return fetch(origin + pathname, { ...init, headers });
+    return request(origin + pathname, { ...init, headers });
   };
 }


### PR DESCRIPTION
## Why

True-device owned-sync on `v1.1.523` still returned empty data. Enrollment and ZSL/2 handshake succeeded; `/link/push` bootstrap came back **502 `dispatch_failed`**.

The Go child posts SYNC_OP to `ZEPHYR_LINK_SYNC_BRIDGE`. That URL was `http://127.0.0.1:${PORT}/internal/link/sync`. Docker (and any HTTPS-only deploy) sets `HTTP_ENABLED=false`, so `PORT` (default 3000, or whatever the operator mapped) never listens. Connection refused → dispatch_failed → empty mirror. Existing closed-loop tests all set `HTTP_ENABLED=true`, so they never saw this.

The Android ACK JSON crash from #87 is a separate layer. This is why content still did not arrive after that fix.

## Fix

- Bind a **private loopback** HTTP listener for `/internal/link/sync`. Default port is ephemeral (`listen(0)`). Operators can pin `ZEPHYR_LINK_INTERNAL_PORT`.
- Refuse a collision with the public HTTP or HTTPS port.
- Gate the listener to 127.0.0.1 / ::1. Do not expose the sync core on the public socket.
- Go spawn waits for the listener (`syncBridgeUrlReady`) so the child never starts against a dead URL.
- Public `PORT` / `HTTPS_PORT` remain operator-controlled and are no longer used as the internal bridge address.

## Tests

- HTTP closed loop still asserts the bridge URL is **not** `127.0.0.1:${PORT}`.
- New: HTTPS-only + custom `ZEPHYR_LINK_INTERNAL_PORT` enrolls a device, completes ZSL/2 (X25519 + ML-KEM-768 ciphertext required), and bootstrap delivers a server-authored note.
- Two-device converge still green.
- Static contract: no `syncBridgeUrl: http://127.0.0.1:${PORT}/internal/link/sync`.

Verified on the test host (Node 22 + Go 1.24):
- `real server closes enrollment -> device list -> Go handshake -> SYNC_ACK loop` pass
- `HTTPS-only deploy with a custom public port still delivers Link bootstrap` pass
- `real Link two devices converge through canonical change log` pass
- `android-link-runtime` 11/11

Do not merge until CI is green. After merge: Docker `v1.1.524`. Mobile pre52 already has the ACK JSON fix; it still needs this main-end image.