### PR TITLE
fix(android): stop liquid glass from crashing on the first island frame

### DIFF
--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Backdrop.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Backdrop.kt
@@ -143,6 +143,7 @@ private class LayerBackdropNode(
 
     override fun ContentDrawScope.draw() {
         drawContent()
+        if (size.width < 1f || size.height < 1f) return
         recordLayer(backdrop.graphicsLayer) { backdrop.onDraw(this@draw) }
     }
 

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
@@ -278,10 +278,10 @@ private class DrawBackdropNode(
                 ),
                 block = recordBackdropBlock,
             )
-            if (!recorded) return@drawBackdropLayer
-
-            layer.topLeft = if (pad != 0f) IntOffset(-pad.toInt(), -pad.toInt()) else IntOffset.Zero
-            drawLayer(layer)
+            if (recorded) {
+                layer.topLeft = if (pad != 0f) IntOffset(-pad.toInt(), -pad.toInt()) else IntOffset.Zero
+                drawLayer(layer)
+            }
         }
     }
 

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
@@ -270,7 +270,7 @@ private class DrawBackdropNode(
         val layer = graphicsLayer
         if (layer != null) {
             val pad = padding
-            recordLayer(
+            val recorded = recordLayer(
                 layer,
                 size = IntSize(
                     size.width.toInt() + pad.toInt() * 2,
@@ -278,6 +278,7 @@ private class DrawBackdropNode(
                 ),
                 block = recordBackdropBlock,
             )
+            if (!recorded) return@drawBackdropLayer
 
             layer.topLeft = if (pad != 0f) IntOffset(-pad.toInt(), -pad.toInt()) else IntOffset.Zero
             drawLayer(layer)
@@ -295,23 +296,34 @@ private class DrawBackdropNode(
     }
 
     override fun ContentDrawScope.draw() {
-        if (effectScope.update(this)) {
-            updateEffects()
+        if (size.width < 1f || size.height < 1f) {
+            drawContent()
+            return
         }
-
-        onDrawBehind?.invoke(this)
-        drawBackdropLayer()
-        onDrawSurface?.invoke(this)
-        drawContent()
-        onDrawFront?.invoke(this)
-
-        exportedBackdrop?.graphicsLayer?.let { layer ->
-            recordLayer(layer) {
-                onDrawBehind?.invoke(this)
-                drawBackdropLayer()
-                onDrawSurface?.invoke(this)
-                onDrawFront?.invoke(this)
+        try {
+            if (effectScope.update(this)) {
+                updateEffects()
             }
+
+            onDrawBehind?.invoke(this)
+            drawBackdropLayer()
+            onDrawSurface?.invoke(this)
+            drawContent()
+            onDrawFront?.invoke(this)
+
+            exportedBackdrop?.graphicsLayer?.let { layer ->
+                recordLayer(layer) {
+                    onDrawBehind?.invoke(this)
+                    drawBackdropLayer()
+                    onDrawSurface?.invoke(this)
+                    onDrawFront?.invoke(this)
+                }
+            }
+        } catch (failure: Throwable) {
+            GlassRuntime.disableEffects()
+            android.util.Log.e("ZephyrGlass", "backdrop draw failed; glass disabled", failure)
+            onDrawSurface?.invoke(this)
+            drawContent()
         }
     }
 
@@ -339,11 +351,22 @@ private class DrawBackdropNode(
     }
 
     private fun updateEffects() {
-        if (!isRenderEffectSupported()) return
+        if (!isRenderEffectSupported()) {
+            graphicsLayer?.renderEffect = null
+            padding = 0f
+            return
+        }
 
-        effectScope.apply(effects)
-        graphicsLayer?.renderEffect = effectScope.renderEffect
-        padding = effectScope.padding
+        try {
+            effectScope.apply(effects)
+            graphicsLayer?.renderEffect = effectScope.renderEffect
+            padding = effectScope.padding
+        } catch (failure: Throwable) {
+            GlassRuntime.disableEffects()
+            android.util.Log.e("ZephyrGlass", "backdrop effect failed; glass disabled", failure)
+            graphicsLayer?.renderEffect = null
+            padding = 0f
+        }
     }
 
     override fun onAttach() {

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Effects.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Effects.kt
@@ -34,13 +34,18 @@ internal fun RenderEffect?.chain(other: RenderEffect): RenderEffect {
 internal fun createRuntimeShaderEffect(
     runtimeShader: RuntimeShader,
     uniformShaderName: String,
-): RenderEffect {
-    val androidShader = runtimeShader.asAndroidRuntimeShader()
-        ?: throw IllegalStateException("RuntimeShader must be AndroidRuntimeShader on API 33+")
-    return android.graphics.RenderEffect.createRuntimeShaderEffect(
-        androidShader,
-        uniformShaderName,
-    ).asComposeRenderEffect()
+): RenderEffect? {
+    val androidShader = runtimeShader.asAndroidRuntimeShader() ?: return null
+    return try {
+        android.graphics.RenderEffect.createRuntimeShaderEffect(
+            androidShader,
+            uniformShaderName,
+        ).asComposeRenderEffect()
+    } catch (failure: Throwable) {
+        GlassRuntime.disableShaders()
+        android.util.Log.e("ZephyrGlass", "runtime shader effect failed; glass shaders disabled", failure)
+        null
+    }
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
@@ -101,6 +106,7 @@ fun BackdropEffectScope.lens(
         } else {
             obtainRuntimeShader("RefractionWithDispersion", RoundedRectRefractionWithDispersionShaderString)
         }
+        if (size.minDimension < 1f) return
         shader.apply {
             setFloatUniform("size", size.width, size.height)
             setFloatUniform("offset", -padding, -padding)
@@ -112,7 +118,7 @@ fun BackdropEffectScope.lens(
                 setFloatUniform("chromaticAberration", 1f)
             }
         }
-        effect(createRuntimeShaderEffect(shader, "content"))
+        createRuntimeShaderEffect(shader, "content")?.let(::effect)
     }
 }
 
@@ -161,7 +167,7 @@ fun BackdropEffectScope.runtimeShaderEffect(
 ) {
     if (!isRuntimeShaderSupported()) return
     val shader = obtainRuntimeShader(key, shaderString).apply(block)
-    val effect = createRuntimeShaderEffect(shader, uniformShaderName)
+    val effect = createRuntimeShaderEffect(shader, uniformShaderName) ?: return
     renderEffect = renderEffect.chain(effect)
 }
 

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Highlight.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Highlight.kt
@@ -199,7 +199,7 @@ internal class HighlightNode(
 
     override fun ContentDrawScope.draw() {
         val hl = highlight()
-        if (hl == null || hl.width.value <= 0f) {
+        if (hl == null || hl.width.value <= 0f || size.minDimension < 1f) {
             drawContent()
             return
         }
@@ -225,7 +225,7 @@ internal class HighlightNode(
 
         layer.alpha = hl.alpha
         layer.blendMode = hl.style.blendMode
-        layer.record(safeSize) {
+        val recorded = recordLayer(layer, safeSize) {
             translate(1f, 1f) {
                 val canvas = drawContext.canvas
                 canvas.save()
@@ -234,6 +234,7 @@ internal class HighlightNode(
                 canvas.restore()
             }
         }
+        if (!recorded) return
 
         translate(-1f, -1f) {
             drawLayer(layer)
@@ -262,12 +263,17 @@ internal class HighlightNode(
         paint.asFrameworkPaint().maskFilter = if (radius > 0f) BlurMaskFilter(radius, BlurMaskFilter.Blur.NORMAL) else null
 
         if (isRuntimeShaderSupported()) {
-            val shader = with(hl.style) {
-                createShader(
-                    shape = shapeProvider.shape,
-                    runtimeShaderCache = runtimeShaderCache,
-                )
-            }
+            val shader = runCatching {
+                with(hl.style) {
+                    createShader(
+                        shape = shapeProvider.shape,
+                        runtimeShaderCache = runtimeShaderCache,
+                    )
+                }
+            }.onFailure { failure ->
+                GlassRuntime.disableShaders()
+                android.util.Log.e("ZephyrGlass", "highlight shader failed; glass shaders disabled", failure)
+            }.getOrNull()
             paint.asFrameworkPaint().shader = shader?.asAndroidRuntimeShader()
         }
     }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
@@ -34,16 +34,24 @@ internal fun DrawScope.recordLayer(
     size: IntSize = this.size.toIntSize(),
     density: Density? = null,
     block: DrawScope.() -> Unit,
-) {
+): Boolean {
+    if (size.width <= 0 || size.height <= 0) return false
     val d = density ?: this
-    layer.record(size) {
-        val prevDensity = drawContext.density
-        drawContext.density = d
-        try {
-            this.block()
-        } finally {
-            drawContext.density = prevDensity
+    return try {
+        layer.record(size) {
+            val prevDensity = drawContext.density
+            drawContext.density = d
+            try {
+                this.block()
+            } finally {
+                drawContext.density = prevDensity
+            }
         }
+        true
+    } catch (failure: Throwable) {
+        GlassRuntime.disableEffects()
+        android.util.Log.e("ZephyrGlass", "graphics layer record failed; glass disabled", failure)
+        false
     }
 }
 

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Platform.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Platform.kt
@@ -3,8 +3,39 @@ package one.zephyr.mobile.ui.glass
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 
+/**
+ * Process-wide kill switch for the liquid-glass GPU path.
+ *
+ * AGSL compile errors and driver aborts (Adreno SIGSEGV on a
+ * zero-length unit vector during the first island frame) must not take
+ * the activity down. After a failure, glass degrades to tinted rounded
+ * rects for the rest of the process.
+ */
+internal object GlassRuntime {
+    @Volatile var shadersEnabled: Boolean = true
+        private set
+    @Volatile var effectsEnabled: Boolean = true
+        private set
+
+    fun disableShaders() {
+        shadersEnabled = false
+    }
+
+    fun disableEffects() {
+        shadersEnabled = false
+        effectsEnabled = false
+    }
+
+    fun resetForTests() {
+        shadersEnabled = true
+        effectsEnabled = true
+    }
+}
+
 @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
-fun isRenderEffectSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+fun isRenderEffectSupported(): Boolean =
+    GlassRuntime.effectsEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
 @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
-fun isRuntimeShaderSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+fun isRuntimeShaderSupported(): Boolean =
+    GlassRuntime.shadersEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/RuntimeShader.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/RuntimeShader.kt
@@ -84,9 +84,12 @@ internal object NoOpRuntimeShader : RuntimeShader {
 }
 
 fun createRuntimeShader(@Language("AGSL") shaderString: String): RuntimeShader {
-    return if (isRuntimeShaderSupported()) {
+    if (!isRuntimeShaderSupported()) return NoOpRuntimeShader
+    return try {
         AndroidRuntimeShader(android.graphics.RuntimeShader(shaderString))
-    } else {
+    } catch (failure: Throwable) {
+        GlassRuntime.disableShaders()
+        android.util.Log.e("ZephyrGlass", "AGSL compile failed; glass shaders disabled", failure)
         NoOpRuntimeShader
     }
 }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shaders.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shaders.kt
@@ -2,6 +2,11 @@
  * Liquid Glass Shaders - AGSL implementation
  * Ported from Kyant0/AndroidLiquidGlass (Backdrop)
  * Apache License 2.0
+ *
+ * Adreno (Xiaomi HyperOS) SIGSEGVs on a zero-length unit vector and on
+ * content.eval with a NaN coordinate. First-frame island size can be
+ * 0x0, and the capsule centre has a zero SDF gradient. Both have to
+ * short-circuit instead of hitting the driver.
  */
 
 package one.zephyr.mobile.ui.glass
@@ -27,15 +32,26 @@ float sdRoundedRect(float2 coord, float2 halfSize, float radius) {
     return outside + inside;
 }
 
+float2 safeNormalize(float2 v) {
+    float len = length(v);
+    return len > 1.0e-4 ? v / len : float2(0.0);
+}
+
 float2 gradSdRoundedRect(float2 coord, float2 halfSize, float radius) {
     float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
     if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
-        return sign(coord) * normalize(max(cornerCoord, 0.0));
+        return sign(coord) * safeNormalize(max(cornerCoord, 0.0));
     } else {
         float gradX = step(cornerCoord.y, cornerCoord.x);
         return sign(coord) * float2(gradX, 1.0 - gradX);
     }
-}"""
+}
+
+float circleMap(float x) {
+    float t = clamp(x, 0.0, 1.0);
+    return 1.0 - sqrt(1.0 - t * t);
+}
+"""
 
 @Language("AGSL")
 val RoundedRectRefractionShaderString = """
@@ -50,28 +66,32 @@ uniform float depthEffect;
 
 $RoundedRectSDF
 
-float circleMap(float x) {
-    return 1.0 - sqrt(1.0 - x * x);
-}
-
 half4 main(float2 coord) {
+    if (size.x < 1.0 || size.y < 1.0) {
+        return content.eval(coord);
+    }
     float2 halfSize = size * 0.5;
     float2 centeredCoord = (coord + offset) - halfSize;
-    float radius = radiusAt(coord, cornerRadii);
-    
+    float radius = radiusAt(centeredCoord, cornerRadii);
+
     float sd = sdRoundedRect(centeredCoord, halfSize, radius);
     if (-sd >= refractionHeight) {
         return content.eval(coord);
     }
     sd = min(sd, 0.0);
-    
-    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+
+    float height = max(refractionHeight, 1.0e-4);
+    float d = circleMap(1.0 - -sd / height) * refractionAmount;
     float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
-    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
-    
+    float2 grad = safeNormalize(
+        gradSdRoundedRect(centeredCoord, halfSize, gradRadius) +
+            depthEffect * safeNormalize(centeredCoord)
+    );
+
     float2 refractedCoord = coord + d * grad;
     return content.eval(refractedCoord);
-}"""
+}
+"""
 
 @Language("AGSL")
 val RoundedRectRefractionWithDispersionShaderString = """
@@ -87,65 +107,70 @@ uniform float chromaticAberration;
 
 $RoundedRectSDF
 
-float circleMap(float x) {
-    return 1.0 - sqrt(1.0 - x * x);
-}
-
 half4 main(float2 coord) {
+    if (size.x < 1.0 || size.y < 1.0) {
+        return content.eval(coord);
+    }
     float2 halfSize = size * 0.5;
     float2 centeredCoord = (coord + offset) - halfSize;
-    float radius = radiusAt(coord, cornerRadii);
-    
+    float radius = radiusAt(centeredCoord, cornerRadii);
+
     float sd = sdRoundedRect(centeredCoord, halfSize, radius);
     if (-sd >= refractionHeight) {
         return content.eval(coord);
     }
     sd = min(sd, 0.0);
-    
-    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+
+    float height = max(refractionHeight, 1.0e-4);
+    float d = circleMap(1.0 - -sd / height) * refractionAmount;
     float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
-    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
-    
+    float2 grad = safeNormalize(
+        gradSdRoundedRect(centeredCoord, halfSize, gradRadius) +
+            depthEffect * safeNormalize(centeredCoord)
+    );
+
     float2 refractedCoord = coord + d * grad;
-    float dispersionIntensity = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));
+    float denom = max(halfSize.x * halfSize.y, 1.0);
+    float dispersionIntensity = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / denom);
     float2 dispersedCoord = d * grad * dispersionIntensity;
-    
+
     half4 color = half4(0.0);
-    
+
     half4 red = content.eval(refractedCoord + dispersedCoord);
     color.r += red.r / 3.5;
     color.a += red.a / 7.0;
-    
+
     half4 orange = content.eval(refractedCoord + dispersedCoord * (2.0 / 3.0));
     color.r += orange.r / 3.5;
     color.g += orange.g / 7.0;
     color.a += orange.a / 7.0;
-    
+
     half4 yellow = content.eval(refractedCoord + dispersedCoord * (1.0 / 3.0));
     color.r += yellow.r / 3.5;
     color.g += yellow.g / 3.5;
     color.a += yellow.a / 7.0;
-    
+
     half4 green = content.eval(refractedCoord);
     color.g += green.g / 3.5;
     color.a += green.a / 7.0;
-    
+
     half4 cyan = content.eval(refractedCoord - dispersedCoord * (1.0 / 3.0));
     color.g += cyan.g / 3.5;
     color.b += cyan.b / 3.0;
     color.a += cyan.a / 7.0;
-    
+
     half4 blue = content.eval(refractedCoord - dispersedCoord * (2.0 / 3.0));
     color.b += blue.b / 3.0;
     color.a += blue.a / 7.0;
-    
+
     half4 purple = content.eval(refractedCoord - dispersedCoord);
     color.r += purple.r / 7.0;
     color.b += purple.b / 3.0;
     color.a += purple.a / 7.0;
-    
+
     return color;
-}"""
+}
+"""
 
 @Language("AGSL")
 val DefaultHighlightShaderString = """
@@ -158,17 +183,21 @@ uniform float falloff;
 $RoundedRectSDF
 
 half4 main(float2 coord) {
+    if (size.x < 1.0 || size.y < 1.0) {
+        return half4(0.0);
+    }
     float2 halfSize = size * 0.5;
     float2 centeredCoord = coord - halfSize;
-    float radius = radiusAt(coord, cornerRadii);
-    
+    float radius = radiusAt(centeredCoord, cornerRadii);
+
     float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
     float2 grad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
     float2 normal = float2(cos(angle), sin(angle));
     float d = dot(grad, normal);
-    float intensity = pow(abs(d), falloff);
+    float intensity = pow(abs(d), max(falloff, 1.0e-4));
     return color * intensity;
-}"""
+}
+"""
 
 @Language("AGSL")
 val AmbientHighlightShaderString = """
@@ -180,15 +209,19 @@ uniform float falloff;
 $RoundedRectSDF
 
 half4 main(float2 coord) {
+    if (size.x < 1.0 || size.y < 1.0) {
+        return half4(0.0);
+    }
     float2 halfSize = size * 0.5;
     float2 centeredCoord = coord - halfSize;
-    float radius = radiusAt(coord, cornerRadii);
-    
+    float radius = radiusAt(centeredCoord, cornerRadii);
+
     float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
     float2 grad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
     float2 normal = float2(cos(angle), sin(angle));
     float d = dot(grad, normal);
-    float intensity = pow(abs(d), falloff);
+    float intensity = pow(abs(d), max(falloff, 1.0e-4));
     float t = step(0.0, d);
     return half4(t, t, t, 1.0) * intensity;
-}"""
+}
+"""

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shadow.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Shadow.kt
@@ -106,6 +106,10 @@ internal class ShadowNode(
             drawContent()
             return
         }
+        if (size.minDimension < 1f) {
+            drawContent()
+            return
+        }
 
         val layer = shadowLayer
         if (layer != null) {
@@ -126,7 +130,7 @@ internal class ShadowNode(
 
             layer.alpha = sh.alpha
             layer.blendMode = sh.blendMode
-            layer.record(shadowSize) {
+            val recorded = recordLayer(layer, shadowSize) {
                 translate(radius * 2f + offsetX, radius * 2f + offsetY) {
                     val canvas = drawContext.canvas
                     canvas.drawOutline(outline, paint)
@@ -135,9 +139,10 @@ internal class ShadowNode(
                     canvas.translate(offsetX, offsetY)
                 }
             }
-
-            translate(-radius * 2f, -radius * 2f) {
-                drawLayer(layer)
+            if (recorded) {
+                translate(-radius * 2f, -radius * 2f) {
+                    drawLayer(layer)
+                }
             }
         }
 
@@ -204,6 +209,7 @@ internal class InnerShadowNode(
         drawContent()
 
         if (!isRenderEffectSupported()) return
+        if (size.minDimension < 1f) return
 
         val sh = shadow() ?: return
         val layer = shadowLayer ?: return
@@ -229,7 +235,7 @@ internal class InnerShadowNode(
             layer.renderEffect = if (radius > 0f) BlurEffect(radius, radius, TileMode.Decal) else null
             prevRadius = radius
         }
-        layer.record {
+        val recorded = recordLayer(layer) {
             val canvas = drawContext.canvas
             canvas.save()
             canvas.clipOutline(outline, cp)
@@ -239,6 +245,7 @@ internal class InnerShadowNode(
             canvas.translate(-offsetX, -offsetY)
             canvas.restore()
         }
+        if (!recorded) return
 
         val canvas = drawContext.canvas
         canvas.save()

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
@@ -133,7 +133,7 @@ class LiquidGlassTest {
                 "bare normalize() is an Adreno SIGSEGV on Xiaomi first frames",
                 Regex("""(?<!safe)normalize\s*\(""").containsMatchIn(source),
             )
-            assertTrue(source.contains("if (length(v) < 1e-4)"))
+            assertTrue(source.contains("len > 1.0e-4"))
             assertTrue(source.contains("if (size.x < 1.0 || size.y < 1.0)"))
         }
         assertTrue(RoundedRectRefractionShaderString.contains("float2 safeNormalize(float2 v)"))

--- a/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
+++ b/zephyr_one/mobile/android/core-ui/src/test/kotlin/one/zephyr/mobile/ui/glass/LiquidGlassTest.kt
@@ -118,4 +118,39 @@ class LiquidGlassTest {
         val s3 = cache.obtainRuntimeShader("testKey", RoundedRectRefractionShaderString)
         assertNotNull(s3)
     }
+
+    @Test
+    fun shadersNeverCallBareNormalizeOnAZeroVector() {
+        val sources = listOf(
+            RoundedRectRefractionShaderString,
+            RoundedRectRefractionWithDispersionShaderString,
+            DefaultHighlightShaderString,
+            AmbientHighlightShaderString,
+        )
+        for (source in sources) {
+            assertTrue(source.contains("safeNormalize"))
+            assertFalse(
+                "bare normalize() is an Adreno SIGSEGV on Xiaomi first frames",
+                Regex("""(?<!safe)normalize\s*\(""").containsMatchIn(source),
+            )
+            assertTrue(source.contains("if (length(v) < 1e-4)"))
+            assertTrue(source.contains("if (size.x < 1.0 || size.y < 1.0)"))
+        }
+        assertTrue(RoundedRectRefractionShaderString.contains("float2 safeNormalize(float2 v)"))
+    }
+
+    @Test
+    fun disablingShadersFallsBackWithoutThrowing() {
+        GlassRuntime.resetForTests()
+        try {
+            GlassRuntime.disableShaders()
+            assertFalse(isRuntimeShaderSupported())
+            val shader = createRuntimeShader(RoundedRectRefractionShaderString)
+            assertEquals(null, shader.asAndroidRuntimeShader())
+            GlassRuntime.disableEffects()
+            assertFalse(isRenderEffectSupported())
+        } finally {
+            GlassRuntime.resetForTests()
+        }
+    }
 }

--- a/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
+++ b/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
@@ -86,6 +86,37 @@ test('ZephyrOneRoot establishes root Backdrop and propagates LocalBackdrop', () 
   assert.ok(rootSource.includes('LocalBackdrop provides'));
 });
 
+test('AGSL shaders use safeNormalize and skip a 0x0 first frame', () => {
+  const shaderSource = fs.readFileSync(path.join(GLASS_ROOT, 'Shaders.kt'), 'utf8');
+  assert.ok(shaderSource.includes('float2 safeNormalize(float2 v)'));
+  assert.ok(shaderSource.includes('if (size.x < 1.0 || size.y < 1.0)'));
+  assert.ok(shaderSource.includes('Adreno'));
+  const agslBodies = [...shaderSource.matchAll(/"""([\s\S]*?)"""/g)].map((m) => m[1]);
+  assert.ok(agslBodies.length >= 3, 'expected AGSL string bodies');
+  for (const body of agslBodies) {
+    assert.equal((body.match(/(?<!safe)normalize\s*\(/g) || []).length, 0);
+  }
+});
+
+test('glass GPU path can disable itself instead of crashing composition', () => {
+  const platform = fs.readFileSync(path.join(GLASS_ROOT, 'Platform.kt'), 'utf8');
+  assert.ok(platform.includes('object GlassRuntime'));
+  assert.ok(platform.includes('fun disableShaders'));
+  assert.ok(platform.includes('fun disableEffects'));
+
+  const runtime = fs.readFileSync(path.join(GLASS_ROOT, 'RuntimeShader.kt'), 'utf8');
+  assert.ok(runtime.includes('GlassRuntime.disableShaders()'));
+  assert.ok(runtime.includes('NoOpRuntimeShader'));
+
+  const internal = fs.readFileSync(path.join(GLASS_ROOT, 'Internal.kt'), 'utf8');
+  assert.ok(internal.includes('if (size.width <= 0 || size.height <= 0) return false'));
+  assert.ok(internal.includes('GlassRuntime.disableEffects()'));
+
+  const draw = fs.readFileSync(path.join(GLASS_ROOT, 'DrawBackdropModifier.kt'), 'utf8');
+  assert.ok(draw.includes('GlassRuntime.disableEffects()'));
+  assert.ok(draw.includes('backdrop draw failed; glass disabled'));
+});
+
 test('All Liquid Glass Kotlin sources are pure ASCII', () => {
   const files = fs.readdirSync(GLASS_ROOT).filter((f) => f.endsWith('.kt'));
   for (const file of files) {


### PR DESCRIPTION
## 现象
`zom-v1.0.0pre58` 一启动就闪退。#104 把 [Kyant0/AndroidLiquidGlass](https://github.com/Kyant0/AndroidLiquidGlass) 的 AGSL 原样搬进了底部岛第一帧。Kyant 的 demo 不是启动瞬间画胶囊；小米 Adreno 在 `normalize(float2(0))` 和 0×0 `GraphicsLayer.record` 上直接 SIGSEGV，Kotlin 接不住。

#105 的 last-write-wins / 域名拨号不在启动路径上，不是这次崩溃。

## 修
对照 Kyant `kmp` 分支的 `Shaders.kt` / `Lens.kt` / `LayerRecorder.kt`：视觉仍走同一套 SDF 折射，但：
- `normalize()` 换成带长度下限的 `safeNormalize`
- 0×0 第一帧直接跳过 GPU 路径
- AGSL / RenderEffect / `layer.record` 失败后关掉玻璃 GPU，降级成圆角着色，不再把 Activity 打死

## 测
`node --test zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs` 过。

合入后发 **zom-v1.0.0pre59**。Docker 不用重发。
