### PR TITLE
fix(android): bind envelope AAD to the published serverId

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
@@ -411,6 +411,12 @@ class AccountContainer(
      * key rotation is visible to the sealer and the opener without rebuilding the whole graph.
      */
     private val serverKeyState = MutableStateFlow<ServerEncryptionKey?>(null)
+    /**
+     * Envelope AAD serverId from /capabilities. Empty until the first validated
+     * capabilities payload; opening a secret before that fails closed rather
+     * than silently using the local ServerProfile row id.
+     */
+    private val envelopeServerId = MutableStateFlow("")
 
     fun onServerEncryptionKey(key: ServerEncryptionKey) {
         serverKeyState.value = key
@@ -419,7 +425,7 @@ class AccountContainer(
     val sealer: DeviceSecretSealer = DeviceSecretSealer(
         secretStore = secretStore,
         serverKey = { serverKeyState.value },
-        serverId = binding.serverProfileId,
+        serverId = { envelopeServerId.value },
         userId = binding.userId,
         deviceId = binding.deviceId,
     )
@@ -432,7 +438,7 @@ class AccountContainer(
      */
     val envelopeOpener: DeviceEnvelopeOpener = DeviceEnvelopeOpener(
         identity = deviceIdentity,
-        serverId = binding.serverProfileId,
+        serverId = { envelopeServerId.value },
         userId = binding.userId,
         deviceId = binding.deviceId,
         knownKeyVersions = { serverKeyState.value?.let { setOf(it.keyVersion) } ?: emptySet() },
@@ -535,6 +541,7 @@ class AccountContainer(
             /* Feed the server's published ML-KEM key into the live key state so the sealer can
              * seal and the opener recognises the key version. A null/absent key means "defer
              * secrets", which the sealer already honours, so only an Available key updates state. */
+            if (caps.serverId.isNotEmpty()) envelopeServerId.value = caps.serverId
             val enc = caps.serverEncryption
             if (enc != null) {
                 val decoded = runCatching {

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt
@@ -20,7 +20,12 @@ import one.zephyr.mobile.security.MobileAad
  */
 class DeviceEnvelopeOpener(
     private val identity: DeviceIdentity,
-    private val serverId: String,
+    /**
+     * Published main-end serverId from /capabilities, not the local ServerProfile
+     * row id. Envelope AAD is bound to the server's value; a local UUID makes
+     * every password-bearing connection unopenable and aborts the whole page.
+     */
+    private val serverId: () -> String,
     private val userId: String,
     private val deviceId: String,
     private val knownKeyVersions: () -> Set<Int>,
@@ -30,7 +35,7 @@ class DeviceEnvelopeOpener(
     override fun open(change: SyncChange, fieldName: String): ByteArray? {
         val envelope = change.secretEnvelopes[fieldName] ?: return null
         val expected = MobileAad.SecretInput(
-            serverId = serverId,
+            serverId = serverId(),
             userId = userId,
             deviceId = deviceId,
             entityType = change.entityType,

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceSecretSealer.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceSecretSealer.kt
@@ -40,7 +40,8 @@ data class ServerEncryptionKey(val publicKey: ByteArray, val keyVersion: Int) {
 class DeviceSecretSealer(
     private val secretStore: SecretStore,
     private val serverKey: ServerEncryptionKeyProvider,
-    private val serverId: String,
+    /** Same published serverId the opener uses; see DeviceEnvelopeOpener. */
+    private val serverId: () -> String,
     private val userId: String,
     private val deviceId: String,
 ) : SecretSealer {
@@ -59,7 +60,7 @@ class DeviceSecretSealer(
         return try {
             val aad = MobileAad.secretAad(
                 MobileAad.SecretInput(
-                    serverId = serverId,
+                    serverId = serverId(),
                     userId = userId,
                     deviceId = deviceId,
                     entityType = entityType,

--- a/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorCapabilitiesTest.kt
+++ b/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorCapabilitiesTest.kt
@@ -70,6 +70,25 @@ class SyncActorCapabilitiesTest {
     }
 
     @Test
+    fun `validateBinding surfaces the published envelope serverId`() = runTest {
+        val transport = FakeSyncTransport()
+        transport.capabilitiesResult = ApiResult.Success(
+            ServerCapabilities(
+                protocolVersions = listOf(SyncContract.PROTOCOL_VERSION),
+                registryHash = "h",
+                serverId = "srv-published",
+            ),
+            null,
+        )
+        var seen: ServerCapabilities? = null
+        val subject = actor(transport, FakeSyncLocalStore(BindingState.IDLE)) { seen = it }
+
+        subject.request(SyncTrigger.MANUAL)
+
+        assertEquals("srv-published", seen!!.serverId)
+    }
+
+    @Test
     fun `a capabilities payload without a key still fires the callback`() = runTest {
         val transport = FakeSyncTransport()
         transport.capabilitiesResult = ApiResult.Success(


### PR DESCRIPTION
## Why

Notes and snippets sync. Any account with a real SSH connection still fails on pre54 + v1.1.529.

The Node downlink is correct: the test-host change for \`home\` (cursor 37) carries \`hasPassword=true\`, a device envelope, and \`rdpTouchSensitivity: 1.5\`. The Go Link binary on the test host already contains the finite-float ACK path.

The abort is on Android. Envelope AAD is bound to the **published** \`serverId\` from \`/capabilities\` (\`srv-...\`). Android rebuilt AAD from \`binding.serverProfileId\`, which is the local \`ServerProfile\` row UUID assigned at bind time. The ciphertext then fails \`EnvelopeGuard\` as \`envelope_aad_mismatch\`. \`prepareSecrets\` treats that as \`ENVELOPE_REJECTED\` and drops the **entire** page, so one password-bearing connection looks like a total sync failure.

iOS already persisted \`authentication.capabilities.serverId\` on the binding record. Android did not.

Putting the main-end at-rest encryption key on the bind screen would not help: the server already decrypts at rest before sealing a device envelope. That key must never leave the host.

## Fix

- \`DeviceEnvelopeOpener\` / \`DeviceSecretSealer\` take a live \`serverId\` lambda.
- \`AccountContainer\` stores the capabilities \`serverId\` and never falls back to the local profile id. Opening before capabilities arrive fails closed.
- Test: \`validateBinding surfaces the published envelope serverId\`.

## Release

Android-only. Needs a new mobile pre (\`pre55\`). Docker v1.1.529 does not need a rebuild.