### PR TITLE
fix(web): 监控延迟改走编辑→测试连接同一条握手

### DIFF
--- a/handshake-latency.js
+++ b/handshake-latency.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/* Handshake latency helpers for the monitor panel.
+ *
+ * The number shown as 连接延迟 MUST come from the same wall-clock as
+ * 编辑 → 测试连接 (`testSSHConnection` → `createRoutedSSHConnection`):
+ * TCP + jump hosts + auth. These helpers only decide *when* to refresh
+ * and *whether* a probe result is usable — they never invent an RTT from
+ * the live-session stats exec.
+ */
+
+function acceptHandshakeLatency(probe) {
+    if (!probe || probe.ok !== true) return null;
+    const ms = Number(probe.durationMs);
+    if (!Number.isFinite(ms)) return null;
+    return Math.max(0, Math.round(ms));
+}
+
+function shouldRefreshHandshakeLatency({ lastMs, lastAt, running, now, intervalMs } = {}) {
+    if (running) return false;
+    const interval = Number(intervalMs);
+    if (!Number.isFinite(interval) || interval < 0) return false;
+    if (lastMs == null) return true;
+    return (Number(now) - Number(lastAt || 0)) >= interval;
+}
+
+module.exports = {
+    acceptHandshakeLatency,
+    shouldRefreshHandshakeLatency,
+};

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ const {
     verifyAuthenticationResponse,
 } = require('@simplewebauthn/server');
 const { getRemoteStats } = require('./stats');
