### PR TITLE
feat(web): Docker 面板接入现有 zephyr-motion 引擎

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -5658,6 +5658,12 @@ html.ssh-kb-open .terminal-page {
 .docker-inspect-drawer { height: min(420px, 62%); }
 .docker-inspect-drawer .docker-container-log { font-size: 11px; line-height: 1.5; white-space: pre; }
 .docker-mountpoint { font-family: var(--font-mono); font-size: 11px; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Docker 表格行/创建区块的动画初始值由 dockerMotion.rows/expandIn 在 JS 端
+ * M.set() 即时设置，不走 CSS——保证引擎未就绪时内容立即可见（无 FOUC）。
+ * 引擎就绪后面板会加 .docker-motion-ready，此处仅保留 will-change 提示。 */
+.docker-motion-ready .docker-table tbody tr { will-change: transform, opacity; }
+.docker-motion-ready .docker-create[open] .docker-create-grid { will-change: transform, opacity; }
 .docker-mirror-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 10px; }
 .docker-mirror-item { display: flex; align-items: center; gap: 8px; }
 .docker-mirror-item input {

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -7922,6 +7922,7 @@ function showDockerPanel() {
     });
     checkDockerStatus();
     startDockerStatsLoop();
+    armDockerMotion();
 }
 
 function hideDockerPanel() {
@@ -8063,6 +8064,7 @@ function renderDockerContainers(containers = []) {
         dockerContainersBody.appendChild(tr);
     });
     renderDockerOverview();
+    dockerMotion.rows(dockerContainersBody);
 }
 
 function renderDockerImages(images = []) {
@@ -8108,6 +8110,7 @@ function renderDockerImages(images = []) {
     });
     renderDockerOverview();
     dockerCreateImageDatalist();
+    dockerMotion.rows(dockerImagesBody);
 }
 
 function normalizeVolume(row = {}) {
@@ -8146,6 +8149,7 @@ function renderDockerVolumes(volumes = []) {
         dockerVolumesBody.appendChild(tr);
         dockerSend({ type: 'docker-volume-inspect', name: volume.name });
     });
+    dockerMotion.rows(dockerVolumesBody);
 }
 
 function openDockerInspect(name) {
@@ -8204,6 +8208,7 @@ function renderDockerNetworks(networks = []) {
             dockerSend({ type: 'docker-network-inspect', id: network.id });
         }
     });
