### PR TITLE
fix(sync): seal owned secrets and send full note bodies on downlink

### DIFF
--- a/ai-provider-service.js
+++ b/ai-provider-service.js
@@ -377,11 +377,11 @@ class AiProviderService {
                 return out;
             });
     }
-    listOwned(userId, { includeDeleted = false } = {}) {
+    listOwned(userId, { includeDeleted = false, includeSecret = false } = {}) {
         const sql = includeDeleted
             ? 'SELECT * FROM ai_providers WHERE owner_user_id=? ORDER BY updated_at DESC'
             : 'SELECT * FROM ai_providers WHERE owner_user_id=? AND deleted_at IS NULL ORDER BY updated_at DESC';
-        return this.db.prepare(sql).all(String(userId)).map((r) => this._row(r));
+        return this.db.prepare(sql).all(String(userId)).map((r) => this._row(r, { includeSecret }));
     }
     getOwned(userId, id, opts = {}) {
         const sql = opts.includeDeleted

--- a/mobile-v1-ai-knowledge-entities.js
+++ b/mobile-v1-ai-knowledge-entities.js
@@ -340,6 +340,12 @@ class AiKnowledgeService {
         return {};
     }
 
+    _withEnvSecret(userId, row) {
+        if (!row) return row;
+        const value = this._envValue(userId, row.id);
+        return value ? { ...row, value } : row;
+    }
+
     list(userOrId, type) {
         const user = requireOwner(userOrId);
         type = this._assertType(type);
@@ -352,6 +358,24 @@ class AiKnowledgeService {
         const row = this._row(this.stmtGet.get(String(user.userId), type, validId(id)));
         if (!row || (!includeDeleted && row.deletedAt != null)) return null;
         return row;
+    }
+
+    /**
+     * Mobile sync only. Web listForUser must never see env plaintext; the
+     * projector seals `value` into a device envelope before it hits the wire.
+     */
+    listOwnedForSync(userOrId, type) {
+        const user = requireOwner(userOrId);
+        const rows = this.list(user, type);
+        return type === 'aiEnv'
+            ? rows.map((row) => this._withEnvSecret(user.userId, row))
+            : rows;
+    }
+
+    readOwnedForSync(userOrId, type, id, options = {}) {
+        const user = requireOwner(userOrId);
+        const row = this.read(user, type, id, options);
+        return type === 'aiEnv' ? this._withEnvSecret(user.userId, row) : row;
     }
 
     residency(userOrId, type, id) {
@@ -634,8 +658,8 @@ function createAiKnowledgeEntityAdapters({ db, store, changeBridge, service, now
         adapters.set(type, {
             idOf: (row) => row.id,
             residency: (user, id) => knowledge.residency(user, type, id),
-            list: (user) => knowledge.list(user, type),
-            read: (user, id) => knowledge.read(user, type, id),
+            list: (user) => knowledge.listOwnedForSync(user, type),
+            read: (user, id) => knowledge.readOwnedForSync(user, type, id),
             revisionOf: (row) => Math.max(1, Number(row?.revision) || 1),
             create: (user, id, patch, mutationContext = {}) => knowledge.writeFromMobile(user, type, id, patch, mutationContext),
             update: (user, id, patch, mutationContext = {}) => {

--- a/mobile-v1-ai-provider-entities.js
+++ b/mobile-v1-ai-provider-entities.js
@@ -219,7 +219,7 @@ function safeModels(models) {
 function projectAiProvider(row) {
     if (!row) return null;
     if (row.deletedAt != null) return null;
-    return {
+    const projected = {
         id: stableId(row.id),
         ownerUserId: String(row.ownerUserId || ''),
         revision: Math.max(1, Number(row.revision) || 1),
@@ -237,6 +237,12 @@ function projectAiProvider(row) {
         sharedUserIds: [...new Set((Array.isArray(row.sharedUserIds) ? row.sharedUserIds : []).map(String).filter(Boolean))].slice(0, 200),
         enabled: row.enabled !== false,
     };
+    /* Plaintext stays on the adapter row only long enough for MobileV1Api to
+     * seal a device envelope. projectPayload strips the field before wire. */
+    if (typeof row.apiKey === 'string' && row.apiKey && row.apiKey !== '******') {
+        projected.apiKey = row.apiKey;
+    }
+    return projected;
 }
 
 function mergeModelsWithServerOnlyFields(current, incoming) {
@@ -278,8 +284,8 @@ function createAiProviderEntityAdapters({ registry, service } = {}) {
         idOf: (row) => stableId(row?.id),
         revisionOf: (row) => Math.max(1, Number(row?.revision) || 1),
         residency: (user, id) => service.residency(user?.userId, id),
-        list: (user) => service.listOwned(user?.userId).map(projectAiProvider),
-        read: (user, id) => projectAiProvider(service.readOwned(user?.userId, id)),
+        list: (user) => service.listOwned(user?.userId, { includeSecret: true }).map(projectAiProvider),
+        read: (user, id) => projectAiProvider(service.readOwned(user?.userId, id, { includeSecret: true })),
         create: (user, id, patch, mutationContext = {}) => {
             id = stableId(id);
             if (service.residency(user?.userId, id) !== 'missing') {

--- a/mobile-v1-entities.js
+++ b/mobile-v1-entities.js
@@ -118,16 +118,51 @@ function residencyOf(rawLookup, type, user, id) {
  * "unknown fields are retained but never emitted in a One-authored fieldMask",
  * so the value round-trips while the client is forbidden from editing it.
  */
+function presenceFlag(fieldName) {
+    const name = String(fieldName || '');
+    return 'has' + name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function hasStoredSecret(value) {
+    if (value == null) return false;
+    if (typeof value === 'boolean') return value === true;
+    const text = String(value);
+    return text.length > 0 && text !== '******';
+}
+
+function extractSecrets(spec, row) {
+    const secrets = {};
+    if (!row) return secrets;
+    for (const field of spec.secretFields || []) {
+        if (hasStoredSecret(row[field])) secrets[field] = String(row[field]);
+    }
+    return secrets;
+}
+
 function projectPayload(spec, row) {
     if (!row) return {};
     const drop = new Set([
         ...(spec.secretFields || []),
         ...(spec.deviceLocalFields || []),
     ]);
+    /* Connection/proxy/sshKey web-library extras must not ride the owned
+     * mirror. `capabilities` is a real resourceAcl field, so it cannot be
+     * dropped globally; only strip the host-library copies here. */
+    if (spec.type === 'connection' || spec.type === 'proxy' || spec.type === 'sshKey' || spec.type === 'jumpHost') {
+        drop.add('capabilities');
+        drop.add('owner');
+    }
+    if (spec.type === 'note') drop.add('preview');
     const payload = {};
     for (const [key, value] of Object.entries(row)) {
         if (drop.has(key)) continue;
         payload[key] = value;
+    }
+    /* One refuses a secret-bearing row whose presence flags are missing, and
+     * refuses hasX=true without a matching device envelope. Always emit the
+     * boolean, including false, so an empty-secret connection can still sync. */
+    for (const field of spec.secretFields || []) {
+        payload[presenceFlag(field)] = hasStoredSecret(row[field]);
     }
     return payload;
 }
@@ -224,14 +259,14 @@ function createEntityAdapters({
     adapters.set('connection', {
         idOf: (row) => row.id,
         residency: (user, id) => residencyOf(rawLookup, 'connection', user, id),
-        list: (user) => resourceService.listConnections(user, { includeEphemeral: false })
-            .filter((row) => row.ownerUserId === user.userId),
+        list: (user) => resourceService.storage.listAllConnectionRows()
+            .filter((row) => row && row.ownerUserId === user.userId && !row.ephemeral),
         read: (user, id) => readOwned(
             rawLookup,
             'connection',
             user,
             id,
-            () => resourceService.getConnection(user, id),
+            () => resourceService.storage.getConnectionById(id),
         ),
         revisionOf: (row) => Math.max(1, Number(row.revision) || 1),
         create: (user, id, patch, mutationContext) => {
@@ -269,8 +304,7 @@ function createEntityAdapters({
         adapters.set(type, {
             idOf: (row) => row.id,
             residency: (user, id) => residencyOf(rawLookup, type, user, id),
-            list: (user) => resourceService.listOwned(user, type)
-                .filter((row) => row.ownerUserId === user.userId),
+            list: (user) => resourceService.listOwnedRawForSync(user, type),
             read: (user, id) => readOwned(
                 rawLookup,
                 type,
@@ -301,11 +335,8 @@ function createEntityAdapters({
         adapters.set('note', {
             idOf: (row) => row.noteId,
             residency: (user, id) => residencyOf(rawLookup, 'note', user, id),
-            list: (user) => {
-                const result = notesService.list(user, { limit: 500 });
-                const rows = result.items || result.notes || [];
-                return rows.filter((row) => row.ownerUserId === user.userId);
-            },
+            list: (user) => notesService.listOwnedForSync(user)
+                .filter((row) => row.ownerUserId === user.userId),
             read: (user, id) => readOwned(
                 rawLookup,
                 'note',
@@ -473,4 +504,12 @@ function connectionDefaults(id, patch) {
     };
 }
 
-module.exports = { createEntityAdapters, projectPayload, assertMaskAllowed, connectionDefaults };
+module.exports = {
+    createEntityAdapters,
+    projectPayload,
+    extractSecrets,
+    presenceFlag,
+    hasStoredSecret,
+    assertMaskAllowed,
+    connectionDefaults,
+};

--- a/mobile-v1-routes.js
+++ b/mobile-v1-routes.js
@@ -41,7 +41,7 @@ const {
     PROOF_MAX_ISSUES_PER_MINUTE,
 } = require('./mobile-v1-store');
 const { MobileV1BlobManager } = require('./mobile-v1-blob-manager');
-const { createEntityAdapters, projectPayload, assertMaskAllowed } = require('./mobile-v1-entities');
+const { createEntityAdapters, projectPayload, extractSecrets, assertMaskAllowed } = require('./mobile-v1-entities');
 const { SharedResourceApi, noStore } = require('./mobile-v1-shared');
 const { MobileV1Wake } = require('./mobile-v1-wake');
 const mobileCrypto = require('./mobile-v1-crypto');
@@ -1611,6 +1611,15 @@ class MobileV1Api {
                                 : (spec.editableFields || []).slice(),
                         ),
                         payload: projectPayload(spec, row),
+                        ...this.ownedSecretEnvelopeFields({
+                            spec,
+                            row,
+                            user: auth.user,
+                            device: auth.device,
+                            entityType,
+                            entityId: rowId,
+                            entityRevision: adapter.revisionOf(row),
+                        }),
                     });
                     afterEntityId = rowId;
                 }
@@ -1675,7 +1684,7 @@ class MobileV1Api {
         /* A foreign row aborts the entire page before nextCursor reaches the
          * device. Advancing past it would leave shared data resident or the owned
          * mirror silently incomplete. */
-        const changes = page.changes.map((change) => this.hydrateChange(auth.user, change));
+        const changes = page.changes.map((change) => this.hydrateChange(auth.user, change, auth.device));
         return {
             ok: true,
             fromCursor: page.fromCursor,
@@ -1859,7 +1868,7 @@ class MobileV1Api {
         return { values, release };
     }
 
-    hydrateChange(user, change) {
+    hydrateChange(user, change, device = null) {
         const spec = this.entityByType.get(change.entityType);
         const adapter = this.adapters.get(change.entityType);
         if (!spec || !adapter) {
@@ -1893,7 +1902,91 @@ class MobileV1Api {
         } catch {
             row = null;
         }
-        return { ...safeChange, payload: row ? projectPayload(spec, row) : {} };
+        if (!row) return { ...safeChange, payload: {} };
+        return {
+            ...safeChange,
+            payload: projectPayload(spec, row),
+            ...this.ownedSecretEnvelopeFields({
+                spec,
+                row,
+                user,
+                device,
+                entityType: change.entityType,
+                entityId: change.entityId,
+                entityRevision: change.revision,
+            }),
+        };
+    }
+
+    deviceEncryptionPublicKey(device) {
+        const raw = device && device.encryption_public_key;
+        if (!raw) return null;
+        const key = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+        return key.length === mobileCrypto.MLKEM768_PUBLIC_KEY_BYTES ? key : null;
+    }
+
+    /**
+     * Seals stored secrets to the bound device's ML-KEM public key.
+     *
+     * One's mirror writer requires a boolean presence flag for every registry
+     * secret field, and a matching envelope whenever that flag is true. Web
+     * library rows used to send `******` / `hasPassword=true` with no envelope,
+     * which aborted the entire bootstrap page as soon as the account had a
+     * real connection. Downlink uses the same envelope suite as uplink, bound
+     * to this deviceId so a captured ciphertext cannot be opened on another
+     * handset.
+     */
+    ownedSecretEnvelopeFields({ spec, row, user, device, entityType, entityId, entityRevision }) {
+        const secrets = extractSecrets(spec, row);
+        const fields = Object.keys(secrets);
+        if (!fields.length) return {};
+
+        const publicKey = this.deviceEncryptionPublicKey(device);
+        if (!publicKey) {
+            throw new MobileStoreError(
+                'server_unavailable',
+                '\u8bbe\u5907\u52a0\u5bc6\u516c\u94a5\u4e0d\u53ef\u7528\uff0c\u65e0\u6cd5\u4e0b\u53d1\u5bc6\u94a5',
+                503,
+                { retryable: true },
+            );
+        }
+
+        const serverKey = this.serverEncryptionKey();
+        if (!serverKey) {
+            throw new MobileStoreError(
+                'server_unavailable',
+                '\u670d\u52a1\u7aef\u52a0\u5bc6\u5bc6\u94a5\u4e0d\u53ef\u7528\uff0c\u65e0\u6cd5\u4e0b\u53d1\u5bc6\u94a5',
+                503,
+                { retryable: true },
+            );
+        }
+        const keyVersion = Number(serverKey.keyVersion);
+        const envelopes = {};
+        for (const fieldName of fields) {
+            const plaintext = Buffer.from(String(secrets[fieldName]), 'utf8');
+            try {
+                const aad = mobileCrypto.secretAadBytes({
+                    serverId: this.store.serverId(),
+                    userId: user.userId,
+                    deviceId: device.device_id,
+                    entityType,
+                    entityId: String(entityId),
+                    fieldName,
+                    entityRevision: Number(entityRevision),
+                    keyVersion,
+                });
+                envelopes[fieldName] = mobileCrypto.sealEnvelope({
+                    plaintext,
+                    publicKey,
+                    aad,
+                    keyVersion,
+                    entityRevision: Number(entityRevision),
+                });
+            } finally {
+                plaintext.fill(0);
+            }
+        }
+        return { secretEnvelopes: envelopes };
     }
 
     /**

--- a/notes-service.js
+++ b/notes-service.js
@@ -472,7 +472,7 @@ class NotesService {
         return this.get(user, noteId);
     }
 
-    list(user, { q = '', group = null, tag = null, connectionId = null, limit = 50, offset = 0, trash = false } = {}) {
+    list(user, { q = '', group = null, tag = null, connectionId = null, limit = 50, offset = 0, trash = false, includeContent = false } = {}) {
         this._assertActiveUser(user);
         limit = Math.min(Math.max(Number(limit) || 50, 1), 200);
         offset = Math.max(Number(offset) || 0, 0);
@@ -517,9 +517,26 @@ class NotesService {
             rows = rows.filter((r) => parseJson(r.linked_connection_ids_json, []).includes(cid));
         }
         return {
-            notes: rows.map((r) => this._row(r, { includeContent: false })),
+            notes: rows.map((r) => this._row(r, { includeContent: includeContent === true })),
             total: trash ? rows.length : this.stmtCountOwner.get(user.userId).c,
         };
+    }
+
+    /**
+     * Owner-complete note projection for mobile bootstrap/changes.
+     *
+     * The web list path redacts `content` to a 240-char preview so the library
+     * page stays cheap. Sync must send the full body: One stores the payload as
+     * the offline mirror, and a title-only page is a durable data loss, not a
+     * UI convenience. Trash stays off this list: a bootstrap upsert would
+     * clear deletedAt on the device. Restore still arrives as a later change.
+     */
+    listOwnedForSync(user) {
+        this._assertActiveUser(user);
+        const rows = this.stmtListUserState.all(user.userId);
+        return rows
+            .filter((row) => this._ownerIsActive(row) && !row.deleted_at)
+            .map((row) => this._row(row, { includeContent: true }));
     }
 
     groups(user) {

--- a/resource-service.js
+++ b/resource-service.js
@@ -532,6 +532,22 @@ class ResourceService {
         return rows.filter((r) => visible.has(r.id)).map((r) => ({ ...r, owner: r.ownerUserId === user.userId ? 'own' : 'shared' }));
     }
 
+    /**
+     * Owner-only, unmasked rows for the mobile sync projector.
+     *
+     * The web list variants replace secret values with '******'. Sync must
+     * never emit that placeholder: One treats any secret-named payload key as
+     * a residency violation, and a hasPassword=true row without an envelope
+     * aborts the whole page. Presence flags plus a sealed envelope (built by
+     * MobileV1Api) are the only legal downlink for these fields.
+     */
+    listOwnedRawForSync(user, resourceType) {
+        const rows = resourceType === 'proxy' ? this.storage.listProxiesRaw()
+            : resourceType === 'sshKey' ? this.storage.listSshKeysRaw()
+                : this.storage.listJumpHosts();
+        return rows.filter((row) => row && row.ownerUserId === user.userId);
+    }
+
     getRawAuthorized(user, resourceType, id, capability) {
         const raw = this._rawResource(resourceType, id);
         this.authz.assertCan(user, capability, resourceType, id, raw || { ownerUserId: '' }, { resourceExists: !!raw });

--- a/storage.js
+++ b/storage.js
@@ -1110,6 +1110,7 @@ function addActivity(activity) {
 function clearActivities() { db.prepare('DELETE FROM activities').run(); }
 
 function listProxies() { return db.prepare('SELECT * FROM proxies ORDER BY createdAt DESC').all().map(rowToProxy); }
+function listProxiesRaw() { return db.prepare('SELECT * FROM proxies ORDER BY createdAt DESC').all().map(decryptProxy).filter(Boolean); }
 function getProxyRaw(id) { return decryptProxy(db.prepare('SELECT * FROM proxies WHERE id=?').get(id)); }
 function saveProxy(p) {
     const prior = db.prepare('SELECT ownerUserId, visibility, createdAt, revision FROM proxies WHERE id=?').get(p.id);
@@ -1120,6 +1121,7 @@ function saveProxy(p) {
 }
 function deleteProxy(id) { db.prepare('DELETE FROM proxies WHERE id=?').run(id); }
 function listSshKeys() { return db.prepare('SELECT * FROM ssh_keys ORDER BY createdAt DESC').all().map((row) => rowToSshKey(row)); }
+function listSshKeysRaw() { return db.prepare('SELECT * FROM ssh_keys ORDER BY createdAt DESC').all().map(decryptSshKey).filter(Boolean); }
 function getSshKeyRaw(id) { return decryptSshKey(db.prepare('SELECT * FROM ssh_keys WHERE id=?').get(id)); }
 function saveSshKey(k) {
     const prior = db.prepare('SELECT ownerUserId, visibility, createdAt, revision FROM ssh_keys WHERE id=?').get(k.id);
@@ -1192,4 +1194,4 @@ function deletePasskey(username, id) { db.prepare('DELETE FROM passkeys WHERE us
 function rawDb() { return db; }
 function close() { if (db) { db.close(); db = null; } }
 
-module.exports = { init, ensureAiGuidanceDefaults, getUsersStore, saveUsersStore, getUser, getUserById, getUserBrief, getFirstUser, listUsers, createUser, archiveDeletedUsername, updateUser, updateUserById, renameUser, getConnectionsStore, saveConnectionsStore, getConnectionById, insertConnection, updateConnectionRow, deleteConnectionRow, listAllConnectionRows, cleanupExpiredEphemeralConnections, getSettings, updateSettings, addActivity, getActivities, getActivitiesForUser, queryActivities, clearActivities, listProxies, getProxyRaw, saveProxy, deleteProxy, listSshKeys, getSshKeyRaw, saveSshKey, deleteSshKey, listJumpHosts, saveJumpHost, deleteJumpHost, addLoginEvent, listLoginEvents, clearLoginEvents, getIpBan, saveIpBan, clearIpBan, listIpBans, createResetCode, findResetCode, markResetCodeUsed, recordResetCodeAttempt, invalidateResetCodesForUser, createPasswordRollbackToken, findPasswordRollbackTokenByHash, markPasswordRollbackTokenUsed, invalidatePasswordRollbackTokensForUser, listPasskeys, savePasskey, getPasskeyByCredentialId, updatePasskeyCounter, deletePasskey, rawDb, close, CLIENT_TOKEN_KEY_FILE, ClientTokenKeyring, createClientTokenKeyring };
+module.exports = { init, ensureAiGuidanceDefaults, getUsersStore, saveUsersStore, getUser, getUserById, getUserBrief, getFirstUser, listUsers, createUser, archiveDeletedUsername, updateUser, updateUserById, renameUser, getConnectionsStore, saveConnectionsStore, getConnectionById, insertConnection, updateConnectionRow, deleteConnectionRow, listAllConnectionRows, cleanupExpiredEphemeralConnections, getSettings, updateSettings, addActivity, getActivities, getActivitiesForUser, queryActivities, clearActivities, listProxies, listProxiesRaw, getProxyRaw, saveProxy, deleteProxy, listSshKeys, listSshKeysRaw, getSshKeyRaw, saveSshKey, deleteSshKey, listJumpHosts, saveJumpHost, deleteJumpHost, addLoginEvent, listLoginEvents, clearLoginEvents, getIpBan, saveIpBan, clearIpBan, listIpBans, createResetCode, findResetCode, markResetCodeUsed, recordResetCodeAttempt, invalidateResetCodesForUser, createPasswordRollbackToken, findPasswordRollbackTokenByHash, markPasswordRollbackTokenUsed, invalidatePasswordRollbackTokensForUser, listPasskeys, savePasskey, getPasskeyByCredentialId, updatePasskeyCounter, deletePasskey, rawDb, close, CLIENT_TOKEN_KEY_FILE, ClientTokenKeyring, createClientTokenKeyring };

--- a/tests/mobile-v1-acl-token-metadata.test.mjs
+++ b/tests/mobile-v1-acl-token-metadata.test.mjs
@@ -428,8 +428,9 @@ test('central entity composition registers only owner-safe ACL and Client Token 
     const tokenSpec = registry.entities.find((entity) => entity.type === 'clientToken');
     const projected = projectPayload(tokenSpec, tokenRows[0]);
     assert.deepEqual(Object.keys(projected).sort(), [
-      'createdAt', 'id', 'lastUsedAt', 'name', 'ownerUserId', 'revision', 'updatedAt',
+      'createdAt', 'hasToken', 'id', 'lastUsedAt', 'name', 'ownerUserId', 'revision', 'updatedAt',
     ]);
+    assert.equal(projected.hasToken, false);
     assert.ok(!JSON.stringify(projected).includes('CENTRAL_TOKEN_SECRET_CANARY'));
   } finally {
     context.cleanup();

--- a/tests/mobile-v1-ai-provider-entities.test.mjs
+++ b/tests/mobile-v1-ai-provider-entities.test.mjs
@@ -161,11 +161,12 @@ test('canonical provider projection and feed never expose credentials or arbitra
     }, { changedSecretFields: ['apiKey'] });
 
     const projected = context.adapter.read(alice, 'provider-safe');
-    assert.deepEqual(Object.keys(projected).sort(), [
+    assert.deepEqual(Object.keys(projected).filter((key) => key !== 'apiKey').sort(), [
       'baseUrl', 'config', 'createdAt', 'defaultModel', 'enabled', 'id', 'models', 'name',
       'ownerUserId', 'revision', 'shareWithAdmins', 'shareWithUsers', 'sharedUserIds',
       'type', 'updatedAt', 'visibility',
     ]);
+    assert.equal(projected.apiKey, canary);
     assert.deepEqual(projected.config, {
       apiMode: 'responses',
       options: { vision: true, max_tokens: 4096 },
@@ -195,14 +196,19 @@ test('canonical provider projection and feed never expose credentials or arbitra
     const providerChanges = context.bridge.store.changePage('alice', 0, 20).changes;
     assert.deepEqual(providerChanges[1].fieldMask, []);
 
+    const { projectPayload } = require(path.join(root, 'mobile-v1-entities.js'));
+    const spec = enabledRegistry.entities.find((entity) => entity.type === 'aiProvider');
+    const wire = projectPayload(spec, projected);
+    assert.equal(wire.apiKey, undefined);
+    assert.equal(wire.hasApiKey, true);
     const syncState = JSON.stringify({
-      projected,
+      wire,
       changes: providerChanges,
       outbox: context.bridge.pendingWakeEvents(),
     });
     assert.ok(!syncState.includes(canary));
     assert.ok(!syncState.includes(replacementCanary));
-    assert.ok(!syncState.includes('apiKey'));
+    assert.ok(!syncState.includes('"apiKey"'));
     assert.deepEqual(context.bridge.store.changePage('alice', 0, 20).changes[0].fieldMask.sort(), [
       'baseUrl', 'config', 'defaultModel', 'enabled', 'models', 'name', 'shareWithAdmins',
       'shareWithUsers', 'sharedUserIds', 'type', 'visibility',

--- a/zephyr_one/mobile/android/core-network/src/test/resources/production-sync-wire.json
+++ b/zephyr_one/mobile/android/core-network/src/test/resources/production-sync-wire.json
@@ -113,7 +113,9 @@
           "ownerUserId": "owner-1",
           "revision": 1,
           "name": "fixture",
-          "updatedAt": 1
+          "updatedAt": 1,
+          "hasPassword": false,
+          "hasPrivateKey": false
         }
       },
       {
@@ -158,7 +160,9 @@
           "ownerUserId": "owner-1",
           "revision": 1,
           "name": "fixture",
-          "updatedAt": 1
+          "updatedAt": 1,
+          "hasPassword": false,
+          "hasPrivateKey": false
         }
       }
     ]

--- a/zephyr_one/mobile/tests/mobile-v1-owned-sync-projection.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-owned-sync-projection.test.mjs
@@ -1,0 +1,233 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Owned-sync downlink projection.
+ *
+ * Two production bugs this locks:
+ *  1. NotesService.list() redacts `content` to a 240-char preview. Bootstrap
+ *     used that list, so One stored titles and empty bodies.
+ *  2. Web library rows emit hasPassword=true / password='******' with no
+ *     device envelope. One's mirror writer then aborts the whole page, which
+ *     is why an empty account "syncs" and an account with connections fails.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..');
+const require = createRequire(import.meta.url);
+const { createDatabase } = require(path.join(repoRoot, 'sqlite-driver.js'));
+const { MobileV1Api } = require(path.join(repoRoot, 'mobile-v1-routes.js'));
+const { MobileV1Store } = require(path.join(repoRoot, 'mobile-v1-store.js'));
+const { projectPayload } = require(path.join(repoRoot, 'mobile-v1-entities.js'));
+const { NotesService } = require(path.join(repoRoot, 'notes-service.js'));
+const mobileCrypto = require(path.join(repoRoot, 'mobile-v1-crypto.js'));
+
+const registry = JSON.parse(fs.readFileSync(
+  path.join(here, '..', 'contracts', 'registries', 'entity-registry.json'),
+  'utf8',
+));
+const connectionSpec = registry.entities.find((entity) => entity.type === 'connection');
+const noteSpec = registry.entities.find((entity) => entity.type === 'note');
+const user = { userId: 'owner-1', username: 'owner', role: 'admin', status: 'active' };
+
+let mlKem = null;
+try { mlKem = require('@noble/post-quantum/ml-kem.js').ml_kem768; } catch { mlKem = null; }
+
+function installNotesSchema(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      username TEXT PRIMARY KEY, userId TEXT NOT NULL UNIQUE, passwordHash TEXT NOT NULL,
+      defaultPassword INTEGER NOT NULL DEFAULT 0, createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL,
+      email TEXT NOT NULL DEFAULT '', role TEXT NOT NULL DEFAULT 'user', status TEXT NOT NULL DEFAULT 'active',
+      isSuperAdmin INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS notes (
+      note_id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, title TEXT NOT NULL,
+      content TEXT NOT NULL DEFAULT '', group_path TEXT NOT NULL DEFAULT '',
+      tags_json TEXT NOT NULL DEFAULT '[]', linked_connection_ids_json TEXT NOT NULL DEFAULT '[]',
+      sort_order REAL, revision INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL, deleted_at INTEGER, visibility TEXT NOT NULL DEFAULT 'private',
+      share_with_users INTEGER NOT NULL DEFAULT 0, share_with_admins INTEGER NOT NULL DEFAULT 0,
+      allow_ai INTEGER NOT NULL DEFAULT 0, allow_ai_read INTEGER NOT NULL DEFAULT 0,
+      allow_ai_write INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS resource_acl (
+      resource_type TEXT NOT NULL, resource_id TEXT NOT NULL, subject_type TEXT NOT NULL DEFAULT 'user',
+      subject_id TEXT NOT NULL, capabilities_json TEXT NOT NULL, granted_by_user_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL, expires_at INTEGER, revoked_at INTEGER,
+      PRIMARY KEY (resource_type, resource_id, subject_type, subject_id)
+    );
+    CREATE TABLE IF NOT EXISTS audit_events (
+      event_id TEXT PRIMARY KEY, actor_user_id TEXT, target_user_id TEXT, resource_type TEXT,
+      resource_id TEXT, action TEXT NOT NULL, outcome TEXT NOT NULL,
+      metadata_json TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL
+    );
+  `);
+  db.prepare(`INSERT INTO users (username, userId, passwordHash, createdAt, updatedAt, role, status)
+    VALUES (?, ?, 'x', 1, 1, 'admin', 'active')`).run(user.username, user.userId);
+}
+
+function fakeAuthz(db) {
+  const lookup = db.prepare('SELECT userId, status, role FROM users WHERE userId = ?');
+  return {
+    getUserById: (id) => lookup.get(String(id || '')) || null,
+    listSubjectGrants: () => [],
+    audit() {},
+  };
+}
+
+test('web note list stays preview-only while owned sync carries the full body', () => {
+  const db = createDatabase(':memory:', { forceBuiltin: true });
+  try {
+    installNotesSchema(db);
+    const notes = new NotesService(db, fakeAuthz(db), () => 1_700_000_000_000, { mobileChangeBridge: false });
+    const body = '# Runbook\n\n' + 'restart the blue service after approval. '.repeat(20);
+    const created = notes.create(user, { title: 'ops', content: body, groupPath: 'ops' });
+    assert.ok(body.length > 240);
+
+    const web = notes.list(user, { limit: 50 });
+    assert.equal(web.notes.length, 1);
+    assert.equal(web.notes[0].content, undefined);
+    assert.equal(web.notes[0].preview, body.slice(0, 240));
+
+    const syncRows = notes.listOwnedForSync(user);
+    assert.equal(syncRows.length, 1);
+    assert.equal(syncRows[0].content, body);
+    assert.equal(syncRows[0].preview, undefined);
+
+    const listed = notes.listOwnedForSync(user);
+    assert.equal(listed[0].content, body);
+
+    const payload = projectPayload(noteSpec, listed[0]);
+    assert.equal(payload.content, body);
+    assert.equal(payload.preview, undefined);
+    assert.equal(payload.noteId, created.noteId);
+  } finally {
+    try { db.close(); } catch {}
+  }
+});
+
+test('secret-bearing connections emit presence flags, never placeholders or plaintext', () => {
+  const payload = projectPayload(connectionSpec, {
+    id: 'connection-1',
+    ownerUserId: user.userId,
+    revision: 3,
+    name: 'prod',
+    host: '10.0.0.8',
+    port: 22,
+    protocol: 'SSH',
+    username: 'root',
+    password: 'real-password',
+    privateKey: '',
+    capabilities: ['view', 'revealSecret'],
+    owner: 'own',
+    hasPassword: true,
+  });
+  assert.equal(payload.password, undefined);
+  assert.equal(payload.privateKey, undefined);
+  assert.equal(payload.capabilities, undefined);
+  assert.equal(payload.owner, undefined);
+  assert.equal(payload.hasPassword, true);
+  assert.equal(payload.hasPrivateKey, false);
+  assert.equal(payload.name, 'prod');
+});
+
+test('bootstrap seals stored secrets to the bound device and keeps note bodies intact', (t) => {
+  if (!mlKem) return t.skip('@noble/post-quantum not installed');
+  const pair = mlKem.keygen();
+  const db = createDatabase(':memory:', { forceBuiltin: true });
+  try {
+    installNotesSchema(db);
+    const notes = new NotesService(db, fakeAuthz(db), () => 1_700_000_000_001, { mobileChangeBridge: false });
+    const body = 'full markdown body that must survive bootstrap';
+    const note = notes.create(user, { title: 'keepalive', content: body });
+    const connection = {
+      id: 'connection-secret',
+      ownerUserId: user.userId,
+      revision: 4,
+      name: 'bastion',
+      host: '10.1.1.1',
+      port: 22,
+      protocol: 'SSH',
+      username: 'root',
+      password: 's3cret-downlink',
+      privateKey: '',
+      updatedAt: 4,
+    };
+    const store = new MobileV1Store({ db, entityRegistry: registry });
+    store._hmacKey = Buffer.alloc(32, 0x5a);
+    store.serverId = () => 'server-fixture';
+    const device = {
+      device_id: 'device-1',
+      owner_user_id: user.userId,
+      refresh_generation: 1,
+      encryption_public_key: Buffer.from(pair.publicKey),
+    };
+    const api = Object.create(MobileV1Api.prototype);
+    api.requireDevice = () => ({ user, device });
+    api.bootstrapTypes = ['connection', 'note'];
+    api.entityByType = new Map([['connection', connectionSpec], ['note', noteSpec]]);
+    api.adapters = new Map([
+      ['connection', {
+        list: () => [connection],
+        read: (_user, id) => id === connection.id ? connection : null,
+        idOf: (row) => row.id,
+        revisionOf: (row) => row.revision,
+        residency: () => 'owned',
+      }],
+      ['note', {
+        list: (owner) => notes.listOwnedForSync(owner),
+        read: (owner, id) => notes.get(owner, id),
+        idOf: (row) => row.noteId,
+        revisionOf: (row) => row.revision,
+        residency: () => 'owned',
+      }],
+    ]);
+    api.store = store;
+    api.serverEncryptionKey = () => ({ publicKey: Buffer.alloc(1184, 7), keyVersion: 1 });
+    api.log = () => {};
+
+    const res = {
+      statusCode: 200, body: null,
+      status(value) { this.statusCode = value; return this; },
+      setHeader() {},
+      json(value) { this.body = value; return value; },
+    };
+    api.handleBootstrap({ mobileRequestId: 'request-1', query: {} }, res);
+    assert.equal(res.statusCode, 200, JSON.stringify(res.body).slice(0, 400));
+    assert.equal(res.body.complete, true);
+
+    const connChange = res.body.entities.find((entity) => entity.entityType === 'connection');
+    const noteChange = res.body.entities.find((entity) => entity.entityType === 'note');
+    assert.ok(connChange, 'connection missing from bootstrap');
+    assert.ok(noteChange, 'note missing from bootstrap');
+    assert.equal(connChange.payload.password, undefined);
+    assert.equal(connChange.payload.hasPassword, true);
+    assert.ok(connChange.secretEnvelopes?.password, 'password envelope missing');
+    const aad = mobileCrypto.secretAadBytes({
+      serverId: 'server-fixture',
+      userId: user.userId,
+      deviceId: device.device_id,
+      entityType: 'connection',
+      entityId: connection.id,
+      fieldName: 'password',
+      entityRevision: connection.revision,
+      keyVersion: 1,
+    });
+    const opened = mobileCrypto.openEnvelope({
+      envelope: connChange.secretEnvelopes.password,
+      expectedAad: aad,
+      privateKey: pair.secretKey,
+    });
+    assert.equal(opened.toString('utf8'), 's3cret-downlink');
+    assert.equal(noteChange.payload.title, 'keepalive');
+    assert.equal(noteChange.payload.content, body);
+    assert.equal(noteChange.entityId, note.noteId);
+  } finally {
+    try { db.close(); } catch {}
+  }
+});

--- a/zephyr_one/mobile/tests/mobile-v1-residency-security.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-residency-security.test.mjs
@@ -61,9 +61,12 @@ function makeAdapterHarness() {
 
   const storage = {
     getConnectionById: (id) => get('connection', id),
+    listAllConnectionRows: () => [...rows.get('connection').values()],
     getProxyRaw: (id) => get('proxy', id),
     getSshKeyRaw: (id) => get('sshKey', id),
     listJumpHosts: () => [...rows.get('jumpHost').values()],
+    listProxiesRaw: () => [...rows.get('proxy').values()],
+    listSshKeysRaw: () => [...rows.get('sshKey').values()],
     rawDb: () => ({
       prepare(sql) {
         const type = /FROM connections/.test(sql) ? 'connection'
@@ -90,8 +93,11 @@ function makeAdapterHarness() {
   };
 
   const resourceService = {
+    storage,
     listConnections: () => [...rows.get('connection').values()],
     getConnection: (user, id) => ownedResult('connection', id, user),
+    listOwnedRawForSync: (user, type) => [...rows.get(type).values()]
+      .filter((row) => row.ownerUserId === user.userId),
     createConnection: (user, patch) => {
       calls.push(['create', 'connection', patch.id]);
       return save('connection', patch.id, user, patch);
@@ -124,6 +130,8 @@ function makeAdapterHarness() {
 
   const notesService = {
     list: () => ({ notes: [...rows.get('note').values()] }),
+    listOwnedForSync: (user) => [...rows.get('note').values()]
+      .filter((row) => row.ownerUserId === user.userId),
     get: (user, id) => ownedResult('note', id, user),
     create: (user, patch) => {
       calls.push(['create', 'note', patch.id]);

--- a/zephyr_one/mobile/tests/mobile-v1-roundtrip.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-roundtrip.test.mjs
@@ -512,15 +512,19 @@ test("bootstrap streams the owned mirror and terminates", async () => {
   assert.equal(providerEntity.payload.models[0].userAgent, undefined);
   assert.equal(providerEntity.payload.models[0].extra, undefined);
   assert.equal(providerEntity.payload.apiKey, undefined);
-  assert.equal(providerEntity.payload.hasApiKey, undefined);
+  assert.equal(providerEntity.payload.hasApiKey, true);
+  assert.ok(providerEntity.secretEnvelopes && providerEntity.secretEnvelopes.apiKey,
+    "a stored API key must arrive as a device envelope");
   assert.equal(providerEntity.payload.config.extraHeaders, undefined);
   assert.equal(providerEntity.payload.config.options.extraJson, undefined);
   assert.ok(!JSON.stringify(providerEntity).includes(AI_PROVIDER_SECRET),
     "the AI provider secret canary leaked into bootstrap");
   assert.ok(clientTokenEntity, "the canonical Client Token metadata was absent from bootstrap");
   assert.deepEqual(Object.keys(clientTokenEntity.payload).sort(), [
-    "createdAt", "id", "lastUsedAt", "name", "ownerUserId", "revision", "updatedAt",
+    "createdAt", "hasToken", "id", "lastUsedAt", "name", "ownerUserId", "revision", "updatedAt",
   ]);
+  assert.equal(clientTokenEntity.payload.hasToken, false);
+  assert.equal(clientTokenEntity.secretEnvelopes, undefined);
   assert.deepEqual(clientTokenEntity.fieldMask, ["name"]);
   assert.equal(clientTokenEntity.payload.name, "mobile-roundtrip");
   assert.ok(!JSON.stringify(clientTokenEntity).includes(state.tokenSecret),

--- a/zephyr_one/mobile/tests/mobile-v1-secrets.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-secrets.test.mjs
@@ -380,6 +380,10 @@ test("a change feed row never carries a secret", async () => {
   assert.ok(mine, "the write must appear in the feed");
   assert.equal(mine.payload.password, undefined, "a secret leaked into a change payload");
   assert.equal(mine.payload.privateKey, undefined, "a secret leaked into a change payload");
+  assert.equal(mine.payload.hasPassword, true, "presence must declare the stored password");
+  assert.equal(mine.payload.hasPrivateKey, false);
+  assert.ok(mine.secretEnvelopes && mine.secretEnvelopes.password,
+    "the stored password must be sealed to this device");
   assert.equal(mine.payload.name, "Secret Host");
 });
 


### PR DESCRIPTION
## Why

Empty accounts could bootstrap. Accounts with real connections/notes could not:

1. **Connections abort the whole page.** Web library rows send `hasPassword=true` and `******` with no device envelope. One's `prepareSecrets` requires a boolean presence flag for every secret field and a matching envelope when the flag is true, so the first password-bearing connection fails the page as `missing_envelope`.
2. **Notes only sync titles.** `NotesService.list()` redacts `content` to a 240-char `preview`. Bootstrap walks `adapter.list()`, so One stores titles without bodies.

## Fix

- Note sync list (`listOwnedForSync`) returns full `content`. Web `/api/notes` list stays preview-only.
- Connection/proxy/sshKey/aiProvider/aiEnv sync reads go through unmasked owner rows.
- `projectPayload` always emits `hasX` presence flags and never the secret itself.
- Bootstrap and changes seal stored secrets to the bound device's ML-KEM public key (`secretEnvelopes`), using the published server `keyVersion` and the same AAD as uplink.

## Tests

- New `mobile-v1-owned-sync-projection.test.mjs`: web preview vs sync body; presence flags without `******`; bootstrap seals and round-trips the envelope.
- Updated roundtrip / secrets / provider / ACL / production fixture for `hasX` + envelopes.

Local: projection + roundtrip + secrets + knowledge + provider + ACL + fieldMask + fixture green. `notes-security` still fails in this sandbox on missing `better-sqlite3` native bindings (pre-existing).