+const { acceptHandshakeLatency, shouldRefreshHandshakeLatency } = require('./handshake-latency');
 const storage = require('./storage');
 const { createDatabase } = require('./sqlite-driver');
 const {
@@ -9921,6 +9922,14 @@ wss.on('connection', (ws, req) => {
     let statsTimer = null;
     let statsRunning = false;
     let remoteStatsState = {};
+    /* 监控延迟必须走和"编辑 → 测试连接"同一条 createRoutedSSHConnection 握手
+     * 路径（TCP + 跳板 + 认证墙钟），不能在已有会话上 exec。连接配置在
+     * connect 成功后写入；握手每 5s 测一次，数字沿用最近一次成功结果。 */
+    let statsConnectionConfig = null;
+    let statsLatencyMs = null;
+    let statsLatencyAt = 0;
+    let statsLatencyRunning = false;
+    const STATS_LATENCY_INTERVAL_MS = 5000;
     let dockerLogStreams = new Map();
     let sftpUploadStreams = new Map();
     const closeTelnetSocket = (reason = 'cleanup') => {
@@ -9974,17 +9983,44 @@ wss.on('connection', (ws, req) => {
         }
         if (statsTimer) return;
         console.info('[STATS] realtime stats started');
+        /* 延迟：复用 testSSHConnection（编辑→测试连接）的 durationMs。
+         * 与 stats 采样并行发出，节流 5s；失败保留上次成功值。 */
+        const kickHandshakeLatency = () => {
+            if (!statsConnectionConfig) return;
+            if (!shouldRefreshHandshakeLatency({
+                lastMs: statsLatencyMs,
+                lastAt: statsLatencyAt,
+                running: statsLatencyRunning,
+                now: Date.now(),
+                intervalMs: STATS_LATENCY_INTERVAL_MS,
+            })) return;
+            statsLatencyRunning = true;
+            testSSHConnection(statsConnectionConfig, 8000)
+                .then((probe) => {
+                    const ms = acceptHandshakeLatency(probe);
+                    if (ms != null) {
+                        statsLatencyMs = ms;
+                        statsLatencyAt = Date.now();
+                    }
+                })
+                .catch(() => {})
+                .finally(() => { statsLatencyRunning = false; });
+        };
         const pushStats = async () => {
             if (ws.readyState !== ws.OPEN || !sshClient || statsRunning) return;
             statsRunning = true;
             const startedAt = Date.now();
+            kickHandshakeLatency();
             try {
                 const result = await getRemoteStats(sshClient, remoteStatsState);
                 remoteStatsState = result.state;
                 statsSampleSeq += 1;
                 sendJSON({
                     type: 'stats',
-                    data: result.stats,
+                    data: {
+                        ...result.stats,
+                        latency: { ms: statsLatencyMs, sampledAt: statsLatencyAt || startedAt },
+                    },
                     sampleSeq: statsSampleSeq,
                     sampledAt: startedAt,
                     durationMs: Date.now() - startedAt,
@@ -10002,6 +10038,7 @@ wss.on('connection', (ws, req) => {
                 statsRunning = false;
             }
         };
+        kickHandshakeLatency();
         pushStats();
         statsTimer = setInterval(pushStats, 1000);
     }
@@ -10014,6 +10051,9 @@ wss.on('connection', (ws, req) => {
         }
         statsRunning = false;
         remoteStatsState = {};
+        statsLatencyMs = null;
+        statsLatencyAt = 0;
+        statsLatencyRunning = false;
     }
 
     function stopDockerLogStreams() {
@@ -10106,6 +10146,7 @@ wss.on('connection', (ws, req) => {
         sshClient = session.sshClient || null;
         sshClients = session.sshClients || [session.sshClient].filter(Boolean);
         sshStream = session.sshStream || null;
+        statsConnectionConfig = session.connectionConfig || statsConnectionConfig;
         telnetSocket = session.telnetSocket || null;
         telnetProtocol = String(session.protocol || '').toUpperCase() === 'TELNET' || !!session.telnetSocket;
         sftpStream = session.sftpStream || null;
@@ -10903,6 +10944,7 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
                 }
                 sshClient = routed.client;
                 sshClients = routed.clients || [routed.client];
+                statsConnectionConfig = conn;
                 console.log(`[SSH] 已连接: ${routed.route}`);
                 console.info('[SSH-DIAG] ssh ready before shell', {
                     connectionId: conn.id || connectionId || '',
@@ -11108,7 +11150,13 @@ echo "Docker registry-mirrors 已更新，请重启 Docker 服务使配置生效
             try {
                 const result = await getRemoteStats(sshClient, remoteStatsState);
                 remoteStatsState = result.state;
-                sendJSON({ type: 'stats', data: result.stats });
+                sendJSON({
+                    type: 'stats',
+                    data: {
+                        ...result.stats,
+                        latency: { ms: statsLatencyMs, sampledAt: statsLatencyAt || Date.now() },
+                    },
+                });
             } catch (err) {
                 console.error('[STATS] 手动读取远程统计失败:', err.message);
                 sendJSON({ type: 'stats-error', message: err.message || '读取远程统计失败' });

--- a/stats.js
+++ b/stats.js
@@ -276,42 +276,8 @@ function computeNetRates(current, previous, elapsedSeconds) {
   };
 }
 
-/* 纯 RTT 探针：exec 一个空命令，只测 SSH 通道环回（与"编辑 → 测试连接"
- * 的握手后环回口径一致），不含 stats 命令的远端执行/公网 IP 探测耗时。
- * 失败返回 null，调用方降级为不显示延迟，绝不拿采样总耗时冒充 RTT。 */
-function probeLatency(sshClient) {
-  return new Promise((resolve) => {
-    const startedAt = Date.now();
-    let settled = false;
-    const finish = (value) => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-    };
-    const timer = setTimeout(() => finish(null), 3000);
-    try {
-      sshClient.exec('true', (err, stream) => {
-        if (err) { clearTimeout(timer); return finish(null); }
-        stream.on('close', () => {
-          clearTimeout(timer);
-          finish(Math.max(0, Date.now() - startedAt));
-        });
-        stream.on('error', () => { clearTimeout(timer); finish(null); });
-        try { stream.end?.(); } catch {}
-      });
-    } catch {
-      clearTimeout(timer);
-      finish(null);
-    }
-  });
-}
-
 async function getRemoteStats(sshClient, previous = {}) {
-  /* 探针与采样并行：探针只测环回，采样继续干重活。总墙钟时间不变。 */
-  const [latencyMs, raw] = await Promise.all([
-    probeLatency(sshClient),
-    execRemote(sshClient, STAT_COMMAND),
-  ]);
+  const raw = await execRemote(sshClient, STAT_COMMAND);
   const sections = splitSections(raw);
   const cpuStat = parseCpuStat(sections.cpu);
   const mem = parseMemory(sections.mem);
@@ -343,11 +309,7 @@ async function getRemoteStats(sshClient, previous = {}) {
       net,
       processes,
       ip: { ipv4, ipv6 },
-      host: { hostname, os: osInfo },
-      /* 连接延迟：纯 SSH 通道环回（空 exec 探针），口径对齐"编辑 → 测试连接"。
-       * 与 stats 采样并行测，不含远端命令执行/公网 IP 探测耗时。探针失败
-       * 时 ms 为 null，前端降级显示 --。 */
-      latency: { ms: latencyMs, sampledAt: now }
+      host: { hostname, os: osInfo }
     },
     state: {
       cpuStat,

--- a/tests/handshake-latency.test.mjs
+++ b/tests/handshake-latency.test.mjs
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { acceptHandshakeLatency, shouldRefreshHandshakeLatency } = require('../handshake-latency.js');
+
+test('acceptHandshakeLatency only keeps a successful handshake durationMs', () => {
+    assert.equal(acceptHandshakeLatency({ ok: true, durationMs: 87.4 }), 87);
+    assert.equal(acceptHandshakeLatency({ ok: true, durationMs: 0 }), 0);
+    assert.equal(acceptHandshakeLatency({ ok: true, durationMs: -3 }), 0);
+    assert.equal(acceptHandshakeLatency({ ok: false, durationMs: 12 }), null);
+    assert.equal(acceptHandshakeLatency({ ok: true, durationMs: 'nope' }), null);
+    assert.equal(acceptHandshakeLatency(null), null);
+    assert.equal(acceptHandshakeLatency({ durationMs: 10 }), null);
+});
+
+test('shouldRefreshHandshakeLatency fires immediately when there is no sample yet', () => {
+    assert.equal(shouldRefreshHandshakeLatency({
+        lastMs: null, lastAt: 0, running: false, now: 1000, intervalMs: 5000,
+    }), true);
+});
+
+test('shouldRefreshHandshakeLatency waits for the interval after a successful sample', () => {
+    assert.equal(shouldRefreshHandshakeLatency({
+        lastMs: 42, lastAt: 1000, running: false, now: 5999, intervalMs: 5000,
+    }), false);
+    assert.equal(shouldRefreshHandshakeLatency({
+        lastMs: 42, lastAt: 1000, running: false, now: 6000, intervalMs: 5000,
+    }), true);
+});
+
+test('shouldRefreshHandshakeLatency never overlaps an in-flight handshake', () => {
+    assert.equal(shouldRefreshHandshakeLatency({
+        lastMs: null, lastAt: 0, running: true, now: 99999, intervalMs: 5000,
+    }), false);
+});

--- a/tests/monitor-latency-contract.test.mjs
+++ b/tests/monitor-latency-contract.test.mjs
@@ -4,34 +4,40 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /* Monitor latency contract:
- * - stats.js annotates every sample with `latency.ms` measured as the SSH
- *   exec channel round-trip (same signal the "编辑 → 测试连接" durationMs uses,
- *   just reusing the 1s stats sample instead of a separate handshake).
- * - terminal.js renders a dedicated 连接延迟 block with a numeric value and a
- *   Chart.js line chart that keeps its Y axis visible (unlike the sparklines).
+ * Latency MUST be measured by the same path as 编辑 → 测试连接:
+ * testSSHConnection → createRoutedSSHConnection wall-clock (TCP + jump +
+ * auth). It must NEVER reuse the stats exec duration or an empty-exec
+ * probe on the live session (those either inflate or silently fail).
  */
 
 const root = path.resolve(import.meta.dirname, '..');
 const terminalJs = fs.readFileSync(path.join(root, 'public', 'terminal.js'), 'utf8');
 const statsJs = fs.readFileSync(path.join(root, 'stats.js'), 'utf8');
+const serverJs = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
 const styleCss = fs.readFileSync(path.join(root, 'public', 'style.css'), 'utf8');
 
-test('stats.js measures latency with a dedicated empty-exec RTT probe, not the stats exec wall time', () => {
-    assert.ok(/function probeLatency\(/.test(statsJs), 'probeLatency must exist');
-    const idx = statsJs.indexOf('function probeLatency(');
-    const probe = statsJs.slice(idx, idx + 1200);
-    assert.ok(/sshClient\.exec\('true'/.test(probe), 'probe must exec an empty command');
-    assert.ok(/Date\.now\(\) - startedAt/.test(probe), 'probe measures exec round-trip');
-    assert.ok(/finish\(null\)/.test(probe), 'probe failure resolves null (degrades, never fakes RTT)');
-    /* getRemoteStats must run probe in parallel with the heavy stats exec and
-     * report probeLatency's result — never the stats command's own duration. */
-    const gidx = statsJs.indexOf('async function getRemoteStats(');
-    const gend = statsJs.indexOf('module.exports', gidx);
-    const gbody = statsJs.slice(gidx, gend > gidx ? gend : gidx + 3000);
-    assert.ok(/probeLatency\(sshClient\)/.test(gbody), 'getRemoteStats calls the probe');
-    assert.ok(/Promise\.all\(\[/.test(gbody), 'probe runs in parallel with stats exec');
-    assert.ok(/latency:\s*\{\s*ms: latencyMs/.test(gbody), 'latency.ms comes from the probe');
-    assert.ok(!/now - startedAt/.test(gbody), 'latency must NOT reuse stats exec wall time');
+test('stats.js no longer measures latency itself (handshake lives in server.js)', () => {
+    assert.ok(!/function probeLatency\(/.test(statsJs), 'empty-exec probe must be gone');
+    assert.ok(!/latency:\s*\{/.test(statsJs), 'stats.js must not stamp latency.ms');
+    assert.ok(!/sshClient\.exec\('true'/.test(statsJs), 'must not exec true on the live session');
+});
+
+test('server.js measures latency via testSSHConnection (same path as 编辑→测试连接)', () => {
+    const idx = serverJs.indexOf('function startStatsPush()');
+    assert.ok(idx > 0, 'startStatsPush must exist');
+    const body = serverJs.slice(idx, idx + 3600);
+    assert.ok(/const kickHandshakeLatency = \(\) =>/.test(body), 'handshake kick is extracted');
+    assert.ok(/kickHandshakeLatency\(\);/.test(body), 'handshake starts immediately, not after stats exec');
+    assert.ok(/testSSHConnection\(statsConnectionConfig/.test(body), 'must call testSSHConnection');
+    assert.ok(/acceptHandshakeLatency\(probe\)/.test(body), 'must accept only a successful handshake durationMs');
+    assert.ok(/shouldRefreshHandshakeLatency\(/.test(body), 'handshake is throttled by helper');
+    assert.ok(/STATS_LATENCY_INTERVAL_MS/.test(body), 'handshake interval constant exists');
+    assert.ok(/latency:\s*\{\s*ms: statsLatencyMs/.test(body), 'payload carries cached handshake ms');
+});
+
+test('connection config is captured on connect and restored on attach', () => {
+    assert.ok(/statsConnectionConfig = conn;/.test(serverJs), 'connect stores config');
+    assert.ok(/statsConnectionConfig = session\.connectionConfig/.test(serverJs), 'attach restores config');
 });
 
 test('monitor skeleton renders a dedicated latency block with a line canvas', () => {


### PR DESCRIPTION
## 根因

v1.1.532 的空 `exec('true')` 探针在已有 SSH 会话上测环回：`stream.end()` 把通道掐死，并且和 stats 采样并行撞 MaxSessions，结果每次都是 `null` → 前端一直 `-- ms`。而且那也不是用户要的数字。

用户要的是 **编辑 → 测试连接** 那个延迟：`testSSHConnection` → `createRoutedSSHConnection` 的墙钟（TCP + 跳板 + 认证）。

## 修

- 监控延迟直接调用 `testSSHConnection`，口径与测试连接完全一致。
- 握手与 1s stats 采样**并行**发出（不再等 stats 命令跑完才开始测，避免首屏一直 `--`）。
- 节流 5s，只缓存成功的 `durationMs`；失败保留上次成功值，绝不拿 stats exec 墙钟冒充。
- 抽出 `handshake-latency.js`（accept / throttle）可单测。`stats.js` 不再填 latency。

## 测试

`handshake-latency` 4 项可执行 + `monitor-latency-contract` 7 项静态契约，全绿。