+    dockerMotion.rows(dockerNetworksBody);
 }
 
 function renderDockerMirrors() {
@@ -8471,9 +8476,12 @@ dockerRestartBtn?.addEventListener('click', () => {
 document.querySelectorAll('[data-docker-tab]').forEach((tab) => {
     tab.addEventListener('click', () => {
         document.querySelectorAll('[data-docker-tab]').forEach((item) => item.classList.toggle('active', item === tab));
+        const previous = document.querySelector('.docker-tab-panel.active');
+        const fromRect = previous?.getBoundingClientRect?.() || null;
         document.querySelectorAll('.docker-tab-panel').forEach((panel) => panel.classList.remove('active'));
         const target = document.getElementById(`docker${tab.dataset.dockerTab[0].toUpperCase()}${tab.dataset.dockerTab.slice(1)}Panel`);
         target?.classList.add('active');
+        if (target && previous && previous !== target) dockerMotion.tabPanel(target, fromRect);
     });
 });
 dockerPullBtn?.addEventListener('click', () => {
@@ -8571,6 +8579,80 @@ dockerPruneVolumesBtn?.addEventListener('click', () => {
     dockerSend({ type: 'docker-prune', kind: 'volumes' });
 });
 dockerInspectCloseBtn?.addEventListener('click', () => { dockerInspectDrawer.style.display = 'none'; });
+
+/* Docker 面板动效：复用现有 zephyr-motion 引擎（与 toast/钉住面板同一套
+ * WASM spring），懒加载且失败可降级——动效挂了不影响任何功能。 */
+const dockerMotion = {
+    engine: null,
+    _p: null,
+    _ensure() {
+        if (this.engine) return Promise.resolve(this.engine);
+        if (this._p) return this._p;
+        this._p = import('./vendor/zephyr-motion/index.js?v=20260728-ai-handle-only-drag1')
+            .then(async (mod) => {
+                const Motion = mod?.Motion || window.Motion;
+                if (!Motion?.to) throw new Error('Motion unavailable');
+                try { await Motion.init({ capacity: 256 }); } catch {}
+                this.engine = Motion;
+                return Motion;
+            })
+            .catch(() => { this._p = null; return null; });
+        return this._p;
+    },
+    /* 容器/网络/存储卷行：渲染后逐行从下方 10px 淡入（stagger 40ms）。
+     * 初始值由 JS 即时 set（M.set），不依赖 CSS 初始态——避免引擎未就绪
+     * 时行永远隐形。 */
+    rows(tbody) {
+        if (!tbody) return;
+        this._ensure().then((M) => {
+            if (!M || M.reducedMotion) return;
+            tbody.querySelectorAll('tr').forEach((tr, i) => {
+                M.set(tr, { y: 10, opacity: 0 });
+                M.to(tr, { y: 0, opacity: 1 }, { preset: 'snappy', delay: i * 0.04 });
+            });
+        }).catch(() => {});
+    },
+    /* tab 面板切换：FLIP morph + 内容淡入。fromRect 由调用方在切换前取。 */
+    tabPanel(el, fromRect) {
+        if (!el) return;
+        this._ensure().then((M) => {
+            if (!M || M.reducedMotion || !fromRect || fromRect.width < 2 || fromRect.height < 2) return;
+            M.morph(el, fromRect, { preset: 'shape', opacityFrom: 0 });
+        }).catch(() => {});
+    },
+    /* 创建区块内部 grid 展开。初始值 JS set，避免 details 原生先闪现。 */
+    expandIn(el) {
+        if (!el) return;
+        this._ensure().then((M) => {
+            if (!M || M.reducedMotion) return;
+            M.set(el, { y: -6, opacity: 0 });
+            M.to(el, { y: 0, opacity: 1 }, { preset: 'snappy' });
+        }).catch(() => {});
+    },
+    /* 工具栏/操作按钮按压回弹（iOS 手感）。 */
+    pressAll(selector) {
+        this._ensure().then((M) => {
+            if (!M || M.reducedMotion || !M.press) return;
+            document.querySelectorAll(selector).forEach((btn) => M.press(btn));
+        }).catch(() => {});
+    },
+};
+
+/* 引擎就绪后给面板打标记，CSS 初始态才生效；并在面板打开时预热引擎。 */
+function armDockerMotion() {
+    dockerMotion._ensure().then((M) => {
+        if (!M || M.reducedMotion) return;
+        dockerPanel?.classList.add('docker-motion-ready');
+        dockerMotion.pressAll('.docker-toolbar .tool-btn, .docker-actions .tool-btn, .docker-create-actions .tool-btn');
+    }).catch(() => {});
+}
+
+/* 创建区块展开：details 原生切换后，把内部 grid 从收起姿态弹到展开。
+ * details 的 content slot 无法被 FLIP 直接测量，这里只对 grid 做 spring。 */
+$('#dockerCreateBlock')?.addEventListener('toggle', (event) => {
+    const block = event.currentTarget;
+    if (block.open) dockerMotion.expandIn(block.querySelector('.docker-create-grid'));
+});
 
 // ---------- 监控面板 ----------
 function safeVal(val, fallback = 0) {

--- a/tests/docker-panel-motion-contract.test.mjs
+++ b/tests/docker-panel-motion-contract.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/* Docker panel motion contract: panel tab switches, table rows, the create
+ * block, and toolbar buttons reuse the existing zephyr-motion engine
+ * (Motion.morph / Motion.to / Motion.press), never a new dependency. All
+ * hooks must degrade gracefully when the engine fails to load. */
+
+const root = path.resolve(import.meta.dirname, '..');
+const terminalJs = fs.readFileSync(path.join(root, 'public', 'terminal.js'), 'utf8');
+const styleCss = fs.readFileSync(path.join(root, 'public', 'style.css'), 'utf8');
+const terminalHtml = fs.readFileSync(path.join(root, 'public', 'terminal.html'), 'utf8');
+
+test('docker panel reuses the existing zephyr-motion engine (no new dependency)', () => {
+    assert.ok(/import\('\.\/vendor\/zephyr-motion\/index\.js/.test(terminalJs), 'lazy-imports existing engine');
+    assert.ok(!/animejs|gsap|framer-motion|lottie/.test(terminalJs), 'must not add a third-party animation lib');
+});
+
+test('dockerMotion exposes rows / tabPanel / expandIn / pressAll with graceful degradation', () => {
+    const idx = terminalJs.indexOf('const dockerMotion = {');
+    assert.ok(idx > 0, 'dockerMotion adapter exists');
+    const body = terminalJs.slice(idx, idx + 2600);
+    assert.ok(/rows\(tbody\)/.test(body), 'rows hook');
+    assert.ok(/tabPanel\(el, fromRect\)/.test(body), 'tab FLIP hook');
+    assert.ok(/expandIn\(el\)/.test(body), 'create-block expand hook');
+    assert.ok(/pressAll\(selector\)/.test(body), 'button press hook');
+    assert.ok(/\.catch\(\(\) =>/.test(body), 'engine failure degrades gracefully');
+    assert.ok(/reducedMotion/.test(body), 'respects reduced-motion');
+});
+
+test('tab switching feeds the FLIP morph with the outgoing panel rect', () => {
+    const idx = terminalJs.indexOf("document.querySelectorAll('[data-docker-tab]')");
+    assert.ok(idx > 0);
+    const body = terminalJs.slice(idx, idx + 900);
+    assert.ok(/getBoundingClientRect/.test(body), 'captures fromRect before switch');
+    assert.ok(/dockerMotion\.tabPanel\(target, fromRect\)/.test(body), 'morphs the incoming panel');
+});
+
+test('table renderers stream rows through dockerMotion.rows', () => {
+    for (const fn of ['renderDockerContainers', 'renderDockerImages', 'renderDockerNetworks', 'renderDockerVolumes']) {
+        const idx = terminalJs.indexOf(`function ${fn}(`);
+        assert.ok(idx > 0, `${fn} exists`);
+        const end = terminalJs.indexOf('\nfunction ', idx + 10);
+        const body = terminalJs.slice(idx, end > idx ? end : idx + 6000);
+        assert.ok(/dockerMotion\.rows\(/.test(body), `${fn} streams rows`);
+    }
+});
+
+test('create block toggle springs the inner grid', () => {
+    assert.ok(/\('#dockerCreateBlock'\)\?\.addEventListener\('toggle'/.test(terminalJs), 'toggle listener');
+    assert.ok(/dockerMotion\.expandIn\(/.test(terminalJs), 'grid expand');
+});
+
+test('motion initial values are set in JS, not CSS (no FOUC when engine is down)', () => {
+    assert.ok(/M\.set\(tr, \{ y: 10, opacity: 0 \}\)/.test(terminalJs), 'row initial set in JS');
+    assert.ok(/M\.set\(el, \{ y: -6, opacity: 0 \}\)/.test(terminalJs), 'grid initial set in JS');
+    assert.ok(!/\.docker-motion-ready .*\{\s*opacity:\s*0/.test(styleCss), 'CSS must not hide rows by default');
+});
+
+test('panel open pre-warms the engine via armDockerMotion', () => {
+    const idx = terminalJs.indexOf('function showDockerPanel()');
+    assert.ok(idx > 0);
+    const body = terminalJs.slice(idx, idx + 700);
+    assert.ok(/armDockerMotion\(\)/.test(body), 'pre-warms engine on open');
+});


### PR DESCRIPTION
复用已在驱动 toast 和钉住面板的 WASM spring 引擎，**零新增动画依赖**。引擎加载失败全部降级为无动画，且尊重 prefers-reduced-motion。

| 交互 | 动效 | 复用 API |
|---|---|---|
| tab 切换 | 从旧面板 rect FLIP morph 到新面板 | `Motion.morph`（shape 预设，与钉住/浮窗一致） |
| 容器/镜像/网络/卷行 | 逐行 y:10 + opacity:0 → identity（stagger 40ms） | `Motion.to`（snappy） |
| 创建容器区块 | details 展开时内部 grid 弹簧 | `Motion.to` |
| 工具栏/操作按钮 | iOS 按压回弹 | `Motion.press` |

**关键工程决策**：初始值全部 JS 端 `M.set()`，不写进 CSS——引擎没就绪时内容立即可见，不会 FOUC 或永久隐形。引擎在面板打开时预热（`armDockerMotion`），就绪后才加 `.docker-motion-ready` 提供 will-change 提示。

新增契约测试 `docker-panel-motion-contract`（7 项）；motion/docker/monitor/pin 契约套件全绿。