### PR TITLE
fix(web): restore webssh click focus and docked panel geometry

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
     <link rel="modulepreload" href="app.js?v=20260811-webdav1">
     <link rel="modulepreload" href="floating-panel.js?v=20260731-panel-drag-physics4">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin8">
 </head>
 <body class="app-body">
     <div class="app-shell">

--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,7 @@ import { createNotesController } from './notes.js?v=20260811-webdav1';
 import { renderMarkdown as renderMarkdownCore, renderInlineMarkdown as renderInlineMarkdownCore } from './markdown.js?v=20260720-notes-md1';
 import { t, initI18n, setLocale, getLocale, applyDomI18n, onLocaleChange, formatDateTime } from './i18n/runtime.js?v=20260811-webdav1';
 import { localizeActivityMessage } from './activity-i18n.js?v=20260811-webdav1';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin8';
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));

--- a/public/novnc.html
+++ b/public/novnc.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - VNC 远程桌面">Zephyr - VNC 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin8">
 </head>
 <body>
     <div class="novnc-page rdp-page">

--- a/public/novnc.js
+++ b/public/novnc.js
@@ -7,7 +7,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin8';
 
 const $ = (sel) => document.querySelector(sel);
 const NOVNC_CLIENT_VERSION = '2026-06-14-theme-palettes';

--- a/public/panel-pin.js
+++ b/public/panel-pin.js
@@ -21,8 +21,18 @@ function scopeFor(page) {
     const style = getComputedStyle(page);
     const borderX = (Number.parseFloat(style.borderLeftWidth) || 0) + (Number.parseFloat(style.borderRightWidth) || 0);
     const borderY = (Number.parseFloat(style.borderTopWidth) || 0) + (Number.parseFloat(style.borderBottomWidth) || 0);
-    const width = (page.clientWidth || rect.width || window.innerWidth) + borderX;
-    const height = (page.clientHeight || rect.height || window.innerHeight) + borderY;
+    const viewport = window.visualViewport;
+    const vvWidth = viewport?.width || window.innerWidth;
+    const vvHeight = viewport?.height || window.innerHeight;
+    const vvLeft = viewport?.offsetLeft || 0;
+    const vvTop = viewport?.offsetTop || 0;
+    // A dock is viewport chrome. The page element can be an iframe child whose
+    // CSS height lags the visual viewport by a few px; use the visual viewport
+    // as the floor so bottom/left/right seams cannot open.
+    const width = Math.max((page.clientWidth || rect.width || window.innerWidth) + borderX, vvWidth);
+    const height = Math.max((page.clientHeight || rect.height || window.innerHeight) + borderY, vvHeight);
+    const left = Math.min(rect.left, vvLeft);
+    const top = Math.min(rect.top, vvTop);
     // `.main-nav` is a direct child of .app-shell, but a `.terminal-page` can be
     // embedded inside another shell. Use local chrome only and never climb out
     // into an ancestor nav; that only creates a bogus white band above docks.
@@ -31,7 +41,7 @@ function scopeFor(page) {
     const topbarHeight = topbar?.offsetHeight || 0;
     // Pinned windows use position:fixed so RDP/VNC windows (whose normal parent
     // is the display stage) can still cover the page chrome exactly like SSH.
-    return { left: rect.left, top: rect.top, width, height, topbarHeight };
+    return { left, top, width, height, topbarHeight };
 }
 
 function rememberNormalGeometry(panel) {
@@ -69,18 +79,13 @@ function halfInset(page) {
     }, 0);
 }
 
