### PR TITLE
feat(android): land liquid glass effect for mobile ui

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -31,6 +31,7 @@ import one.zephyr.mobile.ui.component.TextButton
 import one.zephyr.mobile.ui.theme.ZephyrTextStyles
 import one.zephyr.mobile.ui.theme.ZephyrTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -135,6 +136,9 @@ import one.zephyr.mobile.security.AuthResult
 import one.zephyr.mobile.security.UnlockPresentation
 import one.zephyr.mobile.data.session.SessionExecution
 import one.zephyr.mobile.ui.chrome.PushedPageHeader
+import one.zephyr.mobile.ui.glass.LocalBackdrop
+import one.zephyr.mobile.ui.glass.layerBackdrop
+import one.zephyr.mobile.ui.glass.rememberLayerBackdrop
 import one.zephyr.mobile.ui.island.FloatingIsland
 import one.zephyr.mobile.ui.island.IslandDestination
 import one.zephyr.mobile.ui.island.islandContentBottomInset
@@ -513,13 +517,18 @@ private fun BoundRoot(
         route = popRoute(route)
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        val current = route
+    val rootBackdrop = rememberLayerBackdrop()
 
-        AnimatedContent(
-            targetState = current,
-            modifier = Modifier.fillMaxSize(),
-            contentKey = ::routeContentKey,
+    CompositionLocalProvider(LocalBackdrop provides rootBackdrop) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            val current = route
+
+            AnimatedContent(
+                targetState = current,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .layerBackdrop(rootBackdrop),
+                contentKey = ::routeContentKey,
             transitionSpec = {
                 routeTransition(
                     initial = initialState,
@@ -1041,6 +1050,7 @@ private fun BoundRoot(
             modifier = Modifier.align(Alignment.BottomCenter),
             onDismiss = { toastMessage = null },
         )
+    }
     }
 }
 

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Backdrop.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Backdrop.kt
@@ -1,0 +1,187 @@
+package one.zephyr.mobile.ui.glass
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+
+interface Backdrop {
+    val isCoordinatesDependent: Boolean
+
+    fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)? = null,
+    )
+}
+
+val LocalBackdrop = staticCompositionLocalOf<Backdrop> { emptyBackdrop() }
+
+@Stable
+fun emptyBackdrop(): Backdrop = EmptyBackdrop
+
+@Immutable
+private object EmptyBackdrop : Backdrop {
+    override val isCoordinatesDependent: Boolean = false
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+    }
+}
+
+private val DefaultOnDraw: ContentDrawScope.() -> Unit = { drawContent() }
+
+@Composable
+fun rememberLayerBackdrop(
+    graphicsLayer: GraphicsLayer = rememberGraphicsLayer(),
+    onDraw: ContentDrawScope.() -> Unit = DefaultOnDraw,
+): LayerBackdrop {
+    return remember(graphicsLayer, onDraw) {
+        LayerBackdrop(graphicsLayer, onDraw)
+    }
+}
+
+@Stable
+class LayerBackdrop internal constructor(
+    val graphicsLayer: GraphicsLayer,
+    internal val onDraw: ContentDrawScope.() -> Unit,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean = true
+
+    internal var layerCoordinates: LayoutCoordinates? by mutableStateOf(null)
+
+    private var inverseLayerScope: InverseLayerScope? = null
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        val coords = coordinates ?: return
+        val layerCoords = layerCoordinates ?: return
+        withTransform({
+            if (layerBlock != null) {
+                with(obtainInverseLayerScope()) { inverseTransform(density, layerBlock) }
+            }
+            val offset = try {
+                layerCoords.localPositionOf(coords)
+            } catch (_: Exception) {
+                coords.positionInWindow() - layerCoords.positionInWindow()
+            }
+            translate(-offset.x, -offset.y)
+        }) {
+            drawLayer(graphicsLayer)
+        }
+    }
+
+    private fun obtainInverseLayerScope(): InverseLayerScope {
+        return inverseLayerScope?.apply { reset() }
+            ?: InverseLayerScope().also { inverseLayerScope = it }
+    }
+}
+
+fun Modifier.layerBackdrop(backdrop: LayerBackdrop): Modifier =
+    this.then(LayerBackdropElement(backdrop))
+
+private class LayerBackdropElement(
+    val backdrop: LayerBackdrop,
+) : ModifierNodeElement<LayerBackdropNode>() {
+
+    override fun create(): LayerBackdropNode {
+        return LayerBackdropNode(backdrop)
+    }
+
+    override fun update(node: LayerBackdropNode) {
+        if (node.backdrop != backdrop) {
+            node.backdrop.layerCoordinates = null
+            node.backdrop = backdrop
+        }
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "layerBackdrop"
+        properties["backdrop"] = backdrop
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LayerBackdropElement) return false
+        return backdrop == other.backdrop
+    }
+
+    override fun hashCode(): Int = backdrop.hashCode()
+}
+
+private class LayerBackdropNode(
+    var backdrop: LayerBackdrop,
+) : DrawModifierNode, GlobalPositionAwareModifierNode, Modifier.Node() {
+
+    override fun ContentDrawScope.draw() {
+        drawContent()
+        recordLayer(backdrop.graphicsLayer) { backdrop.onDraw(this@draw) }
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        if (coordinates.isAttached) {
+            backdrop.layerCoordinates = coordinates
+        }
+    }
+
+    override fun onDetach() {
+        backdrop.layerCoordinates = null
+    }
+}
+
+@Composable
+fun rememberCombinedBackdrop(
+    backdrop1: Backdrop,
+    backdrop2: Backdrop,
+): Backdrop {
+    return remember(backdrop1, backdrop2) {
+        Combined2Backdrops(backdrop1, backdrop2)
+    }
+}
+
+@Immutable
+private class Combined2Backdrops(
+    val backdrop1: Backdrop,
+    val backdrop2: Backdrop,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean =
+        backdrop1.isCoordinatesDependent || backdrop2.isCoordinatesDependent
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        with(backdrop1) { drawBackdrop(density, coordinates, layerBlock) }
+        with(backdrop2) { drawBackdrop(density, coordinates, layerBlock) }
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/BackdropEffectScope.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/BackdropEffectScope.kt
@@ -1,0 +1,67 @@
+package one.zephyr.mobile.ui.glass
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+
+sealed interface BackdropEffectScope : Density, RuntimeShaderCache {
+    val size: Size
+    val layoutDirection: LayoutDirection
+    val shape: Shape
+    var padding: Float
+    var renderEffect: RenderEffect?
+}
+
+internal abstract class BackdropEffectScopeImpl : BackdropEffectScope, RuntimeShaderCache {
+    override var density: Float = 1f
+    override var fontScale: Float = 1f
+    override var size: Size = Size.Unspecified
+    override var layoutDirection: LayoutDirection = LayoutDirection.Ltr
+    override var padding: Float = 0f
+    override var renderEffect: RenderEffect? = null
+
+    private val runtimeShaderCache = RuntimeShaderCacheImpl()
+
+    override fun obtainRuntimeShader(key: String, string: String): RuntimeShader {
+        return runtimeShaderCache.obtainRuntimeShader(key, string)
+    }
+
+    fun update(scope: DrawScope): Boolean {
+        val newDensity = scope.density
+        val newFontScale = scope.fontScale
+        val newSize = scope.size
+        val newLayoutDirection = scope.layoutDirection
+
+        val changed = newDensity != density ||
+            newFontScale != fontScale ||
+            newSize != size ||
+            newLayoutDirection != layoutDirection
+
+        if (changed) {
+            density = newDensity
+            fontScale = newFontScale
+            size = newSize
+            layoutDirection = newLayoutDirection
+        }
+        return changed
+    }
+
+    fun apply(effects: BackdropEffectScope.() -> Unit) {
+        padding = 0f
+        renderEffect = null
+        effects()
+    }
+
+    fun reset() {
+        density = 1f
+        fontScale = 1f
+        size = Size.Unspecified
+        layoutDirection = LayoutDirection.Ltr
+        padding = 0f
+        renderEffect = null
+        runtimeShaderCache.clear()
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
@@ -1,0 +1,366 @@
+package one.zephyr.mobile.ui.glass
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.observeReads
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+
+private val DefaultHighlight = { Highlight.Default }
+private val DefaultShadow = { Shadow.Default }
+private val DefaultOnDrawBackdrop: DrawScope.(DrawScope.() -> Unit) -> Unit = { it() }
+
+fun Modifier.drawPlainBackdrop(
+    backdrop: Backdrop,
+    shape: () -> Shape,
+    effects: BackdropEffectScope.() -> Unit,
+    layerBlock: (GraphicsLayerScope.() -> Unit)? = null,
+    exportedBackdrop: LayerBackdrop? = null,
+    onDrawBehind: (DrawScope.() -> Unit)? = null,
+    onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit = DefaultOnDrawBackdrop,
+    onDrawSurface: (DrawScope.() -> Unit)? = null,
+    onDrawFront: (DrawScope.() -> Unit)? = null,
+): Modifier {
+    val shapeProvider = ShapeProvider(shape)
+    return this
+        .then(
+            if (layerBlock != null) {
+                Modifier.graphicsLayer(layerBlock)
+            } else {
+                Modifier
+            },
+        )
+        .then(
+            DrawBackdropElement(
+                backdrop = backdrop,
+                shapeProvider = shapeProvider,
+                effects = effects,
+                layerBlock = layerBlock,
+                exportedBackdrop = exportedBackdrop,
+                onDrawBehind = onDrawBehind,
+                onDrawBackdrop = onDrawBackdrop,
+                onDrawSurface = onDrawSurface,
+                onDrawFront = onDrawFront,
+            ),
+        )
+}
+
+fun Modifier.drawBackdrop(
+    backdrop: Backdrop,
+    shape: () -> Shape,
+    effects: BackdropEffectScope.() -> Unit,
+    highlight: (() -> Highlight?)? = DefaultHighlight,
+    shadow: (() -> Shadow?)? = DefaultShadow,
+    innerShadow: (() -> InnerShadow?)? = null,
+    layerBlock: (GraphicsLayerScope.() -> Unit)? = null,
+    exportedBackdrop: LayerBackdrop? = null,
+    onDrawBehind: (DrawScope.() -> Unit)? = null,
+    onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit = DefaultOnDrawBackdrop,
+    onDrawSurface: (DrawScope.() -> Unit)? = null,
+    onDrawFront: (DrawScope.() -> Unit)? = null,
+): Modifier {
+    val shapeProvider = ShapeProvider(shape)
+    return this
+        .then(
+            if (layerBlock != null) {
+                Modifier.graphicsLayer(layerBlock)
+            } else {
+                Modifier
+            },
+        )
+        .then(
+            if (innerShadow != null) {
+                InnerShadowElement(
+                    shapeProvider = shapeProvider,
+                    shadow = innerShadow,
+                )
+            } else {
+                Modifier
+            },
+        )
+        .then(
+            if (shadow != null) {
+                ShadowElement(
+                    shapeProvider = shapeProvider,
+                    shadow = shadow,
+                )
+            } else {
+                Modifier
+            },
+        )
+        .then(
+            if (highlight != null) {
+                HighlightElement(
+                    shapeProvider = shapeProvider,
+                    highlight = highlight,
+                )
+            } else {
+                Modifier
+            },
+        )
+        .then(
+            DrawBackdropElement(
+                backdrop = backdrop,
+                shapeProvider = shapeProvider,
+                effects = effects,
+                layerBlock = layerBlock,
+                exportedBackdrop = exportedBackdrop,
+                onDrawBehind = onDrawBehind,
+                onDrawBackdrop = onDrawBackdrop,
+                onDrawSurface = onDrawSurface,
+                onDrawFront = onDrawFront,
+            ),
+        )
+}
+
+private class DrawBackdropElement(
+    val backdrop: Backdrop,
+    val shapeProvider: ShapeProvider,
+    val effects: BackdropEffectScope.() -> Unit,
+    val layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    val exportedBackdrop: LayerBackdrop?,
+    val onDrawBehind: (DrawScope.() -> Unit)?,
+    val onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit,
+    val onDrawSurface: (DrawScope.() -> Unit)?,
+    val onDrawFront: (DrawScope.() -> Unit)?,
+) : ModifierNodeElement<DrawBackdropNode>() {
+
+    override fun create(): DrawBackdropNode = DrawBackdropNode(
+        backdrop = backdrop,
+        shapeProvider = shapeProvider,
+        effects = effects,
+        layerBlock = layerBlock,
+        exportedBackdrop = exportedBackdrop,
+        onDrawBehind = onDrawBehind,
+        onDrawBackdrop = onDrawBackdrop,
+        onDrawSurface = onDrawSurface,
+        onDrawFront = onDrawFront,
+    )
+
+    override fun update(node: DrawBackdropNode) {
+        node.backdrop = backdrop
+        node.shapeProvider = shapeProvider
+        node.effects = effects
+        node.layerBlock = layerBlock
+        if (node.exportedBackdrop != exportedBackdrop) {
+            node.exportedBackdrop?.layerCoordinates = null
+            node.exportedBackdrop = exportedBackdrop
+        }
+        node.onDrawBehind = onDrawBehind
+        node.onDrawBackdrop = onDrawBackdrop
+        node.onDrawSurface = onDrawSurface
+        node.onDrawFront = onDrawFront
+        node.invalidateDrawCache()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "drawBackdrop"
+        properties["backdrop"] = backdrop
+        properties["shapeProvider"] = shapeProvider
+        properties["effects"] = effects
+        properties["layerBlock"] = layerBlock
+        properties["exportedBackdrop"] = exportedBackdrop
+        properties["onDrawBehind"] = onDrawBehind
+        properties["onDrawBackdrop"] = onDrawBackdrop
+        properties["onDrawSurface"] = onDrawSurface
+        properties["onDrawFront"] = onDrawFront
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DrawBackdropElement) return false
+        return backdrop == other.backdrop &&
+            shapeProvider == other.shapeProvider &&
+            effects == other.effects &&
+            layerBlock == other.layerBlock &&
+            exportedBackdrop == other.exportedBackdrop &&
+            onDrawBehind == other.onDrawBehind &&
+            onDrawBackdrop == other.onDrawBackdrop &&
+            onDrawSurface == other.onDrawSurface &&
+            onDrawFront == other.onDrawFront
+    }
+
+    override fun hashCode(): Int {
+        var result = backdrop.hashCode()
+        result = 31 * result + shapeProvider.hashCode()
+        result = 31 * result + effects.hashCode()
+        result = 31 * result + (layerBlock?.hashCode() ?: 0)
+        result = 31 * result + (exportedBackdrop?.hashCode() ?: 0)
+        result = 31 * result + (onDrawBehind?.hashCode() ?: 0)
+        result = 31 * result + onDrawBackdrop.hashCode()
+        result = 31 * result + (onDrawSurface?.hashCode() ?: 0)
+        result = 31 * result + (onDrawFront?.hashCode() ?: 0)
+        return result
+    }
+}
+
+private class DrawBackdropNode(
+    var backdrop: Backdrop,
+    var shapeProvider: ShapeProvider,
+    var effects: BackdropEffectScope.() -> Unit,
+    var layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    var exportedBackdrop: LayerBackdrop?,
+    var onDrawBehind: (DrawScope.() -> Unit)?,
+    var onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit,
+    var onDrawSurface: (DrawScope.() -> Unit)?,
+    var onDrawFront: (DrawScope.() -> Unit)?,
+) : LayoutModifierNode, DrawModifierNode, GlobalPositionAwareModifierNode, ObserverModifierNode, Modifier.Node() {
+
+    private val effectScope = object : BackdropEffectScopeImpl() {
+        override val shape: Shape get() = shapeProvider.innerShape
+    }
+
+    private var graphicsLayer: GraphicsLayer? = null
+
+    private val layoutLayerBlock: GraphicsLayerScope.() -> Unit = {
+        clip = true
+        shape = shapeProvider.shape
+        compositingStrategy = CompositingStrategy.Offscreen
+    }
+
+    private var layoutCoordinates: LayoutCoordinates? by mutableStateOf(null, neverEqualPolicy())
+    private var padding by mutableFloatStateOf(0f)
+
+    private val recordBackdropBlock: (DrawScope.() -> Unit) = {
+        val canvas = drawContext.canvas
+        val pad = padding
+
+        if (pad != 0f) {
+            canvas.translate(pad, pad)
+        }
+        onDrawBackdrop {
+            with(backdrop) {
+                drawBackdrop(
+                    density = effectScope,
+                    coordinates = layoutCoordinates,
+                    layerBlock = layerBlock,
+                )
+            }
+        }
+        if (pad != 0f) {
+            canvas.translate(-pad, -pad)
+        }
+    }
+
+    private val drawBackdropLayer: DrawScope.() -> Unit = {
+        val layer = graphicsLayer
+        if (layer != null) {
+            val pad = padding
+            recordLayer(
+                layer,
+                size = IntSize(
+                    size.width.toInt() + pad.toInt() * 2,
+                    size.height.toInt() + pad.toInt() * 2,
+                ),
+                block = recordBackdropBlock,
+            )
+
+            layer.topLeft = if (pad != 0f) IntOffset(-pad.toInt(), -pad.toInt()) else IntOffset.Zero
+            drawLayer(layer)
+        }
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.placeWithLayer(IntOffset.Zero, layerBlock = layoutLayerBlock)
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        if (effectScope.update(this)) {
+            updateEffects()
+        }
+
+        onDrawBehind?.invoke(this)
+        drawBackdropLayer()
+        onDrawSurface?.invoke(this)
+        drawContent()
+        onDrawFront?.invoke(this)
+
+        exportedBackdrop?.graphicsLayer?.let { layer ->
+            recordLayer(layer) {
+                onDrawBehind?.invoke(this)
+                drawBackdropLayer()
+                onDrawSurface?.invoke(this)
+                onDrawFront?.invoke(this)
+            }
+        }
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        if (coordinates.isAttached) {
+            if (backdrop.isCoordinatesDependent) {
+                layoutCoordinates = coordinates
+            } else if (layoutCoordinates != null) {
+                layoutCoordinates = null
+            }
+            exportedBackdrop?.layerCoordinates = coordinates
+        }
+    }
+
+    override fun onObservedReadsChanged() {
+        invalidateDrawCache()
+    }
+
+    fun invalidateDrawCache() {
+        observeEffects()
+    }
+
+    private fun observeEffects() {
+        observeReads { updateEffects() }
+    }
+
+    private fun updateEffects() {
+        if (!isRenderEffectSupported()) return
+
+        effectScope.apply(effects)
+        graphicsLayer?.renderEffect = effectScope.renderEffect
+        padding = effectScope.padding
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        graphicsLayer = graphicsContext.createGraphicsLayer()
+        observeEffects()
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        graphicsLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            graphicsLayer = null
+        }
+
+        effectScope.reset()
+        layoutCoordinates = null
+        exportedBackdrop?.layerCoordinates = null
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Effects.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Effects.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.graphics.ColorMatrixColorFilter
 import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.asAndroidColorFilter
-import androidx.compose.ui.graphics.asAndroidRenderEffect
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.fastCoerceAtLeast

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Effects.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Effects.kt
@@ -1,0 +1,234 @@
+package one.zephyr.mobile.ui.glass
+
+import android.os.Build
+import androidx.annotation.FloatRange
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.ColorMatrixColorFilter
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.asAndroidColorFilter
+import androidx.compose.ui.graphics.asAndroidRenderEffect
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.fastCoerceAtLeast
+import androidx.compose.ui.util.fastCoerceAtMost
+import org.intellij.lang.annotations.Language
+
+@RequiresApi(Build.VERSION_CODES.S)
+internal fun RenderEffect?.chain(other: RenderEffect): RenderEffect {
+    return if (this != null) {
+        android.graphics.RenderEffect.createChainEffect(
+            other.asAndroidRenderEffect(),
+            this.asAndroidRenderEffect(),
+        ).asComposeRenderEffect()
+    } else {
+        other
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+internal fun createRuntimeShaderEffect(
+    runtimeShader: RuntimeShader,
+    uniformShaderName: String,
+): RenderEffect {
+    val androidShader = runtimeShader.asAndroidRuntimeShader()
+        ?: throw IllegalStateException("RuntimeShader must be AndroidRuntimeShader on API 33+")
+    return android.graphics.RenderEffect.createRuntimeShaderEffect(
+        androidShader,
+        uniformShaderName,
+    ).asComposeRenderEffect()
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+internal fun createColorFilterRenderEffect(
+    renderEffect: RenderEffect? = null,
+    colorFilter: ColorFilter,
+): RenderEffect {
+    return if (renderEffect != null) {
+        android.graphics.RenderEffect.createColorFilterEffect(
+            colorFilter.asAndroidColorFilter(),
+            renderEffect.asAndroidRenderEffect(),
+        ).asComposeRenderEffect()
+    } else {
+        android.graphics.RenderEffect.createColorFilterEffect(
+            colorFilter.asAndroidColorFilter(),
+        ).asComposeRenderEffect()
+    }
+}
+
+fun BackdropEffectScope.blur(
+    @FloatRange(from = 0.0) radius: Float,
+    edgeTreatment: TileMode = TileMode.Clamp,
+) {
+    if (!isRenderEffectSupported()) return
+    if (radius <= 0f) return
+
+    if (edgeTreatment != TileMode.Clamp || renderEffect != null) {
+        if (radius > padding) {
+            padding = radius
+        }
+    }
+
+    renderEffect = BlurEffect(
+        renderEffect,
+        radius,
+        radius,
+        edgeTreatment,
+    )
+}
+
+fun BackdropEffectScope.lens(
+    @FloatRange(from = 0.0) refractionHeight: Float,
+    @FloatRange(from = 0.0) refractionAmount: Float,
+    depthEffect: Boolean = false,
+    chromaticAberration: Boolean = false,
+) {
+    if (!isRuntimeShaderSupported()) return
+    if (refractionHeight <= 0f || refractionAmount <= 0f) return
+
+    if (padding > 0f) {
+        padding = (padding - refractionHeight).fastCoerceAtLeast(0f)
+    }
+
+    val radii = cornerRadii
+    if (radii != null) {
+        val shader = if (!chromaticAberration) {
+            obtainRuntimeShader("Refraction", RoundedRectRefractionShaderString)
+        } else {
+            obtainRuntimeShader("RefractionWithDispersion", RoundedRectRefractionWithDispersionShaderString)
+        }
+        shader.apply {
+            setFloatUniform("size", size.width, size.height)
+            setFloatUniform("offset", -padding, -padding)
+            setFloatUniform("cornerRadii", radii)
+            setFloatUniform("refractionHeight", refractionHeight)
+            setFloatUniform("refractionAmount", -refractionAmount)
+            setFloatUniform("depthEffect", if (depthEffect) 1f else 0f)
+            if (chromaticAberration) {
+                setFloatUniform("chromaticAberration", 1f)
+            }
+        }
+        effect(createRuntimeShaderEffect(shader, "content"))
+    }
+}
+
+fun BackdropEffectScope.colorFilter(colorFilter: ColorFilter) {
+    if (!isRenderEffectSupported()) return
+    renderEffect = createColorFilterRenderEffect(renderEffect, colorFilter)
+}
+
+fun BackdropEffectScope.opacity(@FloatRange(from = 0.0, to = 1.0) alpha: Float) {
+    val matrix = ColorMatrix(
+        floatArrayOf(
+            1f, 0f, 0f, 0f, 0f,
+            0f, 1f, 0f, 0f, 0f,
+            0f, 0f, 1f, 0f, 0f,
+            0f, 0f, 0f, alpha, 0f,
+        ),
+    )
+    colorFilter(ColorMatrixColorFilter(matrix))
+}
+
+fun BackdropEffectScope.colorControls(
+    brightness: Float = 0f,
+    contrast: Float = 1f,
+    saturation: Float = 1f,
+) {
+    if (brightness == 0f && contrast == 1f && saturation == 1f) return
+    colorFilter(colorControlsColorFilter(brightness, contrast, saturation))
+}
+
+private val VibrantColorFilter = colorControlsColorFilter(saturation = 1.5f)
+
+fun BackdropEffectScope.vibrancy() {
+    colorFilter(VibrantColorFilter)
+}
+
+fun BackdropEffectScope.effect(effect: RenderEffect) {
+    if (!isRenderEffectSupported()) return
+    renderEffect = renderEffect.chain(effect)
+}
+
+fun BackdropEffectScope.runtimeShaderEffect(
+    key: String,
+    @Language("AGSL") shaderString: String,
+    uniformShaderName: String,
+    block: RuntimeShader.() -> Unit,
+) {
+    if (!isRuntimeShaderSupported()) return
+    val shader = obtainRuntimeShader(key, shaderString).apply(block)
+    val effect = createRuntimeShaderEffect(shader, uniformShaderName)
+    renderEffect = renderEffect.chain(effect)
+}
+
+private val BackdropEffectScope.cornerRadii: FloatArray?
+    get() = when (val s = shape) {
+        is AbsoluteRoundedCornerShape -> {
+            val sz = size
+            val maxRadius = sz.minDimension / 2f
+            val tl = s.topStart.toPx(sz, this)
+            val tr = s.topEnd.toPx(sz, this)
+            val br = s.bottomEnd.toPx(sz, this)
+            val bl = s.bottomStart.toPx(sz, this)
+            floatArrayOf(
+                tl.fastCoerceAtMost(maxRadius),
+                tr.fastCoerceAtMost(maxRadius),
+                br.fastCoerceAtMost(maxRadius),
+                bl.fastCoerceAtMost(maxRadius),
+            )
+        }
+        is CornerBasedShape -> {
+            val sz = size
+            val maxRadius = sz.minDimension / 2f
+            val isLtr = layoutDirection == LayoutDirection.Ltr
+            val tl = if (isLtr) s.topStart.toPx(sz, this) else s.topEnd.toPx(sz, this)
+            val tr = if (isLtr) s.topEnd.toPx(sz, this) else s.topStart.toPx(sz, this)
+            val br = if (isLtr) s.bottomEnd.toPx(sz, this) else s.bottomStart.toPx(sz, this)
+            val bl = if (isLtr) s.bottomStart.toPx(sz, this) else s.bottomEnd.toPx(sz, this)
+            floatArrayOf(
+                tl.fastCoerceAtMost(maxRadius),
+                tr.fastCoerceAtMost(maxRadius),
+                br.fastCoerceAtMost(maxRadius),
+                bl.fastCoerceAtMost(maxRadius),
+            )
+        }
+        else -> {
+            val maxRadius = size.minDimension / 2f
+            floatArrayOf(maxRadius, maxRadius, maxRadius, maxRadius)
+        }
+    }
+
+private fun colorControlsColorFilter(
+    brightness: Float = 0f,
+    contrast: Float = 1f,
+    saturation: Float = 1f,
+): ColorFilter {
+    val invSat = 1f - saturation
+    val r = 0.213f * invSat
+    val g = 0.715f * invSat
+    val b = 0.072f * invSat
+
+    val c = contrast
+    val t = (0.5f - c * 0.5f + brightness) * 255f
+    val s = saturation
+
+    val cr = c * r
+    val cg = c * g
+    val cb = c * b
+    val cs = c * s
+
+    val colorMatrix = ColorMatrix(
+        floatArrayOf(
+            cr + cs, cg, cb, 0f, t,
+            cr, cg + cs, cb, 0f, t,
+            cr, cg, cb + cs, 0f, t,
+            0f, 0f, 0f, 1f, 0f,
+        ),
+    )
+    return ColorMatrixColorFilter(colorMatrix)
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Highlight.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Highlight.kt
@@ -1,0 +1,274 @@
+package one.zephyr.mobile.ui.glass
+
+import android.graphics.BlurMaskFilter
+import androidx.annotation.FloatRange
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastCoerceAtMost
+import kotlin.math.PI
+import kotlin.math.ceil
+
+@Immutable
+data class Highlight(
+    val width: Dp = 0.5f.dp,
+    val blurRadius: Dp = width / 2f,
+    @param:FloatRange(from = 0.0, to = 1.0) val alpha: Float = 1f,
+    val style: HighlightStyle = HighlightStyle.Default,
+) {
+    companion object {
+        @Stable
+        val Default: Highlight = Highlight()
+
+        @Stable
+        val Ambient: Highlight = Highlight(style = HighlightStyle.Ambient)
+
+        @Stable
+        val Plain: Highlight = Highlight(style = HighlightStyle.Plain)
+    }
+}
+
+@Immutable
+interface HighlightStyle {
+    val color: Color
+    val blendMode: BlendMode
+
+    fun DrawScope.createShader(
+        shape: Shape,
+        runtimeShaderCache: RuntimeShaderCache,
+    ): RuntimeShader?
+
+    @Immutable
+    data class Plain(
+        override val color: Color = Color.White.copy(alpha = 0.38f),
+        override val blendMode: BlendMode = BlendMode.Plus,
+    ) : HighlightStyle {
+        override fun DrawScope.createShader(
+            shape: Shape,
+            runtimeShaderCache: RuntimeShaderCache,
+        ): RuntimeShader? = null
+    }
+
+    @Immutable
+    data class Default(
+        override val color: Color = Color.White.copy(alpha = 0.5f),
+        override val blendMode: BlendMode = BlendMode.Plus,
+        val angle: Float = 45f,
+        @param:FloatRange(from = 0.0) val falloff: Float = 1f,
+    ) : HighlightStyle {
+        override fun DrawScope.createShader(
+            shape: Shape,
+            runtimeShaderCache: RuntimeShaderCache,
+        ): RuntimeShader? {
+            return if (isRuntimeShaderSupported()) {
+                runtimeShaderCache.obtainRuntimeShader(
+                    "Default",
+                    DefaultHighlightShaderString,
+                ).apply {
+                    setFloatUniform("size", size.width, size.height)
+                    setFloatUniform("cornerRadii", getCornerRadii(shape))
+                    setColorUniform("color", color.copy(alpha = 1f))
+                    setFloatUniform("angle", angle * (PI / 180f).toFloat())
+                    setFloatUniform("falloff", falloff)
+                }
+            } else {
+                null
+            }
+        }
+    }
+
+    @Immutable
+    data class Ambient(
+        @param:FloatRange(from = 0.0, to = 1.0) val intensity: Float = 0.38f,
+    ) : HighlightStyle {
+        override val color: Color = Color.White.copy(alpha = intensity)
+        override val blendMode: BlendMode = BlendMode.SrcOver
+
+        override fun DrawScope.createShader(
+            shape: Shape,
+            runtimeShaderCache: RuntimeShaderCache,
+        ): RuntimeShader? {
+            return if (isRuntimeShaderSupported()) {
+                runtimeShaderCache.obtainRuntimeShader(
+                    "Ambient",
+                    AmbientHighlightShaderString,
+                ).apply {
+                    setFloatUniform("size", size.width, size.height)
+                    setFloatUniform("cornerRadii", getCornerRadii(shape))
+                    setFloatUniform("angle", 45f * (PI / 180f).toFloat())
+                    setFloatUniform("falloff", 1f)
+                }
+            } else {
+                null
+            }
+        }
+    }
+
+    companion object {
+        @Stable
+        val Default: Default = Default()
+
+        @Stable
+        val Ambient: Ambient = Ambient()
+
+        @Stable
+        val Plain: Plain = Plain()
+    }
+}
+
+private fun DrawScope.getCornerRadii(shape: Shape): FloatArray {
+    val sz = size
+    val maxRadius = sz.minDimension / 2f
+    val cornerShape = shape as? CornerBasedShape ?: return FloatArray(4) { maxRadius }
+    val isLtr = layoutDirection == LayoutDirection.Ltr
+    val tl = if (isLtr) cornerShape.topStart.toPx(sz, this) else cornerShape.topEnd.toPx(sz, this)
+    val tr = if (isLtr) cornerShape.topEnd.toPx(sz, this) else cornerShape.topStart.toPx(sz, this)
+    val br = if (isLtr) cornerShape.bottomEnd.toPx(sz, this) else cornerShape.bottomStart.toPx(sz, this)
+    val bl = if (isLtr) cornerShape.bottomStart.toPx(sz, this) else cornerShape.bottomEnd.toPx(sz, this)
+    return floatArrayOf(
+        tl.fastCoerceAtMost(maxRadius),
+        tr.fastCoerceAtMost(maxRadius),
+        br.fastCoerceAtMost(maxRadius),
+        bl.fastCoerceAtMost(maxRadius),
+    )
+}
+
+internal class HighlightElement(
+    val shapeProvider: ShapeProvider,
+    val highlight: () -> Highlight?,
+) : ModifierNodeElement<HighlightNode>() {
+
+    override fun create(): HighlightNode = HighlightNode(shapeProvider, highlight)
+
+    override fun update(node: HighlightNode) {
+        node.shapeProvider = shapeProvider
+        node.highlight = highlight
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "highlight"
+        properties["shapeProvider"] = shapeProvider
+        properties["highlight"] = highlight
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HighlightElement) return false
+        return shapeProvider == other.shapeProvider && highlight == other.highlight
+    }
+
+    override fun hashCode(): Int = 31 * shapeProvider.hashCode() + highlight.hashCode()
+}
+
+internal class HighlightNode(
+    var shapeProvider: ShapeProvider,
+    var highlight: () -> Highlight?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    private var highlightLayer: GraphicsLayer? = null
+    private val paint = Paint().apply { style = PaintingStyle.Stroke }
+    private var clipPath: Path? = null
+    private val runtimeShaderCache = RuntimeShaderCacheImpl()
+
+    override fun ContentDrawScope.draw() {
+        val hl = highlight()
+        if (hl == null || hl.width.value <= 0f) {
+            drawContent()
+            return
+        }
+
+        drawContent()
+
+        val layer = highlightLayer ?: return
+        val sz = size
+        val density: Density = this
+        val safeSize = IntSize(
+            ceil(sz.width).toInt() + 2,
+            ceil(sz.height).toInt() + 2,
+        )
+
+        val outline = shapeProvider.shape.createOutline(sz, layoutDirection, density)
+        val cp = if (outline is Outline.Rounded) {
+            clipPath ?: Path().also { clipPath = it }
+        } else {
+            null
+        }
+
+        configurePaint(hl)
+
+        layer.alpha = hl.alpha
+        layer.blendMode = hl.style.blendMode
+        layer.record(safeSize) {
+            translate(1f, 1f) {
+                val canvas = drawContext.canvas
+                canvas.save()
+                canvas.clipOutline(outline, cp)
+                canvas.drawOutline(outline, paint)
+                canvas.restore()
+            }
+        }
+
+        translate(-1f, -1f) {
+            drawLayer(layer)
+        }
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        highlightLayer = graphicsContext.createGraphicsLayer()
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        highlightLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            highlightLayer = null
+        }
+        clipPath = null
+        runtimeShaderCache.clear()
+    }
+
+    private fun DrawScope.configurePaint(hl: Highlight) {
+        paint.color = hl.style.color
+        paint.strokeWidth = ceil(hl.width.toPx().fastCoerceAtMost(size.minDimension / 2f)) * 2f
+        val radius = hl.blurRadius.toPx()
+        paint.asFrameworkPaint().maskFilter = if (radius > 0f) BlurMaskFilter(radius, BlurMaskFilter.Blur.NORMAL) else null
+
+        if (isRuntimeShaderSupported()) {
+            val shader = with(hl.style) {
+                createShader(
+                    shape = shapeProvider.shape,
+                    runtimeShaderCache = runtimeShaderCache,
+                )
+            }
+            paint.asFrameworkPaint().shader = shader?.asAndroidRuntimeShader()
+        }
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
@@ -114,8 +114,6 @@ internal class InverseLayerScope : GraphicsLayerScope {
     override var shape: Shape = RectangleShape
     override var clip: Boolean = false
     override var renderEffect: RenderEffect? = null
-    override var blendMode: BlendMode = BlendMode.SrcOver
-    override var colorFilter: ColorFilter? = null
     override var compositingStrategy: CompositingStrategy = CompositingStrategy.Auto
 
     private var matrix: Matrix? = null
@@ -157,8 +155,6 @@ internal class InverseLayerScope : GraphicsLayerScope {
         shape = RectangleShape
         clip = false
         renderEffect = null
-        blendMode = BlendMode.SrcOver
-        colorFilter = null
         compositingStrategy = CompositingStrategy.Auto
         matrix = null
     }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
@@ -1,0 +1,200 @@
+package one.zephyr.mobile.ui.glass
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.DefaultCameraDistance
+import androidx.compose.ui.graphics.DefaultShadowColor
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.DrawTransform
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.toIntSize
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+internal fun DrawScope.recordLayer(
+    layer: GraphicsLayer,
+    size: IntSize = this.size.toIntSize(),
+    density: Density? = null,
+    block: DrawScope.() -> Unit,
+) {
+    val d = density ?: this
+    layer.record(size) {
+        val prevDensity = drawContext.density
+        drawContext.density = d
+        try {
+            this.block()
+        } finally {
+            drawContext.density = prevDensity
+        }
+    }
+}
+
+internal fun Canvas.clipOutline(outline: Outline, path: Path?) {
+    when (outline) {
+        is Outline.Rectangle -> clipRect(outline.rect)
+        is Outline.Rounded -> {
+            path?.let {
+                it.rewind()
+                it.addRoundRect(outline.roundRect)
+                clipPath(it)
+            }
+        }
+        is Outline.Generic -> clipPath(outline.path)
+    }
+}
+
+@Immutable
+internal class ShapeProvider(val shapeBlock: () -> Shape) {
+    private var cachedShape: Shape? = null
+    private var cachedOutline: Outline? = null
+    private var cachedSize: Size = Size.Unspecified
+    private var cachedLayoutDirection: LayoutDirection? = null
+    private var cachedDensity: Float? = null
+
+    val innerShape: Shape
+        get() = shapeBlock()
+
+    val shape = object : Shape {
+        override fun createOutline(
+            size: Size,
+            layoutDirection: LayoutDirection,
+            density: Density,
+        ): Outline {
+            val s = shapeBlock()
+            if (cachedShape != s) {
+                cachedShape = s
+                cachedOutline = null
+            }
+            if (cachedOutline == null || cachedSize != size || cachedLayoutDirection != layoutDirection || cachedDensity != density.density) {
+                cachedSize = size
+                cachedLayoutDirection = layoutDirection
+                cachedDensity = density.density
+                cachedOutline = s.createOutline(size, layoutDirection, density)
+            }
+            return cachedOutline!!
+        }
+    }
+}
+
+internal class InverseLayerScope : GraphicsLayerScope {
+    override var size: Size = Size.Unspecified
+    override var density: Float = 1f
+    override var fontScale: Float = 1f
+    override var scaleX: Float = 1f
+    override var scaleY: Float = 1f
+    override var alpha: Float = 0f
+    override var translationX: Float = 0f
+    override var translationY: Float = 0f
+    override var shadowElevation: Float = 0f
+    override var ambientShadowColor: Color = DefaultShadowColor
+    override var spotShadowColor: Color = DefaultShadowColor
+    override var rotationX: Float = 0f
+    override var rotationY: Float = 0f
+    override var rotationZ: Float = 0f
+    override var cameraDistance: Float = DefaultCameraDistance
+    override var transformOrigin: TransformOrigin = TransformOrigin.Center
+    override var shape: Shape = RectangleShape
+    override var clip: Boolean = false
+    override var renderEffect: RenderEffect? = null
+    override var blendMode: BlendMode = BlendMode.SrcOver
+    override var colorFilter: ColorFilter? = null
+    override var compositingStrategy: CompositingStrategy = CompositingStrategy.Auto
+
+    private var matrix: Matrix? = null
+
+    fun DrawTransform.inverseTransform(
+        density: Density,
+        layerBlock: GraphicsLayerScope.() -> Unit,
+    ) {
+        this@InverseLayerScope.size = size
+        this@InverseLayerScope.density = density.density
+        fontScale = density.fontScale
+
+        layerBlock()
+
+        inverseTransformAtTopLeft(
+            rotationZ = rotationZ,
+            scaleX = scaleX,
+            scaleY = scaleY,
+        )
+    }
+
+    fun reset() {
+        size = Size.Unspecified
+        density = 1f
+        fontScale = 1f
+        scaleX = 1f
+        scaleY = 1f
+        alpha = 1f
+        translationX = 0f
+        translationY = 0f
+        shadowElevation = 0f
+        ambientShadowColor = DefaultShadowColor
+        spotShadowColor = DefaultShadowColor
+        rotationX = 0f
+        rotationY = 0f
+        rotationZ = 0f
+        cameraDistance = DefaultCameraDistance
+        transformOrigin = TransformOrigin.Center
+        shape = RectangleShape
+        clip = false
+        renderEffect = null
+        blendMode = BlendMode.SrcOver
+        colorFilter = null
+        compositingStrategy = CompositingStrategy.Auto
+        matrix = null
+    }
+
+    private fun DrawTransform.inverseTransformAtTopLeft(
+        rotationZ: Float = 0f,
+        scaleX: Float = 1f,
+        scaleY: Float = 1f,
+    ) {
+        if (rotationZ == 0f) {
+            if (scaleX != 0f && scaleY != 0f) {
+                scale(1f / scaleX, 1f / scaleY, Offset.Zero)
+            }
+            return
+        }
+
+        val m = matrix ?: Matrix().also { matrix = it }
+        if (m.values.size < 16) return
+
+        val rz = rotationZ * (PI / 180.0)
+        val rsz = sin(rz).toFloat()
+        val rcz = cos(rz).toFloat()
+
+        val a00 = rcz * scaleX
+        val a01 = rsz * scaleY
+        val a10 = -rsz * scaleX
+        val a11 = rcz * scaleY
+
+        val det = a00 * a11 - a01 * a10
+        if (det == 0f) return
+        val invDet = 1f / det
+        m[0, 0] = a11 * invDet
+        m[0, 1] = -a01 * invDet
+        m[1, 0] = -a10 * invDet
+        m[1, 1] = a00 * invDet
+
+        transform(m)
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/LiquidGlass.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/LiquidGlass.kt
@@ -1,0 +1,151 @@
+package one.zephyr.mobile.ui.glass
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import one.zephyr.mobile.ui.theme.ZephyrRadius
+import one.zephyr.mobile.ui.theme.ZephyrTheme
+
+fun Capsule(): Shape = RoundedCornerShape(percent = 50)
+
+/**
+ * Convenient modifier applying the complete Liquid Glass effect stack:
+ * backdrop sampling -> lens refraction -> blur -> vibrancy -> surface tint -> specular highlight -> ambient shadow.
+ */
+@Composable
+fun Modifier.liquidGlass(
+    backdrop: Backdrop = LocalBackdrop.current,
+    shape: Shape = RoundedCornerShape(ZephyrRadius.pill),
+    tint: Color = Color.Unspecified,
+    surfaceColor: Color = Color.Unspecified,
+    blurRadius: Dp = 12.dp,
+    refractionHeight: Dp = 16.dp,
+    refractionAmount: Dp = 20.dp,
+    depthEffect: Boolean = false,
+    chromaticAberration: Boolean = false,
+    highlight: Highlight? = Highlight.Default,
+    shadow: Shadow? = Shadow.Default,
+    innerShadow: InnerShadow? = null,
+): Modifier {
+    val palette = ZephyrTheme.palette
+    val resolvedSurface = if (surfaceColor.isSpecified) {
+        surfaceColor
+    } else {
+        palette.surfaces.floating.copy(alpha = if (palette.dark) 0.70f else 0.82f)
+    }
+
+    return this.drawBackdrop(
+        backdrop = backdrop,
+        shape = { shape },
+        effects = {
+            vibrancy()
+            if (blurRadius > 0.dp) {
+                blur(blurRadius.toPx())
+            }
+            if (refractionHeight > 0.dp && refractionAmount > 0.dp) {
+                lens(
+                    refractionHeight = refractionHeight.toPx(),
+                    refractionAmount = refractionAmount.toPx(),
+                    depthEffect = depthEffect,
+                    chromaticAberration = chromaticAberration,
+                )
+            }
+        },
+        highlight = if (highlight != null) { { highlight } } else null,
+        shadow = if (shadow != null) { { shadow } } else null,
+        innerShadow = if (innerShadow != null) { { innerShadow } } else null,
+        onDrawSurface = {
+            drawRect(resolvedSurface)
+            if (tint.isSpecified) {
+                drawRect(tint, blendMode = BlendMode.Hue)
+                drawRect(tint.copy(alpha = 0.6f))
+            }
+        },
+    )
+}
+
+/**
+ * High-level interactive Liquid Glass button.
+ */
+@Composable
+fun LiquidButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    backdrop: Backdrop = LocalBackdrop.current,
+    shape: Shape = Capsule(),
+    tint: Color = Color.Unspecified,
+    surfaceColor: Color = Color.Unspecified,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Row(
+        modifier = modifier
+            .liquidGlass(
+                backdrop = backdrop,
+                shape = shape,
+                tint = tint,
+                surfaceColor = surfaceColor,
+                refractionHeight = 12.dp,
+                refractionAmount = 18.dp,
+            )
+            .clip(shape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .height(48.dp)
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+        content = content,
+    )
+}
+
+/**
+ * Liquid Glass container surface.
+ */
+@Composable
+fun LiquidSurface(
+    modifier: Modifier = Modifier,
+    backdrop: Backdrop = LocalBackdrop.current,
+    shape: Shape = RoundedCornerShape(ZephyrRadius.lg),
+    tint: Color = Color.Unspecified,
+    surfaceColor: Color = Color.Unspecified,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .liquidGlass(
+                backdrop = backdrop,
+                shape = shape,
+                tint = tint,
+                surfaceColor = surfaceColor,
+            )
+            .clip(shape),
+        content = content,
+    )
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Platform.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Platform.kt
@@ -1,0 +1,10 @@
+package one.zephyr.mobile.ui.glass
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
+fun isRenderEffectSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
+fun isRuntimeShaderSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/RuntimeShader.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/RuntimeShader.kt
@@ -1,0 +1,112 @@
+package one.zephyr.mobile.ui.glass
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import org.intellij.lang.annotations.Language
+
+interface RuntimeShader {
+    fun setFloatUniform(name: String, value: Float)
+    fun setFloatUniform(name: String, value1: Float, value2: Float)
+    fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float)
+    fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float)
+    fun setFloatUniform(name: String, values: FloatArray)
+
+    fun setIntUniform(name: String, value: Int)
+    fun setIntUniform(name: String, value1: Int, value2: Int)
+    fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int)
+    fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int)
+    fun setIntUniform(name: String, values: IntArray)
+
+    fun setColorUniform(name: String, color: Color)
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+class AndroidRuntimeShader(val shader: android.graphics.RuntimeShader) : RuntimeShader {
+    override fun setFloatUniform(name: String, value: Float) {
+        shader.setFloatUniform(name, value)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float) {
+        shader.setFloatUniform(name, value1, value2)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float) {
+        shader.setFloatUniform(name, value1, value2, value3)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float) {
+        shader.setFloatUniform(name, value1, value2, value3, value4)
+    }
+
+    override fun setFloatUniform(name: String, values: FloatArray) {
+        shader.setFloatUniform(name, values)
+    }
+
+    override fun setIntUniform(name: String, value: Int) {
+        shader.setIntUniform(name, value)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int) {
+        shader.setIntUniform(name, value1, value2)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int) {
+        shader.setIntUniform(name, value1, value2, value3)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int) {
+        shader.setIntUniform(name, value1, value2, value3, value4)
+    }
+
+    override fun setIntUniform(name: String, values: IntArray) {
+        shader.setIntUniform(name, values)
+    }
+
+    override fun setColorUniform(name: String, color: Color) {
+        shader.setColorUniform(name, color.toArgb())
+    }
+}
+
+internal object NoOpRuntimeShader : RuntimeShader {
+    override fun setFloatUniform(name: String, value: Float) {}
+    override fun setFloatUniform(name: String, value1: Float, value2: Float) {}
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float) {}
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float) {}
+    override fun setFloatUniform(name: String, values: FloatArray) {}
+    override fun setIntUniform(name: String, value: Int) {}
+    override fun setIntUniform(name: String, value1: Int, value2: Int) {}
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int) {}
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int) {}
+    override fun setIntUniform(name: String, values: IntArray) {}
+    override fun setColorUniform(name: String, color: Color) {}
+}
+
+fun createRuntimeShader(@Language("AGSL") shaderString: String): RuntimeShader {
+    return if (isRuntimeShaderSupported()) {
+        AndroidRuntimeShader(android.graphics.RuntimeShader(shaderString))
+    } else {
+        NoOpRuntimeShader
+    }
+}
+
+fun RuntimeShader.asAndroidRuntimeShader(): android.graphics.RuntimeShader? {
+    return (this as? AndroidRuntimeShader)?.shader
+}
+
+interface RuntimeShaderCache {
+    fun obtainRuntimeShader(key: String, @Language("AGSL") string: String): RuntimeShader
+}
+
+class RuntimeShaderCacheImpl : RuntimeShaderCache {
+    private val runtimeShaders = mutableMapOf<String, RuntimeShader>()
+
+    override fun obtainRuntimeShader(key: String, string: String): RuntimeShader {
+        return runtimeShaders.getOrPut(key) { createRuntimeShader(string) }
+    }
+
+    fun clear() {
+        runtimeShaders.clear()
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shaders.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shaders.kt
@@ -1,0 +1,194 @@
+/*
+ * Liquid Glass Shaders - AGSL implementation
+ * Ported from Kyant0/AndroidLiquidGlass (Backdrop)
+ * Apache License 2.0
+ */
+
+package one.zephyr.mobile.ui.glass
+
+import org.intellij.lang.annotations.Language
+
+@Language("AGSL")
+private const val RoundedRectSDF = """
+float radiusAt(float2 coord, float4 radii) {
+    if (coord.x >= 0.0) {
+        if (coord.y <= 0.0) return radii.y;
+        else return radii.z;
+    } else {
+        if (coord.y <= 0.0) return radii.x;
+        else return radii.w;
+    }
+}
+
+float sdRoundedRect(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    float outside = length(max(cornerCoord, 0.0)) - radius;
+    float inside = min(max(cornerCoord.x, cornerCoord.y), 0.0);
+    return outside + inside;
+}
+
+float2 gradSdRoundedRect(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
+        return sign(coord) * normalize(max(cornerCoord, 0.0));
+    } else {
+        float gradX = step(cornerCoord.y, cornerCoord.x);
+        return sign(coord) * float2(gradX, 1.0 - gradX);
+    }
+}"""
+
+@Language("AGSL")
+val RoundedRectRefractionShaderString = """
+uniform shader content;
+
+uniform float2 size;
+uniform float2 offset;
+uniform float4 cornerRadii;
+uniform float refractionHeight;
+uniform float refractionAmount;
+uniform float depthEffect;
+
+$RoundedRectSDF
+
+float circleMap(float x) {
+    return 1.0 - sqrt(1.0 - x * x);
+}
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = (coord + offset) - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
+    if (-sd >= refractionHeight) {
+        return content.eval(coord);
+    }
+    sd = min(sd, 0.0);
+    
+    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    
+    float2 refractedCoord = coord + d * grad;
+    return content.eval(refractedCoord);
+}"""
+
+@Language("AGSL")
+val RoundedRectRefractionWithDispersionShaderString = """
+uniform shader content;
+
+uniform float2 size;
+uniform float2 offset;
+uniform float4 cornerRadii;
+uniform float refractionHeight;
+uniform float refractionAmount;
+uniform float depthEffect;
+uniform float chromaticAberration;
+
+$RoundedRectSDF
+
+float circleMap(float x) {
+    return 1.0 - sqrt(1.0 - x * x);
+}
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = (coord + offset) - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
+    if (-sd >= refractionHeight) {
+        return content.eval(coord);
+    }
+    sd = min(sd, 0.0);
+    
+    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    
+    float2 refractedCoord = coord + d * grad;
+    float dispersionIntensity = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));
+    float2 dispersedCoord = d * grad * dispersionIntensity;
+    
+    half4 color = half4(0.0);
+    
+    half4 red = content.eval(refractedCoord + dispersedCoord);
+    color.r += red.r / 3.5;
+    color.a += red.a / 7.0;
+    
+    half4 orange = content.eval(refractedCoord + dispersedCoord * (2.0 / 3.0));
+    color.r += orange.r / 3.5;
+    color.g += orange.g / 7.0;
+    color.a += orange.a / 7.0;
+    
+    half4 yellow = content.eval(refractedCoord + dispersedCoord * (1.0 / 3.0));
+    color.r += yellow.r / 3.5;
+    color.g += yellow.g / 3.5;
+    color.a += yellow.a / 7.0;
+    
+    half4 green = content.eval(refractedCoord);
+    color.g += green.g / 3.5;
+    color.a += green.a / 7.0;
+    
+    half4 cyan = content.eval(refractedCoord - dispersedCoord * (1.0 / 3.0));
+    color.g += cyan.g / 3.5;
+    color.b += cyan.b / 3.0;
+    color.a += cyan.a / 7.0;
+    
+    half4 blue = content.eval(refractedCoord - dispersedCoord * (2.0 / 3.0));
+    color.b += blue.b / 3.0;
+    color.a += blue.a / 7.0;
+    
+    half4 purple = content.eval(refractedCoord - dispersedCoord);
+    color.r += purple.r / 7.0;
+    color.b += purple.b / 3.0;
+    color.a += purple.a / 7.0;
+    
+    return color;
+}"""
+
+@Language("AGSL")
+val DefaultHighlightShaderString = """
+uniform float2 size;
+uniform float4 cornerRadii;
+layout(color) uniform half4 color;
+uniform float angle;
+uniform float falloff;
+
+$RoundedRectSDF
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = coord - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
+    float2 normal = float2(cos(angle), sin(angle));
+    float d = dot(grad, normal);
+    float intensity = pow(abs(d), falloff);
+    return color * intensity;
+}"""
+
+@Language("AGSL")
+val AmbientHighlightShaderString = """
+uniform float2 size;
+uniform float4 cornerRadii;
+uniform float angle;
+uniform float falloff;
+
+$RoundedRectSDF
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = coord - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
+    float2 normal = float2(cos(angle), sin(angle));
+    float d = dot(grad, normal);
+    float intensity = pow(abs(d), falloff);
+    float t = step(0.0, d);
+    return half4(t, t, t, 1.0) * intensity;
+}"""

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shadow.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shadow.kt
@@ -1,0 +1,264 @@
+package one.zephyr.mobile.ui.glass
+
+import android.graphics.BlurMaskFilter
+import androidx.annotation.FloatRange
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.CompositingStrategy
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
+
+@Immutable
+data class Shadow(
+    val radius: Dp = 24f.dp,
+    val offset: DpOffset = DpOffset(0f.dp, radius / 6f),
+    val color: Color = Color.Black.copy(alpha = 0.1f),
+    @param:FloatRange(from = 0.0, to = 1.0) val alpha: Float = 1f,
+    val blendMode: BlendMode = BlendMode.SrcOver,
+) {
+    companion object {
+        @Stable
+        val Default: Shadow = Shadow()
+    }
+}
+
+@Immutable
+data class InnerShadow(
+    val radius: Dp = 24f.dp,
+    val offset: DpOffset = DpOffset(0f.dp, radius),
+    val color: Color = Color.Black.copy(alpha = 0.15f),
+    @param:FloatRange(from = 0.0, to = 1.0) val alpha: Float = 1f,
+    val blendMode: BlendMode = BlendMode.SrcOver,
+) {
+    companion object {
+        @Stable
+        val Default: InnerShadow = InnerShadow()
+    }
+}
+
+private val ShadowMaskPaint = Paint().apply {
+    blendMode = BlendMode.Clear
+}
+
+internal class ShadowElement(
+    val shapeProvider: ShapeProvider,
+    val shadow: () -> Shadow?,
+) : ModifierNodeElement<ShadowNode>() {
+
+    override fun create(): ShadowNode = ShadowNode(shapeProvider, shadow)
+
+    override fun update(node: ShadowNode) {
+        node.shapeProvider = shapeProvider
+        node.shadow = shadow
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "shadow"
+        properties["shapeProvider"] = shapeProvider
+        properties["shadow"] = shadow
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ShadowElement) return false
+        return shapeProvider == other.shapeProvider && shadow == other.shadow
+    }
+
+    override fun hashCode(): Int = 31 * shapeProvider.hashCode() + shadow.hashCode()
+}
+
+internal class ShadowNode(
+    var shapeProvider: ShapeProvider,
+    var shadow: () -> Shadow?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    private var shadowLayer: GraphicsLayer? = null
+    private val paint = Paint()
+
+    override fun ContentDrawScope.draw() {
+        val sh = shadow() ?: run {
+            drawContent()
+            return
+        }
+
+        val layer = shadowLayer
+        if (layer != null) {
+            val sz = size
+            val density: Density = this
+            val radius = sh.radius.toPx()
+            val offsetX = sh.offset.x.toPx()
+            val offsetY = sh.offset.y.toPx()
+            val shadowSize = IntSize(
+                ceil(sz.width + radius * 4f + offsetX).toInt(),
+                ceil(sz.height + radius * 4f + offsetY).toInt(),
+            )
+            val outline = shapeProvider.shape.createOutline(sz, layoutDirection, density)
+
+            paint.color = sh.color
+            val blurRad = sh.radius.toPx()
+            paint.asFrameworkPaint().maskFilter = if (blurRad > 0f) BlurMaskFilter(blurRad, BlurMaskFilter.Blur.NORMAL) else null
+
+            layer.alpha = sh.alpha
+            layer.blendMode = sh.blendMode
+            layer.record(shadowSize) {
+                translate(radius * 2f + offsetX, radius * 2f + offsetY) {
+                    val canvas = drawContext.canvas
+                    canvas.drawOutline(outline, paint)
+                    canvas.translate(-offsetX, -offsetY)
+                    canvas.drawOutline(outline, ShadowMaskPaint)
+                    canvas.translate(offsetX, offsetY)
+                }
+            }
+
+            translate(-radius * 2f, -radius * 2f) {
+                drawLayer(layer)
+            }
+        }
+
+        drawContent()
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer = graphicsContext.createGraphicsLayer().apply {
+            compositingStrategy = CompositingStrategy.Offscreen
+        }
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            shadowLayer = null
+        }
+    }
+}
+
+internal class InnerShadowElement(
+    val shapeProvider: ShapeProvider,
+    val shadow: () -> InnerShadow?,
+) : ModifierNodeElement<InnerShadowNode>() {
+
+    override fun create(): InnerShadowNode = InnerShadowNode(shapeProvider, shadow)
+
+    override fun update(node: InnerShadowNode) {
+        node.shapeProvider = shapeProvider
+        node.shadow = shadow
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "innerShadow"
+        properties["shapeProvider"] = shapeProvider
+        properties["shadow"] = shadow
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InnerShadowElement) return false
+        return shapeProvider == other.shapeProvider && shadow == other.shadow
+    }
+
+    override fun hashCode(): Int = 31 * shapeProvider.hashCode() + shadow.hashCode()
+}
+
+internal class InnerShadowNode(
+    var shapeProvider: ShapeProvider,
+    var shadow: () -> InnerShadow?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    private var shadowLayer: GraphicsLayer? = null
+    private val paint = Paint()
+    private var clipPath: Path? = null
+    private var prevRadius = Float.NaN
+
+    override fun ContentDrawScope.draw() {
+        drawContent()
+
+        if (!isRenderEffectSupported()) return
+
+        val sh = shadow() ?: return
+        val layer = shadowLayer ?: return
+
+        val sz = size
+        val density: Density = this
+        val radius = sh.radius.toPx()
+        val offsetX = sh.offset.x.toPx()
+        val offsetY = sh.offset.y.toPx()
+
+        val outline = shapeProvider.shape.createOutline(sz, layoutDirection, density)
+        val cp = if (outline is Outline.Rounded) {
+            clipPath ?: Path().also { clipPath = it }
+        } else {
+            null
+        }
+
+        paint.color = sh.color
+
+        layer.alpha = sh.alpha
+        layer.blendMode = sh.blendMode
+        if (prevRadius != radius) {
+            layer.renderEffect = if (radius > 0f) BlurEffect(radius, radius, TileMode.Decal) else null
+            prevRadius = radius
+        }
+        layer.record {
+            val canvas = drawContext.canvas
+            canvas.save()
+            canvas.clipOutline(outline, cp)
+            canvas.drawOutline(outline, paint)
+            canvas.translate(offsetX, offsetY)
+            canvas.drawOutline(outline, ShadowMaskPaint)
+            canvas.translate(-offsetX, -offsetY)
+            canvas.restore()
+        }
+
+        val canvas = drawContext.canvas
+        canvas.save()
+        canvas.clipOutline(outline, cp)
+        drawLayer(layer)
+        canvas.restore()
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer = graphicsContext.createGraphicsLayer().apply {
+            compositingStrategy = CompositingStrategy.Offscreen
+        }
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            shadowLayer = null
+        }
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -44,6 +45,13 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import one.zephyr.mobile.ui.component.Icon
 import one.zephyr.mobile.ui.component.Text
+import one.zephyr.mobile.ui.glass.Highlight
+import one.zephyr.mobile.ui.glass.InnerShadow
+import one.zephyr.mobile.ui.glass.LocalBackdrop
+import one.zephyr.mobile.ui.glass.blur
+import one.zephyr.mobile.ui.glass.drawBackdrop
+import one.zephyr.mobile.ui.glass.lens
+import one.zephyr.mobile.ui.glass.vibrancy
 import one.zephyr.mobile.ui.theme.IslandSpec
 import one.zephyr.mobile.ui.theme.ZephyrMotionTokens
 import one.zephyr.mobile.ui.theme.ZephyrTextStyles
@@ -96,6 +104,9 @@ fun FloatingIsland(
         )
         val innerWidth = IslandGeometry.innerWidth(outerWidth, IslandSpec.innerPadding.value)
         val slotWidth = IslandGeometry.slotWidth(innerWidth, destinations.size)
+        val backdrop = LocalBackdrop.current
+        val outerShape = RoundedCornerShape(IslandSpec.outerHeight / 2)
+        val pillShape = RoundedCornerShape(IslandSpec.selectedPillRadius)
 
         Box(
             modifier = Modifier
@@ -103,12 +114,35 @@ fun FloatingIsland(
                 .height(IslandSpec.outerHeight)
                 .shadow(
                     elevation = 12.dp,
-                    shape = RoundedCornerShape(IslandSpec.outerHeight / 2),
+                    shape = outerShape,
                     ambientColor = palette.islandShadow,
                     spotColor = palette.islandShadow,
                 )
-                .clip(RoundedCornerShape(IslandSpec.outerHeight / 2))
-                .background(palette.surfaces.floating)
+                .drawBackdrop(
+                    backdrop = backdrop,
+                    shape = { outerShape },
+                    effects = {
+                        vibrancy()
+                        blur(16f.dp.toPx())
+                        lens(
+                            refractionHeight = 16f.dp.toPx(),
+                            refractionAmount = 24f.dp.toPx(),
+                            depthEffect = true,
+                        )
+                    },
+                    highlight = { Highlight.Default.copy(alpha = if (palette.dark) 0.5f else 0.7f) },
+                    shadow = null,
+                    innerShadow = {
+                        InnerShadow(
+                            radius = 6.dp,
+                            color = if (palette.dark) Color.White.copy(alpha = 0.08f) else Color.Black.copy(alpha = 0.04f),
+                        )
+                    },
+                    onDrawSurface = {
+                        drawRect(palette.surfaces.floating.copy(alpha = if (palette.dark) 0.72f else 0.82f))
+                    },
+                )
+                .clip(outerShape)
                 .padding(IslandSpec.innerPadding),
         ) {
             Box(
@@ -121,8 +155,28 @@ fun FloatingIsland(
                     }
                     .width(slotWidth.dp)
                     .height(IslandSpec.selectedPillHeight)
-                    .clip(RoundedCornerShape(IslandSpec.selectedPillRadius))
-                    .background(palette.islandSelection),
+                    .drawBackdrop(
+                        backdrop = backdrop,
+                        shape = { pillShape },
+                        effects = {
+                            lens(
+                                refractionHeight = 8f.dp.toPx(),
+                                refractionAmount = 14f.dp.toPx(),
+                                chromaticAberration = true,
+                            )
+                        },
+                        highlight = {
+                            Highlight.Default.copy(
+                                width = 0.75f.dp,
+                                alpha = 0.85f,
+                            )
+                        },
+                        shadow = null,
+                        onDrawSurface = {
+                            drawRect(palette.islandSelection.copy(alpha = 0.90f))
+                        },
+                    )
+                    .clip(pillShape),
             )
 
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
@@ -1,0 +1,121 @@
+package one.zephyr.mobile.ui.glass
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LiquidGlassTest {
+
+    @Test
+    fun shaderStringsContainRequiredSdfAndRefractionFunctions() {
+        assertTrue(RoundedRectRefractionShaderString.contains("sdRoundedRect"))
+        assertTrue(RoundedRectRefractionShaderString.contains("gradSdRoundedRect"))
+        assertTrue(RoundedRectRefractionShaderString.contains("radiusAt"))
+        assertTrue(RoundedRectRefractionShaderString.contains("refractionHeight"))
+        assertTrue(RoundedRectRefractionShaderString.contains("refractionAmount"))
+
+        assertTrue(RoundedRectRefractionWithDispersionShaderString.contains("chromaticAberration"))
+        assertTrue(RoundedRectRefractionWithDispersionShaderString.contains("dispersionIntensity"))
+
+        assertTrue(DefaultHighlightShaderString.contains("DefaultHighlight"))
+        assertTrue(DefaultHighlightShaderString.contains("angle"))
+        assertTrue(DefaultHighlightShaderString.contains("falloff"))
+
+        assertTrue(AmbientHighlightShaderString.contains("AmbientHighlight"))
+    }
+
+    @Test
+    fun emptyBackdropDoesNotRequireCoordinates() {
+        val empty = emptyBackdrop()
+        assertFalse(empty.isCoordinatesDependent)
+    }
+
+    @Test
+    fun highlightDefaultsAreConsistent() {
+        val default = Highlight.Default
+        assertEquals(0.5f.dp, default.width)
+        assertEquals(0.25f.dp, default.blurRadius)
+        assertEquals(1f, default.alpha, 0.001f)
+        assertTrue(default.style is HighlightStyle.Default)
+
+        val ambient = Highlight.Ambient
+        assertTrue(ambient.style is HighlightStyle.Ambient)
+
+        val plain = Highlight.Plain
+        assertTrue(plain.style is HighlightStyle.Plain)
+    }
+
+    @Test
+    fun highlightStylesProvideAppropriateBlendModes() {
+        val defaultStyle = HighlightStyle.Default(color = Color.White, angle = 45f)
+        assertEquals(BlendMode.Plus, defaultStyle.blendMode)
+        assertEquals(Color.White, defaultStyle.color)
+
+        val plainStyle = HighlightStyle.Plain()
+        assertEquals(BlendMode.Plus, plainStyle.blendMode)
+
+        val ambientStyle = HighlightStyle.Ambient()
+        assertEquals(BlendMode.SrcOver, ambientStyle.blendMode)
+    }
+
+    @Test
+    fun shadowDefaultsHaveExpectedRadiusAndOffsets() {
+        val shadow = Shadow.Default
+        assertEquals(24f.dp, shadow.radius)
+        assertEquals(DpOffset(0f.dp, 4f.dp), shadow.offset)
+        assertEquals(1f, shadow.alpha, 0.001f)
+
+        val innerShadow = InnerShadow.Default
+        assertEquals(24f.dp, innerShadow.radius)
+        assertEquals(DpOffset(0f.dp, 24f.dp), innerShadow.offset)
+    }
+
+    @Test
+    fun capsuleShapeCreatesRoundedOutline() {
+        val capsule = Capsule()
+        val density = Density(density = 2f, fontScale = 1f)
+        val size = Size(200f, 60f)
+        val outline = capsule.createOutline(size, LayoutDirection.Ltr, density)
+
+        assertTrue(outline is Outline.Rounded)
+        val rounded = outline as Outline.Rounded
+        assertEquals(30f, rounded.roundRect.topLeftCornerRadius.x, 0.001f)
+        assertEquals(30f, rounded.roundRect.bottomRightCornerRadius.y, 0.001f)
+    }
+
+    @Test
+    fun shapeProviderCachesOutlineForSameSize() {
+        val capsule = Capsule()
+        val provider = ShapeProvider { capsule }
+        val density = Density(density = 2f, fontScale = 1f)
+        val size = Size(160f, 50f)
+
+        val outline1 = provider.shape.createOutline(size, LayoutDirection.Ltr, density)
+        val outline2 = provider.shape.createOutline(size, LayoutDirection.Ltr, density)
+        assertSame(outline1, outline2)
+    }
+
+    @Test
+    fun runtimeShaderCacheObtainsSameShaderInstance() {
+        val cache = RuntimeShaderCacheImpl()
+        val s1 = cache.obtainRuntimeShader("testKey", RoundedRectRefractionShaderString)
+        val s2 = cache.obtainRuntimeShader("testKey", RoundedRectRefractionShaderString)
+        assertNotNull(s1)
+        assertSame(s1, s2)
+
+        cache.clear()
+        val s3 = cache.obtainRuntimeShader("testKey", RoundedRectRefractionShaderString)
+        assertNotNull(s3)
+    }
+}

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
@@ -28,11 +28,11 @@ class LiquidGlassTest {
         assertTrue(RoundedRectRefractionWithDispersionShaderString.contains("chromaticAberration"))
         assertTrue(RoundedRectRefractionWithDispersionShaderString.contains("dispersionIntensity"))
 
-        assertTrue(DefaultHighlightShaderString.contains("DefaultHighlight"))
+        assertTrue(DefaultHighlightShaderString.contains("layout(color) uniform half4 color"))
         assertTrue(DefaultHighlightShaderString.contains("angle"))
         assertTrue(DefaultHighlightShaderString.contains("falloff"))
 
-        assertTrue(AmbientHighlightShaderString.contains("AmbientHighlight"))
+        assertTrue(AmbientHighlightShaderString.contains("main(float2 coord)"))
     }
 
     @Test

--- a/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
+++ b/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MOBILE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ANDROID_ROOT = path.join(MOBILE_ROOT, 'android');
+const GLASS_ROOT = path.join(ANDROID_ROOT, 'core-ui', 'src', 'main', 'kotlin', 'one', 'zephyr', 'mobile', 'ui', 'glass');
+
+function readSource(rel) {
+  return fs.readFileSync(path.join(ANDROID_ROOT, rel), 'utf8');
+}
+
+test('Liquid Glass source files exist in core-ui', () => {
+  const expectedFiles = [
+    'Backdrop.kt',
+    'BackdropEffectScope.kt',
+    'DrawBackdropModifier.kt',
+    'Effects.kt',
+    'Highlight.kt',
+    'Internal.kt',
+    'LiquidGlass.kt',
+    'Platform.kt',
+    'RuntimeShader.kt',
+    'Shadow.kt',
+    'Shaders.kt',
+  ];
+
+  for (const file of expectedFiles) {
+    const fullPath = path.join(GLASS_ROOT, file);
+    assert.ok(fs.existsSync(fullPath), `Missing Liquid Glass file: ${file}`);
+    const stat = fs.statSync(fullPath);
+    assert.ok(stat.size > 100, `${file} should not be empty`);
+  }
+});
+
+test('Liquid Glass declares Backdrop, LayerBackdrop and LocalBackdrop', () => {
+  const backdropSource = fs.readFileSync(path.join(GLASS_ROOT, 'Backdrop.kt'), 'utf8');
+  assert.ok(backdropSource.includes('interface Backdrop'));
+  assert.ok(backdropSource.includes('class LayerBackdrop'));
+  assert.ok(backdropSource.includes('fun rememberLayerBackdrop'));
+  assert.ok(backdropSource.includes('val LocalBackdrop = staticCompositionLocalOf<Backdrop>'));
+  assert.ok(backdropSource.includes('fun Modifier.layerBackdrop'));
+});
+
+test('Liquid Glass declares AGSL runtime shaders and SDF refraction', () => {
+  const shaderSource = fs.readFileSync(path.join(GLASS_ROOT, 'Shaders.kt'), 'utf8');
+  assert.ok(shaderSource.includes('RoundedRectRefractionShaderString'));
+  assert.ok(shaderSource.includes('RoundedRectRefractionWithDispersionShaderString'));
+  assert.ok(shaderSource.includes('DefaultHighlightShaderString'));
+  assert.ok(shaderSource.includes('AmbientHighlightShaderString'));
+  assert.ok(shaderSource.includes('sdRoundedRect'));
+  assert.ok(shaderSource.includes('gradSdRoundedRect'));
+  assert.ok(shaderSource.includes('chromaticAberration'));
+});
+
+test('Liquid Glass modifiers and high-level components are declared', () => {
+  const liquidSource = fs.readFileSync(path.join(GLASS_ROOT, 'LiquidGlass.kt'), 'utf8');
+  assert.ok(liquidSource.includes('fun Modifier.liquidGlass'));
+  assert.ok(liquidSource.includes('fun LiquidButton'));
+  assert.ok(liquidSource.includes('fun LiquidSurface'));
+  assert.ok(liquidSource.includes('fun Capsule()'));
+
+  const drawModifierSource = fs.readFileSync(path.join(GLASS_ROOT, 'DrawBackdropModifier.kt'), 'utf8');
+  assert.ok(drawModifierSource.includes('fun Modifier.drawBackdrop'));
+  assert.ok(drawModifierSource.includes('fun Modifier.drawPlainBackdrop'));
+});
+
+test('FloatingIsland integrates Liquid Glass with backdrop sampling and refraction', () => {
+  const islandSource = readSource('core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt');
+  assert.ok(islandSource.includes('one.zephyr.mobile.ui.glass.drawBackdrop'));
+  assert.ok(islandSource.includes('one.zephyr.mobile.ui.glass.LocalBackdrop'));
+  assert.ok(islandSource.includes('lens('));
+  assert.ok(islandSource.includes('vibrancy()'));
+  assert.ok(islandSource.includes('chromaticAberration = true'));
+  assert.ok(islandSource.includes('Highlight.Default'));
+});
+
+test('ZephyrOneRoot establishes root Backdrop and propagates LocalBackdrop', () => {
+  const rootSource = readSource('app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt');
+  assert.ok(rootSource.includes('one.zephyr.mobile.ui.glass.rememberLayerBackdrop'));
+  assert.ok(rootSource.includes('one.zephyr.mobile.ui.glass.LocalBackdrop'));
+  assert.ok(rootSource.includes('one.zephyr.mobile.ui.glass.layerBackdrop'));
+  assert.ok(rootSource.includes('rememberLayerBackdrop()'));
+  assert.ok(rootSource.includes('LocalBackdrop provides'));
+});
+
+test('All Liquid Glass Kotlin sources are pure ASCII', () => {
+  const files = fs.readdirSync(GLASS_ROOT).filter((f) => f.endsWith('.kt'));
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(GLASS_ROOT, file), 'utf8');
+    for (let i = 0; i < raw.length; i++) {
+      const code = raw.charCodeAt(i);
+      assert.ok(
+        code <= 127,
+        `Non-ASCII character (code ${code}) in ${file} at position ${i}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
Landed the [AndroidLiquidGlass](https://github.com/Kyant0/AndroidLiquidGlass) (Backdrop) liquid glass effect in Zephyr One mobile Android:
- Integrated core-ui glass package:
  - `Backdrop`, `LayerBackdrop`, `LocalBackdrop`, `rememberLayerBackdrop()`
  - `drawBackdrop` and `drawPlainBackdrop` modifiers
  - Real-time AGSL SDF rounded-rectangle refraction with dispersion/chromatic aberration (`RoundedRectRefractionShaderString`, `RoundedRectRefractionWithDispersionShaderString`)
  - Specular edge highlights and ambient lighting (`DefaultHighlightShaderString`, `AmbientHighlightShaderString`)
  - Directional blur, vibrancy, and inner/ambient drop shadows
  - Backward compatibility: graceful capability detection on API < 31 (pure translucent glass) and API 31-32 (hardware RenderEffect blur) without crashing
- Enhanced `FloatingIsland` bottom navigation capsule and active pill with liquid glass refraction, vibrancy, and specular highlights
- Wired root page layer in `ZephyrOneRoot` via `rememberLayerBackdrop` and `LocalBackdrop`
- Added JVM unit tests in `LiquidGlassTest` and node contract test in `android-liquid-glass-contract.test.mjs`.