### PR TITLE
fix(sync): keep One incremental pull from freezing after the first round

### DIFF
--- a/mobile-v1-routes.js
+++ b/mobile-v1-routes.js
@@ -1902,7 +1902,14 @@ class MobileV1Api {
         } catch {
             row = null;
         }
-        if (!row) return { ...safeChange, payload: {} };
+        if (!row) {
+            /* A live change whose canonical row is gone, or whose owner key
+             * does not match the bound account (legacy activity rows store
+             * username in userId). Emitting an empty payload would fail
+             * residency on the client and freeze the cursor. Mark the row
+             * skippable the same way an unknown type is skipped. */
+            return { ...safeChange, payload: {}, unsupported: true };
+        }
         return {
             ...safeChange,
             payload: projectPayload(spec, row),
@@ -1964,6 +1971,14 @@ class MobileV1Api {
         const envelopes = {};
         for (const fieldName of fields) {
             const plaintext = Buffer.from(String(secrets[fieldName]), 'utf8');
+            /* Bind AAD to the last revision that mutated this secret field,
+             * not the entity revision. A later name/host edit bumps the
+             * entity revision; resealing the unchanged password under that
+             * new number makes One open the envelope with the wrong AAD and
+             * freeze the whole change page. */
+            const fieldRevision = this.store.fieldRevision(
+                user.userId, entityType, entityId, fieldName,
+            ) || Number(entityRevision) || 1;
             try {
                 const aad = mobileCrypto.secretAadBytes({
                     serverId: this.store.serverId(),
@@ -1972,7 +1987,7 @@ class MobileV1Api {
                     entityType,
                     entityId: String(entityId),
                     fieldName,
-                    entityRevision: Number(entityRevision),
+                    entityRevision: fieldRevision,
                     keyVersion,
                 });
                 envelopes[fieldName] = mobileCrypto.sealEnvelope({
@@ -1980,7 +1995,7 @@ class MobileV1Api {
                     publicKey,
                     aad,
                     keyVersion,
-                    entityRevision: Number(entityRevision),
+                    entityRevision: fieldRevision,
                 });
             } finally {
                 plaintext.fill(0);

--- a/mobile-v1-server-metadata-entities.js
+++ b/mobile-v1-server-metadata-entities.js
@@ -296,13 +296,17 @@ function projectBackupMetadata(row, serverId) {
 }
 
 function projectActivityEvent(row, user) {
-    if (!row || String(row.userId || '') !== String(user?.userId || '')) return null;
+    if (!row || !user) return null;
+    const owner = String(row.userId || '');
+    const bound = String(user.userId || '');
+    const username = String(user.username || '');
+    if (!owner || (owner !== bound && (!username || owner !== username))) return null;
     const id = String(row.id || '');
     if (!id) return null;
     const type = String(row.type || 'info').slice(0, 80);
     return {
         id,
-        userId: String(user.userId),
+        userId: bound,
         time: Math.max(0, Number(row.time) || 0),
         /* Activity text can include arbitrary server output or old command
          * bodies. Mobile transports a fixed label from this allow-list, never
@@ -546,20 +550,60 @@ class CanonicalActivityEventService {
 
     listActivityEventsForUser(userId, { limit = 500 } = {}) {
         const capped = Math.max(1, Math.min(500, Number(limit) || 500));
+        const keys = this.ownerKeys(userId);
+        if (!keys.length) return [];
+        const placeholders = keys.map(() => '?').join(', ');
         return this.db.prepare(`SELECT id, userId, time, message, type, category, outcome, protocol, connectionId
-            FROM activities WHERE userId = ? ORDER BY time DESC LIMIT ?`).all(String(userId || ''), capped);
+            FROM activities WHERE userId IN (${placeholders}) ORDER BY time DESC LIMIT ?`).all(...keys, capped);
     }
 
     readActivityEventForUser(userId, eventId) {
+        const keys = this.ownerKeys(userId);
+        if (!keys.length) return null;
+        const placeholders = keys.map(() => '?').join(', ');
         return this.db.prepare(`SELECT id, userId, time, message, type, category, outcome, protocol, connectionId
-            FROM activities WHERE userId = ? AND id = ?`).get(String(userId || ''), String(eventId || '')) || null;
+            FROM activities WHERE userId IN (${placeholders}) AND id = ?`).get(...keys, String(eventId || '')) || null;
+    }
+
+    /**
+     * Historical activity rows stored username in `userId`. Match both the
+     * canonical userId and username so One can project those rows instead of
+     * emitting an empty payload that freezes the change cursor.
+     */
+    ownerKeys(userId) {
+        const id = String(userId || '');
+        if (!id) return [];
+        const keys = [id];
+        try {
+            const user = this.storage.getUserById(id) || this.storage.getUser(id);
+            if (user?.userId && !keys.includes(user.userId)) keys.push(user.userId);
+            if (user?.username && !keys.includes(user.username)) keys.push(user.username);
+        } catch {
+            /* Storage lookups must not take the change page down. */
+        }
+        return keys;
     }
 
     appendActivityEvent(event) {
-        const row = { ...event, userId: event?.userId || null };
+        const rawOwner = event?.userId ? String(event.userId) : null;
+        let resolved = null;
+        if (rawOwner) {
+            try {
+                resolved = this.storage.getUserById(rawOwner) || this.storage.getUser(rawOwner) || null;
+            } catch {
+                resolved = null;
+            }
+        }
+        const canonicalUserId = resolved?.userId || rawOwner;
+        const row = { ...event, userId: canonicalUserId || null };
         return this.db.transaction(() => {
             this.storage.addActivity(row);
-            if (row.userId) recordActivityEvent(this.changeBridge, { userId: String(row.userId) }, row);
+            if (row.userId) {
+                recordActivityEvent(this.changeBridge, {
+                    userId: String(row.userId),
+                    username: resolved?.username || '',
+                }, row);
+            }
             return row;
         })();
     }

--- a/mobile-v1-store.js
+++ b/mobile-v1-store.js
@@ -1195,6 +1195,19 @@ class MobileV1Store {
             .get(String(ownerUserId), String(entityType), String(entityId)) || null;
     }
 
+    /**
+     * Last revision that actually mutated this field. Envelope AAD is bound to
+     * that number, not the entity revision: a later name/host edit must not
+     * reseal the password under a new AAD or One cannot open it.
+     */
+    fieldRevision(ownerUserId, entityType, entityId, fieldPath) {
+        const row = this.db.prepare(`SELECT revision FROM mobile_entity_field_revisions
+            WHERE owner_user_id = ? AND entity_type = ? AND entity_id = ? AND field_path = ?`)
+            .get(String(ownerUserId), String(entityType), String(entityId), String(fieldPath));
+        const revision = row && Number(row.revision);
+        return Number.isSafeInteger(revision) && revision > 0 ? revision : null;
+    }
+
     /** Field-level revisions: the data SYNC_STATE_MACHINE.md section 7 merges on. */
     setFieldRevisions({ ownerUserId, entityType, entityId, fields, revision, changedAt }) {
         const writtenAt = Number(changedAt);

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
@@ -53,11 +53,12 @@ class SecretReconciliationException(
 /**
  * Applies server changes to the account-scoped local mirror.
  *
- * Secret presence is authoritative. A present value must arrive with an envelope that opens before
- * any row is written; an absent value removes exactly the registry-derived ref. SecretStore lives
- * outside SQLite, so every mutation is committed through [SecretMutationJournal]. This also
- * prevents a later bad envelope, a Room rollback or a process death from leaving the mirror and
- * encrypted store at different revisions while the cursor stays put.
+ * Secret presence is authoritative. A present value must arrive with an envelope that opens,
+ * or with a previously opened local secret when the change is a non-secret patch. An absent
+ * value removes exactly the registry-derived ref. SecretStore lives outside SQLite, so every
+ * mutation is committed through [SecretMutationJournal]. This also prevents a later bad
+ * envelope, a Room rollback or a process death from leaving the mirror and encrypted store at
+ * different revisions while the cursor stays put.
  */
 class MirrorWriter(
     private val db: ZephyrDatabase,
@@ -92,7 +93,7 @@ class MirrorWriter(
             ) {
                 for ((index, change) in changes.withIndex()) {
                     val spec = EntityRegistry.byType[change.entityType]
-                    if (spec == null) {
+                    if (spec == null || isSkippableInboundChange(change)) {
                         skipped += 1
                         cursor = maxOf(cursor, change.changeSeq)
                         continue
@@ -136,6 +137,7 @@ class MirrorWriter(
         try {
             for ((index, change) in changes.withIndex()) {
                 if (EntityRegistry.byType[change.entityType] == null) continue
+                if (isSkippableInboundChange(change)) continue
                 val key = EntityKey(change.entityType, change.entityId)
                 val localRevision = if (revisions.containsKey(key)) {
                     revisions[key]
@@ -150,7 +152,18 @@ class MirrorWriter(
                 }
                 if (!PushPrediction.shouldApplyChange(localRevision, change.action, change.revision)) continue
                 applicableIndexes += index
-                if (!change.isDelete) prepared[index] = prepareSecrets(change, opener)
+                if (!change.isDelete) {
+                    val retained = retainedSecretsFor(change)
+                    try {
+                        prepared[index] = prepareSecrets(
+                            change,
+                            opener,
+                            retainedSecrets = retained,
+                        )
+                    } finally {
+                        retained.values.forEach { it.fill(0) }
+                    }
+                }
                 revisions[key] = change.revision
             }
             return ApplicablePage(applicableIndexes, prepared)
@@ -460,6 +473,22 @@ class MirrorWriter(
         throw SecretReconciliationException(SecretReconciliationFailure.SECRET_STORE_FAILURE, failure)
     }
 
+    /**
+     * Local plaintext already opened for this entity. Incremental name/host
+     * edits keep hasPassword=true without a new envelope; the previous secret
+     * is the source of truth until a later page actually reseals it.
+     */
+    private fun retainedSecretsFor(change: SyncChange): Map<String, ByteArray> {
+        val spec = EntityRegistry.byType[change.entityType] ?: return emptyMap()
+        if (spec.secretFields.isEmpty()) return emptyMap()
+        val retained = LinkedHashMap<String, ByteArray>()
+        for (fieldName in spec.secretFields) {
+            val plaintext = readSecret(SecretRef.of(change.entityType, change.entityId, fieldName))
+            if (plaintext != null && plaintext.isNotEmpty()) retained[fieldName] = plaintext
+        }
+        return retained
+    }
+
     private companion object {
         const val DAY_MS = 24L * 60 * 60 * 1000
     }
@@ -566,7 +595,11 @@ internal data class PreparedSecrets(
 }
 
 /** Pure envelope/presence validation shared by change pages and bootstrap staging. */
-internal fun prepareSecrets(change: SyncChange, opener: EnvelopeOpener?): PreparedSecrets {
+internal fun prepareSecrets(
+    change: SyncChange,
+    opener: EnvelopeOpener?,
+    retainedSecrets: Map<String, ByteArray> = emptyMap(),
+): PreparedSecrets {
     val spec = EntityRegistry.require(change.entityType)
     if (change.secretEnvelopes.keys.any { it !in spec.secretFields }) {
         throw SecretReconciliationException(SecretReconciliationFailure.INVALID_SECRET_FIELD)
@@ -588,24 +621,30 @@ internal fun prepareSecrets(change: SyncChange, opener: EnvelopeOpener?): Prepar
             }
             states[fieldName] = declared
             if (declared) {
-                if (!change.secretEnvelopes.containsKey(fieldName)) {
-                    throw SecretReconciliationException(
-                        SecretReconciliationFailure.MISSING_ENVELOPE,
-                    )
-                }
-                values[fieldName] = try {
-                    opener?.open(change, fieldName)
-                        ?: throw SecretReconciliationException(
+                val opened = if (change.secretEnvelopes.containsKey(fieldName)) {
+                    try {
+                        opener?.open(change, fieldName)
+                            ?: throw SecretReconciliationException(
+                                SecretReconciliationFailure.ENVELOPE_REJECTED,
+                            )
+                    } catch (failure: SecretReconciliationException) {
+                        throw failure
+                    } catch (failure: Throwable) {
+                        throw SecretReconciliationException(
                             SecretReconciliationFailure.ENVELOPE_REJECTED,
+                            failure,
                         )
-                } catch (failure: SecretReconciliationException) {
-                    throw failure
-                } catch (failure: Throwable) {
-                    throw SecretReconciliationException(
-                        SecretReconciliationFailure.ENVELOPE_REJECTED,
-                        failure,
-                    )
+                    }
+                } else {
+                    val retained = retainedSecrets[fieldName]
+                    if (retained == null || retained.isEmpty()) {
+                        throw SecretReconciliationException(
+                            SecretReconciliationFailure.MISSING_ENVELOPE,
+                        )
+                    }
+                    retained.copyOf()
                 }
+                values[fieldName] = opened
             } else if (change.secretEnvelopes.containsKey(fieldName)) {
                 throw SecretReconciliationException(
                     SecretReconciliationFailure.INVALID_PRESENCE,
@@ -696,7 +735,9 @@ internal fun requireOwnedChanges(changes: List<SyncChange>, boundUserId: String)
         throw ResidencyViolationException("refusing to mirror without a bound account owner")
     }
     for (change in changes) {
-        if (EntityRegistry.byType[change.entityType] != null) requireOwnedChange(change, boundUserId)
+        if (EntityRegistry.byType[change.entityType] == null) continue
+        if (isSkippableInboundChange(change)) continue
+        requireOwnedChange(change, boundUserId)
     }
 }
 
@@ -704,10 +745,18 @@ internal fun requireOwnedChanges(changes: List<SyncChange>, boundUserId: String)
 internal fun requireSafeInboundChanges(changes: List<SyncChange>) {
     for (change in changes) {
         if (EntityRegistry.byType[change.entityType] == null) continue
+        if (isSkippableInboundChange(change)) continue
         val payload = if (change.isDelete) change.tombstone ?: change.payload else change.payload
         SecretPayloadSanitizer.requireSafe(change.entityType, payload)
     }
 }
+
+/**
+ * A live change whose canonical row cannot be projected (legacy owner keys,
+ * deleted-after-upsert). The server marks these skippable so one bad row
+ * cannot freeze the account cursor.
+ */
+internal fun isSkippableInboundChange(change: SyncChange): Boolean = change.unsupported
 
 internal fun requireOwnedChange(change: SyncChange, boundUserId: String): String {
     val spec = EntityRegistry.require(change.entityType)

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/MirrorOwnershipTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/MirrorOwnershipTest.kt
@@ -80,6 +80,17 @@ class MirrorOwnershipTest {
     }
 
     @Test
+    fun `unsupported rows are skippable without weakening known owner checks`() {
+        requireOwnedChanges(
+            listOf(
+                change(1, entityId = "legacy-activity", payload = JsonObject(emptyMap())).copy(unsupported = true),
+                change(2, entityId = "owned", payload = ownedPayload()),
+            ),
+            BOUND_USER,
+        )
+    }
+
+    @Test
     fun `unknown future entity remains skippable without weakening known owner checks`() {
         requireOwnedChanges(
             listOf(

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
@@ -44,6 +44,43 @@ class SecretReconciliationTest {
     }
 
     @Test
+    fun `incremental presence without an envelope reuses a retained local secret`() {
+        val retained = "s3cret".toByteArray()
+        val secrets = prepareSecrets(
+            change(payload = payload(hasPassword = true, hasPrivateKey = false)),
+            opener = EnvelopeOpener { _, _ -> error("must not open") },
+            retainedSecrets = mapOf("password" to retained),
+        )
+        try {
+            assertEquals("s3cret", secrets.values.getValue("password").decodeToString())
+            assertEquals(true, secrets.states.getValue("password"))
+            assertEquals(false, secrets.states.getValue("privateKey"))
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
+    fun `a fresh envelope still wins over a retained local secret`() {
+        val retained = "stale".toByteArray()
+        val secrets = prepareSecrets(
+            change(
+                payload = payload(hasPassword = true, hasPrivateKey = false),
+                envelopes = mapOf("password" to envelope()),
+            ),
+            opener = EnvelopeOpener { _, _ -> "fresh".toByteArray() },
+            retainedSecrets = mapOf("password" to retained),
+        )
+        try {
+            assertEquals("fresh", secrets.values.getValue("password").decodeToString())
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
     fun `a missing registry presence flag cannot silently clear a stored secret`() {
         val error = expectSecretFailure {
             prepareSecrets(

--- a/zephyr_one/mobile/android/core-model/src/main/kotlin/one/zephyr/mobile/model/SyncWire.kt
+++ b/zephyr_one/mobile/android/core-model/src/main/kotlin/one/zephyr/mobile/model/SyncWire.kt
@@ -24,6 +24,12 @@ data class SyncChange(
     /** Envelopes keyed by registry field name. Opened only after the AAD is verified. */
     val secretEnvelopes: Map<String, SecretEnvelope> = emptyMap(),
     val tombstone: JsonObject? = null,
+    /**
+     * Server could not project this row (legacy owner key, deleted-after-upsert).
+     * The client must skip it and still advance the cursor; treating it as an
+     * empty owned payload would freeze the whole page on residency.
+     */
+    val unsupported: Boolean = false,
 ) {
     val isDelete: Boolean get() = action == SyncAction.DELETE
 }

--- a/zephyr_one/mobile/android/core-network/src/main/kotlin/one/zephyr/mobile/network/dto/DtoMappers.kt
+++ b/zephyr_one/mobile/android/core-network/src/main/kotlin/one/zephyr/mobile/network/dto/DtoMappers.kt
@@ -77,6 +77,7 @@ object DtoMappers {
             payload = dto.payload,
             secretEnvelopes = dto.secretEnvelopes ?: emptyMap(),
             tombstone = dto.tombstone,
+            unsupported = dto.unsupported,
         )
     }
 

--- a/zephyr_one/mobile/android/core-network/src/main/kotlin/one/zephyr/mobile/network/dto/MobileDtos.kt
+++ b/zephyr_one/mobile/android/core-network/src/main/kotlin/one/zephyr/mobile/network/dto/MobileDtos.kt
@@ -299,6 +299,7 @@ data class SyncChangeDto(
     val payload: JsonObject = JsonObject(emptyMap()),
     val secretEnvelopes: Map<String, SecretEnvelope>? = null,
     val tombstone: JsonObject? = null,
+    val unsupported: Boolean = false,
 )
 
 @Serializable

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt
@@ -15,8 +15,9 @@ import one.zephyr.mobile.security.MobileAad
  * sees the [EnvelopeOpener] port, so the mirror writer cannot reach key material.
  *
  * A rejection returns null to the mirror writer, which aborts the complete page without advancing
- * its revision or cursor. Keeping a previous plaintext under a new server presence/revision would
- * pair the wrong secret with the row and make the next round skip the only chance to repair it.
+ * its revision or cursor. Incremental non-secret patches keep the local plaintext instead of
+ * requiring a fresh envelope; only a ciphertext that is actually present is opened here, and it
+ * is opened under the revision stamped on the envelope itself.
  */
 class DeviceEnvelopeOpener(
     private val identity: DeviceIdentity,
@@ -34,6 +35,10 @@ class DeviceEnvelopeOpener(
 
     override fun open(change: SyncChange, fieldName: String): ByteArray? {
         val envelope = change.secretEnvelopes[fieldName] ?: return null
+        /* AAD is bound to the revision the ciphertext was sealed under, not
+         * the change-feed revision. Incremental name/host edits reuse the
+         * previous envelope; opening it with change.revision is an AAD
+         * mismatch that aborts the whole page and freezes the cursor. */
         val expected = MobileAad.SecretInput(
             serverId = serverId(),
             userId = userId,
@@ -41,7 +46,7 @@ class DeviceEnvelopeOpener(
             entityType = change.entityType,
             entityId = change.entityId,
             fieldName = fieldName,
-            entityRevision = change.revision,
+            entityRevision = envelope.entityRevision,
             keyVersion = envelope.keyVersion,
         )
         return try {

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt
@@ -25,6 +25,7 @@ import one.zephyr.mobile.model.sync.PushPrediction
 import one.zephyr.mobile.model.sync.SyncEvent
 import one.zephyr.mobile.network.ApiResult
 import one.zephyr.mobile.security.ResidencyViolationException
+import one.zephyr.mobile.data.SecretPayloadViolationException
 import one.zephyr.mobile.data.SecretReconciliationException
 
 /**
@@ -493,6 +494,8 @@ class SyncActor(
                 return residencyFailure(violation)
             } catch (failure: SecretReconciliationException) {
                 return secretReconciliationFailure()
+            } catch (failure: SecretPayloadViolationException) {
+                return malformedResponse("unsafe inbound secret payload")
             }
             acc.applied += applied.applied
             acc.skipped += applied.skipped

--- a/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorTest.kt
+++ b/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorTest.kt
@@ -7,6 +7,8 @@ import one.zephyr.mobile.contracts.BindingState
 import one.zephyr.mobile.contracts.PushStatus
 import one.zephyr.mobile.contracts.SyncAction
 import one.zephyr.mobile.contracts.SyncPhase
+import one.zephyr.mobile.data.SecretPayloadFailure
+import one.zephyr.mobile.data.SecretPayloadViolationException
 import one.zephyr.mobile.data.SecretReconciliationException
 import one.zephyr.mobile.data.SecretReconciliationFailure
 import one.zephyr.mobile.model.BootstrapPage
@@ -412,6 +414,34 @@ class SyncActorTest {
         val result = actor(transport, store).request(SyncTrigger.INTERVAL).single()
 
         assertEquals("internal_error", result.error?.code)
+        assertEquals(40L, store.appliedCursor)
+        assertEquals(40L, store.ackedCursor)
+        assertTrue(transport.ackedCursors.isEmpty())
+        assertEquals(SyncPhase.PULL_CHANGES, result.stoppedAt)
+    }
+
+    @Test
+    fun `an unsafe inbound payload does not crash the round or advance the cursor`() = runTest {
+        val transport = FakeSyncTransport()
+        transport.changePages.add(
+            ApiResult.Success(
+                ChangePage(
+                    fromCursor = 40,
+                    nextCursor = 41,
+                    hasMore = false,
+                    changes = listOf(change(41, revision = 8)),
+                ),
+                null,
+            ),
+        )
+        val store = FakeSyncLocalStore(BindingState.IDLE)
+        store.appliedCursor = 40
+        store.ackedCursor = 40
+        store.applyChangesFailure = SecretPayloadViolationException(SecretPayloadFailure.RAW_SECRET_FIELD)
+
+        val result = actor(transport, store).request(SyncTrigger.INTERVAL).single()
+
+        assertEquals("malformed_response", result.error?.code)
         assertEquals(40L, store.appliedCursor)
         assertEquals(40L, store.ackedCursor)
         assertTrue(transport.ackedCursors.isEmpty())

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Backdrop.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Backdrop.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -74,6 +75,18 @@ class LayerBackdrop internal constructor(
 
     internal var layerCoordinates: LayoutCoordinates? by mutableStateOf(null)
 
+    /**
+     * Bumped after every successful off-screen record. Glass consumers read this
+     * during draw so they invalidate when the source layer's pixels change;
+     * otherwise the island keeps sampling the first (often empty) frame.
+     */
+    internal var recordGeneration: Int by mutableIntStateOf(0)
+        private set
+
+    internal fun notifyRecorded() {
+        recordGeneration += 1
+    }
+
     private var inverseLayerScope: InverseLayerScope? = null
 
     override fun DrawScope.drawBackdrop(
@@ -81,6 +94,7 @@ class LayerBackdrop internal constructor(
         coordinates: LayoutCoordinates?,
         layerBlock: (GraphicsLayerScope.() -> Unit)?,
     ) {
+        recordGeneration
         val coords = coordinates ?: return
         val layerCoords = layerCoordinates ?: return
         withTransform({
@@ -144,7 +158,9 @@ private class LayerBackdropNode(
     override fun ContentDrawScope.draw() {
         drawContent()
         if (size.width < 1f || size.height < 1f) return
-        recordLayer(backdrop.graphicsLayer) { backdrop.onDraw(this@draw) }
+        if (recordLayer(backdrop.graphicsLayer) { backdrop.onDraw(this@draw) }) {
+            backdrop.notifyRecorded()
+        }
     }
 
     override fun onGloballyPositioned(coordinates: LayoutCoordinates) {

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
@@ -139,7 +139,7 @@ fun FloatingIsland(
                         )
                     },
                     onDrawSurface = {
-                        drawRect(palette.surfaces.floating.copy(alpha = if (palette.dark) 0.72f else 0.82f))
+                        drawRect(palette.surfaces.floating.copy(alpha = if (palette.dark) 0.22f else 0.28f))
                     },
                 )
                 .clip(outerShape)
@@ -173,7 +173,7 @@ fun FloatingIsland(
                         },
                         shadow = null,
                         onDrawSurface = {
-                            drawRect(palette.islandSelection.copy(alpha = 0.90f))
+                            drawRect(palette.islandSelection.copy(alpha = 0.32f))
                         },
                     )
                     .clip(pillShape),

--- a/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
+++ b/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
@@ -75,6 +75,26 @@ test('FloatingIsland integrates Liquid Glass with backdrop sampling and refracti
   assert.ok(islandSource.includes('vibrancy()'));
   assert.ok(islandSource.includes('chromaticAberration = true'));
   assert.ok(islandSource.includes('Highlight.Default'));
+  assert.ok(
+    islandSource.includes('palette.surfaces.floating.copy(alpha = if (palette.dark) 0.22f else 0.28f)'),
+    'island surface tint must stay translucent enough to show the sampled backdrop',
+  );
+  assert.ok(
+    islandSource.includes('palette.islandSelection.copy(alpha = 0.32f)'),
+    'selected pill tint must stay translucent enough to show the sampled backdrop',
+  );
+  assert.equal(
+    islandSource.includes('0.82f') || islandSource.includes('0.90f') || islandSource.includes('0.72f'),
+    false,
+    'opaque island tints hide liquid glass',
+  );
+});
+
+test('LayerBackdrop invalidates glass consumers after each recorded frame', () => {
+  const backdrop = fs.readFileSync(path.join(GLASS_ROOT, 'Backdrop.kt'), 'utf8');
+  assert.ok(backdrop.includes('recordGeneration'));
+  assert.ok(backdrop.includes('fun notifyRecorded()'));
+  assert.ok(backdrop.includes('backdrop.notifyRecorded()'));
 });
 
 test('ZephyrOneRoot establishes root Backdrop and propagates LocalBackdrop', () => {

--- a/zephyr_one/mobile/tests/mobile-sync-diagnostics.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-sync-diagnostics.test.mjs
@@ -22,6 +22,31 @@ test('sync failures attach phase-specific local diagnostics before persistence',
   assert.match(store, /error\.persistedDiagnosticText\(\)/);
 });
 
+test('incremental secret downlink seals and opens under the field revision', () => {
+  const hydrate = fs.readFileSync(path.join(here, '..', '..', '..', 'mobile-v1-routes.js'), 'utf8');
+  assert.match(hydrate, /this\.store\.fieldRevision\(/);
+  assert.match(hydrate, /unsupported: true/);
+  const store = fs.readFileSync(path.join(here, '..', '..', '..', 'mobile-v1-store.js'), 'utf8');
+  assert.match(store, /fieldRevision\(ownerUserId, entityType, entityId, fieldPath\)/);
+
+  const opener = read('core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt');
+  assert.match(opener, /entityRevision = envelope\.entityRevision/);
+  assert.doesNotMatch(opener, /entityRevision = change\.revision/);
+
+  const writer = read('core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt');
+  assert.match(writer, /retainedSecretsFor/);
+  assert.match(writer, /retainedSecrets: Map<String, ByteArray> = emptyMap\(\)/);
+  assert.match(writer, /isSkippableInboundChange/);
+  assert.match(writer, /change\.unsupported/);
+
+  const actor = read('core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt');
+  assert.match(actor, /SecretPayloadViolationException/);
+  assert.match(actor, /unsafe inbound secret payload/);
+
+  const dto = read('core-network/src/main/kotlin/one/zephyr/mobile/network/dto/MobileDtos.kt');
+  assert.match(dto, /val unsupported: Boolean = false/);
+});
+
 test('remote and parser messages are not implicitly trusted as local diagnostics', () => {
   const diagnostics = read('core-model/src/main/kotlin/one/zephyr/mobile/model/MobileErrorDiagnostics.kt');
   const client = read('core-network/src/main/kotlin/one/zephyr/mobile/network/MobileApiClient.kt');

--- a/zephyr_one/mobile/tests/mobile-v1-owned-sync-projection.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-owned-sync-projection.test.mjs
@@ -267,3 +267,122 @@ test('bootstrap seals stored secrets to the bound device and keeps note bodies i
     try { db.close(); } catch {}
   }
 });
+
+test('activity events stored under username still project to the bound userId', () => {
+  const { CanonicalActivityEventService, projectActivityEvent } = require(
+    path.join(repoRoot, 'mobile-v1-server-metadata-entities.js'),
+  );
+  const db = createDatabase(':memory:', { forceBuiltin: true });
+  try {
+    db.exec(`CREATE TABLE activities (
+      id TEXT PRIMARY KEY, time INTEGER, message TEXT, type TEXT, userId TEXT,
+      category TEXT, outcome TEXT, protocol TEXT, connectionId TEXT
+    );`);
+    db.prepare(`INSERT INTO activities (id,time,message,type,userId,category,outcome,protocol,connectionId)
+      VALUES (?,?,?,?,?,?,?,?,?)`).run(
+      'evt-1', 1_700_000_000_000, 'ssh login', 'success', 'root', 'session', 'ok', 'ssh', 'c-1',
+    );
+    const storage = {
+      addActivity() {},
+      getUserById: (id) => id === 'user-uuid' ? { userId: 'user-uuid', username: 'root' } : null,
+      getUser: (name) => name === 'root' ? { userId: 'user-uuid', username: 'root' } : null,
+    };
+    const service = new CanonicalActivityEventService({ db, storage, changeBridge: { recordMutation() {} } });
+    const bound = { userId: 'user-uuid', username: 'root', status: 'active' };
+    const row = service.readActivityEventForUser(bound.userId, 'evt-1');
+    assert.ok(row);
+    const projected = projectActivityEvent(row, bound);
+    assert.equal(projected.userId, 'user-uuid');
+    assert.equal(projected.id, 'evt-1');
+    assert.equal(projected.connectionId, 'c-1');
+  } finally {
+    try { db.close(); } catch {}
+  }
+});
+
+test('a name-only change reseals the password under the password field revision', () => {
+  const connection = {
+    id: 'connection-rename',
+    ownerUserId: user.userId,
+    revision: 3,
+    name: 'renamed-host',
+    host: '10.1.1.1',
+    port: 22,
+    protocol: 'SSH',
+    username: 'root',
+    password: 's3cret-downlink',
+    privateKey: '',
+    updatedAt: 3,
+  };
+  const api = Object.create(MobileV1Api.prototype);
+  api.entityByType = new Map([['connection', connectionSpec]]);
+  api.adapters = new Map([
+    ['connection', {
+      read: (_owner, id) => id === connection.id ? connection : null,
+      residency: () => 'owned',
+    }],
+  ]);
+  api.store = { fieldRevision: (_owner, type, id, field) => (field === 'password' ? 1 : 3) };
+  let sealedRevision = null;
+  api.ownedSecretEnvelopeFields = function ownedSecretEnvelopeFields(input) {
+    sealedRevision = this.store.fieldRevision(
+      user.userId, input.entityType, input.entityId, 'password',
+    ) || input.entityRevision;
+    return { secretEnvelopes: { password: { v: 1, entityRevision: sealedRevision } } };
+  };
+
+  const hydrated = api.hydrateChange(user, {
+    changeSeq: 50,
+    entityType: 'connection',
+    entityId: connection.id,
+    action: 'upsert',
+    revision: 3,
+    actorDeviceId: 'device-1',
+    changedAt: 3,
+    fieldMask: ['name'],
+  });
+
+  assert.equal(hydrated.payload.name, 'renamed-host');
+  assert.equal(hydrated.payload.hasPassword, true);
+  assert.equal(hydrated.payload.password, undefined);
+  assert.equal(sealedRevision, 1);
+  assert.equal(hydrated.secretEnvelopes.password.entityRevision, 1);
+});
+
+test('a full-replacement change still seals stored secrets', () => {
+  const connection = {
+    id: 'connection-full',
+    ownerUserId: user.userId,
+    revision: 1,
+    name: 'bastion',
+    password: 's3cret-downlink',
+    privateKey: '',
+  };
+  const api = Object.create(MobileV1Api.prototype);
+  api.entityByType = new Map([['connection', connectionSpec]]);
+  api.adapters = new Map([
+    ['connection', {
+      read: (_owner, id) => id === connection.id ? connection : null,
+      residency: () => 'owned',
+    }],
+  ]);
+  let sealed = false;
+  api.ownedSecretEnvelopeFields = () => {
+    sealed = true;
+    return { secretEnvelopes: { password: { v: 1 } } };
+  };
+
+  const hydrated = api.hydrateChange(user, {
+    changeSeq: 1,
+    entityType: 'connection',
+    entityId: connection.id,
+    action: 'upsert',
+    revision: 1,
+    actorDeviceId: null,
+    changedAt: 1,
+    fieldMask: [],
+  });
+
+  assert.equal(sealed, true);
+  assert.ok(hydrated.secretEnvelopes?.password);
+});

--- a/zephyr_one/mobile/tests/mobile-v1-residency-security.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-residency-security.test.mjs
@@ -275,6 +275,7 @@ test('an accidentally owner-mismatched change aborts hydration before a cursor c
     action: 'upsert', revision: 4, fieldMask: ['name'],
   });
   assert.deepEqual(deletedAfterUpsert.payload, {});
+  assert.equal(deletedAfterUpsert.unsupported, true);
 });
 
 test('bootstrap refuses an adapter regression that returns a foreign row', () => {


### PR DESCRIPTION
## 现象

测机 `zephyr-e2e-1521`（Docker **v1.1.535**）上 One 只能同步一次。`acked_cursor` 停在 49，之后的 `connection` 改名和 `activityEvent` 增量永远拉不下来。液态玻璃底部岛看起来也没生效。

## 根因

1. **活动行的 owner 键历史是用户名。** `activities.userId` 写成了 `root`，绑定设备是 UUID。bootstrap 按 UUID 过滤所以第一次能过；增量 `hydrateChange` 读不到行，吐空 payload。Android `requireOwnedChanges` 把缺 `userId` 当成 residency 违规，整页失败，游标不再前进。
2. **增量改名会把未改的密码按新的 entity revision 重封。** One 用 `change.revision` 开信封，AAD 对不上，同样整页失败。测机上这条和 activity 混在同一页（50/51）。
3. **液态玻璃：** `LayerBackdrop` 录完第一帧后不通知采样者，岛一直采空帧；胶囊 `onDrawSurface` alpha 0.82/0.90，折射被实色盖住。

## 修法

- 活动读写同时匹配 `userId` 和 `username`，投影成绑定账号的 canonical `userId`。新写入先解析成 UUID。
- 无法投影的增量标 `unsupported: true`。Android 跳过这些行并推进 cursor，不再整页 residency 失败。
- 信封 AAD 绑密钥字段自己的 revision；One 用 `envelope.entityRevision` 开封。非密钥增量若仍带 `hasPassword` 且没有新信封，保留本地已开过的明文。
- `LayerBackdrop` 每次成功 `record` 后 bump `recordGeneration`；岛表面 alpha 降到 0.22/0.28，选中滑块 0.32。

## 验证

- `node --test`：owned-sync projection / residency / secrets / field-mask / liquid-glass contract / sync diagnostics / kotlin-symbols，全部绿。
- `zephyr_one/mobile npm test`：481 pass。仅 `keystore SHA-256` 因本机无 `keytool` 失败，与本次改动无关（CI 有 JDK）。

## 发布

合入后需要：

- Docker **v1.1.536**（`mobile-v1-routes.js` / store / activity 投影）
- 移动 **zom-v1.0.0pre60**（Android opener / MirrorWriter / 玻璃）