-function pageSafeInset(page, side) {
-    const value = Number.parseFloat(getComputedStyle(page)[`padding${side}`] || '0') || 0;
-    return Math.max(0, Math.round(value));
-}
-
 function applyInsets(page, { bottomOverride = null } = {}) {
     const left = sideInset(page, 'left');
     const right = sideInset(page, 'right');
-    // A bottom dock covers the page's own bottom safe padding, so content must
-    // reserve dock height + that padding back to keep the terminal above it.
-    const dock = bottomOverride ?? halfInset(page);
-    const bottom = dock > 0 ? dock + pageSafeInset(page, 'Bottom') : 0;
+    // A bottom dock covers the page's own bottom safe padding; the CSS rule
+    // already reserves safe-area separately. Adding both here pushed the SSH
+    // terminal completely off-screen while resizing the dock.
+    const bottom = bottomOverride ?? halfInset(page);
     page.style.setProperty('--pin-inset-left', `${left}px`);
     page.style.setProperty('--pin-inset-right', `${right}px`);
     page.style.setProperty('--pin-inset-bottom', `${bottom}px`);
@@ -566,12 +571,14 @@ export function attachDesktopPanelPin(page, panel, { dragHandle, layoutButton, o
     observer.observe(panel, { attributes: true, attributeFilter: ['class', 'style', 'hidden'] });
     panel._pinObserver = observer;
 
-    window.addEventListener('resize', () => {
+    const onViewportResize = () => {
         if (!panel.dataset.pinSide) return;
         place(panel);
         panelGroup(panel._pinPage).forEach((other) => other !== panel && place(other));
         applyInsets(panel._pinPage);
-    });
+    };
+    window.addEventListener('resize', onViewportResize);
+    window.visualViewport?.addEventListener?.('resize', onViewportResize);
     return true;
 }
 

--- a/public/rdp-wasm-client.js
+++ b/public/rdp-wasm-client.js
@@ -27,7 +27,7 @@ import {
     applyPanelLayout,
     closePanelLayoutMenu,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin8';
 import {
     subscribeAgentEvents,
     unsubscribeAgentEvents,

--- a/public/rdp.html
+++ b/public/rdp.html
@@ -6,7 +6,7 @@
     <title data-i18n="Zephyr - 远程桌面">Zephyr - 远程桌面</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin8">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260730-rdp-topbar-ssh-scroll2">
 </head>
 <body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin7';
+const CACHE_NAME = 'zephyr-static-20260830-desktop-panel-pin8';
 const PRECACHE = [
     '/app.js?v=20260811-webdav1',
     '/style.css?v=20260811-webdav1',
@@ -9,15 +9,15 @@ const PRECACHE = [
     '/notes.js?v=20260811-webdav1',
     '/preview-mock.js?v=20260811-webdav1',
     '/theme-runtime.js?v=20260615-visual-color-picker',
-    '/terminal.js?v=20260801-terminal-grid-converge1-mobile-ime2',
-    '/telnet-terminal.js?v=20260801-terminal-grid-converge1-mobile-ime2',
+    '/terminal.js?v=20260830-terminal-focus1',
+    '/telnet-terminal.js?v=20260830-terminal-focus1',
     '/terminal-history-gesture.js?v=20260801-terminal-stability1',
     '/terminal-grid-convergence.js?v=20260801-terminal-grid-converge1',
     '/vendor/wterm-fork/index.js?v=20260801-terminal-stability1',
     '/vendor/wterm-fork/core/xterm-headless-register.js?v=20260801-terminal-stability1',
     '/floating-panel.js?v=20260731-panel-drag-physics4',
-    '/panel-pin.js?v=20260830-desktop-panel-pin7',
-    '/panel-pin.css?v=20260830-desktop-panel-pin7',
+    '/panel-pin.js?v=20260830-desktop-panel-pin8',
+    '/panel-pin.css?v=20260830-desktop-panel-pin8',
     '/markdown.js?v=20260720-notes-md1',
 ];
 const MAX_CACHE_ENTRIES = 160;

--- a/public/telnet-terminal.html
+++ b/public/telnet-terminal.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=overlays-content">
     <title data-i18n="Zephyr - Telnet 终端">Zephyr - Telnet 终端</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
-    <link rel="modulepreload" href="telnet-terminal.js?v=20260801-terminal-grid-converge1-mobile-ime2">
+    <link rel="modulepreload" href="telnet-terminal.js?v=20260830-terminal-focus1">
     <link rel="modulepreload" href="theme-runtime.js?v=20260725-telnet-page-split1">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin8">
     <script type="importmap">
         {
             "imports": {
@@ -166,6 +166,6 @@
             </div>
         </div>
     </div>
-    <script src="telnet-terminal.js?v=20260801-terminal-grid-converge1-mobile-ime2" type="module"></script>
+    <script src="telnet-terminal.js?v=20260830-terminal-focus1" type="module"></script>
 </body>
 </html>

--- a/public/telnet-terminal.js
+++ b/public/telnet-terminal.js
@@ -34,7 +34,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin8';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=overlays-content">
     <title data-i18n="Zephyr - 终端">Zephyr - 终端</title>
     <link rel="icon" type="image/svg+xml" href="/zephyr-mark.svg">
-    <link rel="modulepreload" href="terminal.js?v=20260801-terminal-grid-converge1-mobile-ime2">
+    <link rel="modulepreload" href="terminal.js?v=20260830-terminal-focus1">
     <link rel="modulepreload" href="theme-runtime.js?v=20260725-telnet-page-split1">
     <link rel="modulepreload" href="i18n/runtime.js?v=20260728-ai-handle-only-drag1">
     <link rel="stylesheet" href="/vendor/wterm-fork/terminal.css?v=20260801-terminal-grid-converge1">
     <link rel="stylesheet" href="style.css?v=20260811-webdav1">
-    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin7">
+    <link rel="stylesheet" href="panel-pin.css?v=20260830-desktop-panel-pin8">
     <link rel="stylesheet" href="/vendor/viewerjs/viewer.min.css">
     <link rel="stylesheet" href="preview/image/image-preview.css?v=20260725-telnet-page-split1">
     <link rel="stylesheet" href="preview/media/media-preview.css?v=20260725-telnet-page-split1">
@@ -365,6 +365,6 @@
     <script src="preview/image/image-preview.js?v=20260731-panel-drag-physics4"></script>
     <script src="preview/media/media-preview.js?v=20260731-panel-drag-physics4"></script>
     <script src="editor/zephyr-editor.bundle.js?v=20260725-telnet-page-split1" type="module"></script>
-    <script src="terminal.js?v=20260801-terminal-grid-converge1-mobile-ime2" type="module"></script>
+    <script src="terminal.js?v=20260830-terminal-focus1" type="module"></script>
 </body>
 </html>

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -33,7 +33,7 @@ import {
     consumeLayoutClickSuppression,
     markLayoutClickSuppressed,
 } from './floating-panel.js?v=20260731-panel-drag-physics4';
-import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin7';
+import { attachDesktopPanelPin } from './panel-pin.js?v=20260830-desktop-panel-pin8';
 
 /** @type {ReturnType<typeof createTerminalSurfaceController> | null} */
 let terminalSurface = null;
@@ -12725,6 +12725,28 @@ async function initWTerm(connectionToken = activeConnectionToken, { followOnConn
     term.onClipboard = (request) => { void handleTerminalClipboardRequest(request); };
     wtermWrapper.addEventListener('pointerdown', noteTerminalUserGesture, { passive: true });
     wtermWrapper.addEventListener('keydown', noteTerminalUserGesture, true);
+    // Desktop parity with ordinary terminals: any clean click in the SSH text
+    // area hands keyboard focus back to wterm. The only exception is an active
+    // selection/copy gesture, where focusing the hidden textarea would collapse
+    // the text the user is trying to copy.
+    if (!wtermWrapper._zephyrDesktopClickFocusBound) {
+        wtermWrapper._zephyrDesktopClickFocusBound = true;
+        wtermWrapper.addEventListener('mousedown', (event) => {
+            if (isTouchKeyboardDevice() || event.button !== 0) return;
+            if (hasLiveTerminalSelection()) return;
+            if (event.target?.closest?.('a, button, input, textarea, select, [contenteditable="true"]')) return;
+            window.setTimeout(() => {
+                if (hasLiveTerminalSelection()) return;
+                try { term?.focus?.(); } catch (_) {}
+            }, 0);
+        });
+        wtermWrapper.addEventListener('click', (event) => {
+            if (isTouchKeyboardDevice() || event.button !== 0) return;
+            if (hasLiveTerminalSelection()) return;
+            if (event.target?.closest?.('a, button, input, textarea, select, [contenteditable="true"]')) return;
+            try { term?.focus?.(); } catch (_) {}
+        });
+    }
     // Desktop double-click → xterm word separators; browser copies selection only.
     if (!wtermWrapper._zephyrWordSelectBound) {
         wtermWrapper._zephyrWordSelectBound = true;

--- a/tests/desktop-panel-pin-contract.test.mjs
+++ b/tests/desktop-panel-pin-contract.test.mjs
@@ -55,10 +55,20 @@ test('panel pins are desktop-only and mobile cannot receive controls', () => {
 test('side rails stay above bottom dock while bottom dock owns and covers the full lower row', () => {
     assert.match(pin, /function halfInset\(page\)/);
     assert.match(pin, /const height = fullHeight - halfInset\(page\)/);
+    assert.match(pin, /const viewport = window\.visualViewport;/);
+    assert.match(pin, /Math\.max\(\(page\.clientWidth \|\| rect\.width \|\| window\.innerWidth\) \+ borderX, vvWidth\)/);
+    assert.match(pin, /Math\.max\(\(page\.clientHeight \|\| rect\.height \|\| window\.innerHeight\) \+ borderY, vvHeight\)/);
     assert.match(pin, /left: `\$\{scope\.left - edge\.left\}px`, top: `\$\{scope\.top \+ fullHeight - height\}px`,\n            width: `\$\{scope\.width \+ edge\.left \+ edge\.right\}px`, height: `\$\{height \+ edge\.bottom\}px`/);
     assert.match(pin, /applyInsets\(page, \{ bottomOverride: next \}\)/);
+    assert.match(pin, /window\.visualViewport\?\.addEventListener\?\.\('resize', onViewportResize\)/);
     assert.match(css, /pin-has-bottom/);
     assert.match(css, /var\(--pin-inset-bottom, 0px\)/);
+});
+
+test('bottom dock inset does not double-add the page safe padding and push SSH off-screen', () => {
+    assert.match(pin, /const bottom = bottomOverride \?\? halfInset\(page\);/);
+    assert.doesNotMatch(pin, /pageSafeInset/);
+    assert.match(css, /padding-bottom: calc\(max\(4px, env\(safe-area-inset-bottom\)\) \+ var\(--pin-inset-bottom, 0px\)\)/);
 });
 
 test('bottom dock locks both pin buttons and supports top-handle vertical resize', () => {
@@ -118,7 +128,7 @@ test('nested cloned panels are explicitly reset to ordinary floating windows', (
 test('all desktop top-level panel surfaces are wired; demo is not referenced', () => {
     for (const source of [terminal, telnet, rdp, vnc, app]) {
         assert.match(source, /attachDesktopPanelPin/);
-        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin7/);
+        assert.match(source, /panel-pin\.js\?v=20260830-desktop-panel-pin8/);
         assert.doesNotMatch(source, /panel-pin-demo/);
     }
     for (const name of ['fileManager', 'infoModal', 'dockerPanel', 'snippetPanel', 'shortcutPanel']) assert.ok(terminal.includes(name));
@@ -139,14 +149,14 @@ test('pinning uses complete geometry and surface transitions without a flash ani
 test('all shipped pages load pin styling without demo artifact', () => {
     for (const file of ['public/terminal.html', 'public/telnet-terminal.html', 'public/rdp.html', 'public/novnc.html', 'public/app.html']) {
         const html = read(file);
-        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin7/);
+        assert.match(html, /panel-pin\.css\?v=20260830-desktop-panel-pin8/);
         assert.doesNotMatch(html, /panel-pin-demo/);
     }
     assert.equal(fs.existsSync(path.join(root, 'public/panel-pin-demo.html')), false);
 });
 
 test('service worker rotates and precaches both panel-pin assets', () => {
-    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin7/);
-    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin7/);
-    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin7/);
+    assert.match(sw, /zephyr-static-20260830-desktop-panel-pin8/);
+    assert.match(sw, /\/panel-pin\.js\?v=20260830-desktop-panel-pin8/);
+    assert.match(sw, /\/panel-pin\.css\?v=20260830-desktop-panel-pin8/);
 });

--- a/tests/ssh-terminal-stability-contract.test.mjs
+++ b/tests/ssh-terminal-stability-contract.test.mjs
@@ -56,6 +56,14 @@ test('snapshot replay restores carriage-return progress and alternate screen wit
     restored.dispose();
 });
 
+test('desktop terminal clicks focus wterm unless a live selection is being copied', () => {
+    assert.match(terminalSrc, /_zephyrDesktopClickFocusBound = true/);
+    assert.match(terminalSrc, /if \(isTouchKeyboardDevice\(\) \|\| event\.button !== 0\) return;/);
+    assert.match(terminalSrc, /if \(hasLiveTerminalSelection\(\)\) return;/);
+    assert.match(terminalSrc, /event\.target\?\.closest\?\.\('a, button, input, textarea, select, \[contenteditable="true"\]'\)/);
+    assert.match(terminalSrc, /try \{ term\?\.focus\?\.\(\); \} catch \(_\) \{\}/);
+});
+
 test('mobile copy completion collapses native selection and explicitly resumes IME input', () => {
     for (const [label, src] of [['ssh', terminalSrc], ['telnet', telnetSrc]]) {
         assert.match(src, /function exitMobileTerminalSelectionMode/, `${label}: exit helper`);


### PR DESCRIPTION
## 修复点
- 桌面端 WebSSH 点击 SSH 文本区域即恢复输入焦点；只有在正在复制/选中文本时才不把焦点抢回 wterm。
- bottom dock 几何改为以 visualViewport 为下限，同时监听 `visualViewport.resize`，避免页面 iframe/布局高度落后导致的右侧/底部白缝。
- 修复 bottom inset 双倍叠加页面自身 bottom safe padding 的问题；之前拖动下 1/2 会把 SSH 操作界面推出可视区。
- cache revision：`desktop-panel-pin8`、`terminal-focus1`。

## 验证
- `node --test tests/desktop-panel-pin-contract.test.mjs` 16/16
- `node --test tests/ssh-terminal-stability-contract.test.mjs` 6/6
- `node --test tests/*panel*contract.test.mjs` 34/34
- `node --check public/panel-pin.js public/terminal.js`
- `git diff --check`
