### PR TITLE
fix(android): persist envelope identity as JSON so sync cannot crash

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
@@ -829,24 +829,23 @@ class AccountContainer(
 
     private suspend fun restorePublishedEnvelopeIdentity() {
         if (localMode) return
-        val storedId = runCatching {
-            database.devicePreferenceDao().find(ENVELOPE_SERVER_ID_PREF)?.valueJson
-        }.getOrNull()?.trim().orEmpty()
+        val storedId = PublishedEnvelopePrefs.decodeServerId(
+            runCatching {
+                database.devicePreferenceDao().find(ENVELOPE_SERVER_ID_PREF)?.valueJson
+            }.getOrNull(),
+        )
         if (storedId.isNotEmpty()) {
             envelopeServerId.value = storedId
         }
-        val storedKey = runCatching {
-            database.devicePreferenceDao().find(ENVELOPE_SERVER_KEY_PREF)?.valueJson
-        }.getOrNull()?.trim().orEmpty()
-        if (storedKey.isEmpty()) return
-        val parts = storedKey.split(':', limit = 2)
-        val version = parts.getOrNull(0)?.toIntOrNull() ?: return
-        val publicKey = parts.getOrNull(1)?.let { encoded ->
-            runCatching { one.zephyr.mobile.model.Base64Codec.decode(encoded) }.getOrNull()
-        } ?: return
-        if (version > 0 && publicKey.isNotEmpty()) {
-            serverKeyState.value = ServerEncryptionKey(publicKey = publicKey, keyVersion = version)
-        }
+        val storedKey = PublishedEnvelopePrefs.decodeServerKey(
+            runCatching {
+                database.devicePreferenceDao().find(ENVELOPE_SERVER_KEY_PREF)?.valueJson
+            }.getOrNull(),
+        ) ?: return
+        serverKeyState.value = ServerEncryptionKey(
+            publicKey = storedKey.second,
+            keyVersion = storedKey.first,
+        )
     }
 
     private fun rememberPublishedEnvelopeIdentity(
@@ -855,7 +854,7 @@ class AccountContainer(
     ) {
         if (publishedServerId.isNotEmpty()) {
             envelopeServerId.value = publishedServerId
-            persistPreference(ENVELOPE_SERVER_ID_PREF, publishedServerId)
+            persistPreference(ENVELOPE_SERVER_ID_PREF, PublishedEnvelopePrefs.encodeServerId(publishedServerId))
         }
         if (encryption == null) return
         val decoded = runCatching {
@@ -865,7 +864,7 @@ class AccountContainer(
         serverKeyState.value = ServerEncryptionKey(publicKey = decoded, keyVersion = encryption.keyVersion)
         persistPreference(
             ENVELOPE_SERVER_KEY_PREF,
-            encryption.keyVersion.toString() + ":" + one.zephyr.mobile.model.Base64Codec.encode(decoded),
+            PublishedEnvelopePrefs.encodeServerKey(encryption.keyVersion, decoded),
         )
     }
 

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/PublishedEnvelopePrefs.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/PublishedEnvelopePrefs.kt
@@ -1,0 +1,59 @@
+package one.zephyr.mobile.app.di
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import one.zephyr.mobile.data.EntityCodec
+import one.zephyr.mobile.model.Base64Codec
+
+/**
+ * Wire form for the published envelope identity rows in `device_preferences`.
+ *
+ * That table is observed as a map of JSON objects (language, theme, app lock).
+ * A bare `srv-...` string is not an object: kotlinx.serialization throws, Compose
+ * collection of [one.zephyr.mobile.data.repository.SettingsRepository.observePreferences]
+ * crashes the process the moment capabilities persist. Store `{"value":...}` and
+ * still read the pre56 crash-write so a device that already died on first sync
+ * can open envelopes after the upgrade.
+ */
+internal object PublishedEnvelopePrefs {
+
+    fun encodeServerId(id: String): String =
+        EntityCodec.encode(JsonObject(mapOf("value" to JsonPrimitive(id))))
+
+    fun decodeServerId(raw: String?): String {
+        val text = raw?.trim().orEmpty()
+        if (text.isEmpty()) return ""
+        runCatching { EntityCodec.parse(text) }.getOrNull()?.let { obj ->
+            return EntityCodec.string(obj, "value").orEmpty()
+        }
+        if (text.startsWith("{") || text.startsWith("[")) return ""
+        return text
+    }
+
+    fun encodeServerKey(keyVersion: Int, publicKey: ByteArray): String =
+        EntityCodec.encode(
+            JsonObject(
+                mapOf(
+                    "keyVersion" to JsonPrimitive(keyVersion),
+                    "publicKey" to JsonPrimitive(Base64Codec.encode(publicKey)),
+                ),
+            ),
+        )
+
+    fun decodeServerKey(raw: String?): Pair<Int, ByteArray>? {
+        val text = raw?.trim().orEmpty()
+        if (text.isEmpty()) return null
+        runCatching { EntityCodec.parse(text) }.getOrNull()?.let { obj ->
+            val version = EntityCodec.intOrNull(obj, "keyVersion") ?: return null
+            val encoded = EntityCodec.string(obj, "publicKey") ?: return null
+            val publicKey = runCatching { Base64Codec.decode(encoded) }.getOrNull() ?: return null
+            return if (version > 0 && publicKey.isNotEmpty()) version to publicKey else null
+        }
+        val parts = text.split(':', limit = 2)
+        val version = parts.getOrNull(0)?.toIntOrNull() ?: return null
+        val publicKey = parts.getOrNull(1)?.let { encoded ->
+            runCatching { Base64Codec.decode(encoded) }.getOrNull()
+        } ?: return null
+        return if (version > 0 && publicKey.isNotEmpty()) version to publicKey else null
+    }
+}

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/di/PublishedEnvelopePrefsTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/di/PublishedEnvelopePrefsTest.kt
@@ -1,0 +1,59 @@
+package one.zephyr.mobile.app.di
+
+import one.zephyr.mobile.data.EntityCodec
+import one.zephyr.mobile.model.Base64Codec
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PublishedEnvelopePrefsTest {
+
+    @Test
+    fun `serverId round-trips as a JSON object SettingsRepository can parse`() {
+        val encoded = PublishedEnvelopePrefs.encodeServerId("srv-published")
+        val parsed = EntityCodec.parse(encoded)
+        assertEquals("srv-published", EntityCodec.string(parsed, "value"))
+        assertEquals("srv-published", PublishedEnvelopePrefs.decodeServerId(encoded))
+    }
+
+    @Test
+    fun `serverId still reads the pre56 crash-write bare string`() {
+        assertEquals("srv-published", PublishedEnvelopePrefs.decodeServerId("srv-published"))
+        assertEquals("", PublishedEnvelopePrefs.decodeServerId("{not-json"))
+        assertEquals("", PublishedEnvelopePrefs.decodeServerId(""))
+    }
+
+    @Test
+    fun `serverKey round-trips without a colon-split payload`() {
+        val publicKey = byteArrayOf(1, 2, 3, 4, 5)
+        val encoded = PublishedEnvelopePrefs.encodeServerKey(7, publicKey)
+        val parsed = EntityCodec.parse(encoded)
+        assertEquals(7, EntityCodec.intOrNull(parsed, "keyVersion"))
+        val decoded = PublishedEnvelopePrefs.decodeServerKey(encoded)
+        assertNotNull(decoded)
+        assertEquals(7, decoded!!.first)
+        assertArrayEquals(publicKey, decoded.second)
+    }
+
+    @Test
+    fun `serverKey still reads the pre56 version-colon-base64 write`() {
+        val publicKey = byteArrayOf(9, 8, 7)
+        val legacy = "3:" + Base64Codec.encode(publicKey)
+        val decoded = PublishedEnvelopePrefs.decodeServerKey(legacy)
+        assertNotNull(decoded)
+        assertEquals(3, decoded!!.first)
+        assertArrayEquals(publicKey, decoded.second)
+    }
+
+    @Test
+    fun `encoded rows are JSON objects so observePreferences cannot throw`() {
+        val id = PublishedEnvelopePrefs.encodeServerId("srv-1")
+        val key = PublishedEnvelopePrefs.encodeServerKey(1, byteArrayOf(1))
+        assertTrue(id.startsWith("{"))
+        assertTrue(key.startsWith("{"))
+        EntityCodec.parse(id)
+        EntityCodec.parse(key)
+    }
+}

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/SettingsRepository.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/SettingsRepository.kt
@@ -79,11 +79,13 @@ class SettingsRepository(
 
     fun observePreferences(): Flow<Map<String, JsonObject>> =
         db.devicePreferenceDao().observeAll().map { rows ->
-            rows.associate { row -> row.key to EntityCodec.parse(row.valueJson) }
+            rows.mapNotNull { row ->
+                parsePreferenceValue(row.valueJson)?.let { row.key to it }
+            }.toMap()
         }
 
     suspend fun preference(key: String): JsonObject? =
-        db.devicePreferenceDao().find(key)?.let { EntityCodec.parse(it.valueJson) }
+        db.devicePreferenceDao().find(key)?.let { parsePreferenceValue(it.valueJson) }
 
     suspend fun putPreference(key: String, value: JsonObject, nowMs: Long) {
         db.devicePreferenceDao().upsert(
@@ -135,5 +137,14 @@ class SettingsRepository(
         const val PREF_AI_SKILLS = "one.ai.skills"
         const val PREF_AI_ENV_NAMES = "one.ai.envNames"
         const val PREF_AI_ENV_VALUES = "one.ai.envValues"
+
+        /**
+         * `device_preferences.valueJson` is documented as a JSON object, but the
+         * table also holds opaque markers (hex readiness) and, briefly, a bare
+         * envelope serverId. Those must not crash the Compose collectors on
+         * [observePreferences].
+         */
+        internal fun parsePreferenceValue(valueJson: String): JsonObject? =
+            runCatching { EntityCodec.parse(valueJson) }.getOrNull()
     }
 }

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/repository/SettingsRepositoryPreferenceParseTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/repository/SettingsRepositoryPreferenceParseTest.kt
@@ -1,0 +1,20 @@
+package one.zephyr.mobile.data.repository
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import one.zephyr.mobile.data.EntityCodec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SettingsRepositoryPreferenceParseTest {
+
+    @Test
+    fun `JSON objects survive and bare strings are skipped`() {
+        val objectRow = EntityCodec.encode(JsonObject(mapOf("value" to JsonPrimitive("zh"))))
+        assertEquals("zh", EntityCodec.string(SettingsRepository.parsePreferenceValue(objectRow)!!, "value"))
+        assertNull(SettingsRepository.parsePreferenceValue("srv-published"))
+        assertNull(SettingsRepository.parsePreferenceValue("deadbeef"))
+        assertNull(SettingsRepository.parsePreferenceValue("{"))
+    }
+}

--- a/zephyr_one/mobile/tests/android-link-runtime.test.mjs
+++ b/zephyr_one/mobile/tests/android-link-runtime.test.mjs
@@ -101,6 +101,13 @@ test('Android resolves Link hostnames before the CGO-less Go core dials', () => 
   assert.match(account, /ENVELOPE_SERVER_ID_PREF/);
   assert.match(account, /restorePublishedEnvelopeIdentity\(\)/);
   assert.match(account, /rememberPublishedEnvelopeIdentity/);
+  assert.match(account, /PublishedEnvelopePrefs\.encodeServerId/);
+  assert.match(account, /PublishedEnvelopePrefs\.decodeServerId/);
+  const prefs = read('android/app/src/main/kotlin/one/zephyr/mobile/app/di/PublishedEnvelopePrefs.kt');
+  assert.match(prefs, /JsonObject\(mapOf\("value" to JsonPrimitive\(id\)\)\)/);
+  const settings = read('android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/SettingsRepository.kt');
+  assert.match(settings, /parsePreferenceValue\(row\.valueJson\)/);
+  assert.match(settings, /runCatching \{ EntityCodec\.parse\(valueJson\) \}\.getOrNull\(\)/);
 });
 
 test('Android publishes local-to-bound account replacement atomically', () => {


### PR DESCRIPTION
pre56 一同步就闪退。

根因：#102 把信封 `serverId` 写成 `device_preferences` 的裸字符串 `srv-...`。那张表被 `SettingsRepository.observePreferences()` 整表当 JSON 对象解析（主题/语言/应用锁）。kotlinx.serialization 对非对象直接抛，Compose 收集器把进程打死。空账号以前能过，是因为 capabilities 还没把这行写进去。

修：
- 写成 `{"value":"..."}` / `{"keyVersion":N,"publicKey":"..."}`
- 仍能读 pre56 那次崩溃写入，升级后不用清数据
- `observePreferences` 跳过非 JSON 对象行（hex 就绪标记本来也不该炸）

主端 Docker 不用重发。移动必须发 **zom-v1.0.0pre57**。