### PR TITLE
fix(sync,android): keep a rename from aborting the next One pull

### DIFF
--- a/mobile-v1-routes.js
+++ b/mobile-v1-routes.js
@@ -1910,10 +1910,38 @@ class MobileV1Api {
              * skippable the same way an unknown type is skipped. */
             return { ...safeChange, payload: {}, unsupported: true };
         }
+        const payload = projectPayload(spec, row);
+        /* Presence flags stay in the payload. Re-sealing an unchanged secret
+         * at a later entity revision is what made One fail the whole page
+         * with internal_error after the first successful sync.
+         *
+         * Empty fieldMask is a full replacement (bootstrap / opaque mutation)
+         * and must reseal. A secret field whose stored field-revision equals
+         * this change.revision was mutated by this write and must reseal.
+         * Name/host/tag patches leave secret field-revisions behind, so they
+         * keep hasPassword=true and omit secretEnvelopes. */
+        const secretFields = spec.secretFields || [];
+        const mask = Array.isArray(safeChange.fieldMask) ? safeChange.fieldMask : [];
+        const secretTouched = secretFields.some((field) => {
+            let rev = null;
+            try {
+                if (this.store && typeof this.store.fieldRevision === 'function') {
+                    rev = this.store.fieldRevision(
+                        user.userId, change.entityType, change.entityId, field,
+                    );
+                }
+            } catch {
+                rev = null;
+            }
+            return Number(rev) === Number(change.revision);
+        });
+        const needsSecretDownlink = secretFields.length > 0 && (
+            mask.length === 0 || secretTouched
+        );
         return {
             ...safeChange,
-            payload: projectPayload(spec, row),
-            ...this.ownedSecretEnvelopeFields({
+            payload,
+            ...(needsSecretDownlink ? this.ownedSecretEnvelopeFields({
                 spec,
                 row,
                 user,
@@ -1921,7 +1949,7 @@ class MobileV1Api {
                 entityType: change.entityType,
                 entityId: change.entityId,
                 entityRevision: change.revision,
-            }),
+            }) : {}),
         };
     }
 

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
@@ -621,22 +621,23 @@ internal fun prepareSecrets(
             }
             states[fieldName] = declared
             if (declared) {
+                val retained = retainedSecrets[fieldName]
                 val opened = if (change.secretEnvelopes.containsKey(fieldName)) {
-                    try {
+                    val plaintext = try {
                         opener?.open(change, fieldName)
-                            ?: throw SecretReconciliationException(
-                                SecretReconciliationFailure.ENVELOPE_REJECTED,
-                            )
                     } catch (failure: SecretReconciliationException) {
                         throw failure
                     } catch (failure: Throwable) {
-                        throw SecretReconciliationException(
+                        null
+                    }
+                    when {
+                        plaintext != null && plaintext.isNotEmpty() -> plaintext
+                        retained != null && retained.isNotEmpty() -> retained.copyOf()
+                        else -> throw SecretReconciliationException(
                             SecretReconciliationFailure.ENVELOPE_REJECTED,
-                            failure,
                         )
                     }
                 } else {
-                    val retained = retainedSecrets[fieldName]
                     if (retained == null || retained.isEmpty()) {
                         throw SecretReconciliationException(
                             SecretReconciliationFailure.MISSING_ENVELOPE,

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
@@ -116,6 +116,45 @@ class SecretReconciliationTest {
     }
 
     @Test
+    fun `a rejected envelope keeps a retained local secret instead of freezing the page`() {
+        val retained = "local-secret".toByteArray()
+        val secrets = prepareSecrets(
+            change(
+                payload = payload(hasPassword = true, hasPrivateKey = false),
+                envelopes = mapOf("password" to envelope()),
+            ),
+            opener = EnvelopeOpener { _, _ -> null },
+            retainedSecrets = mapOf("password" to retained),
+        )
+        try {
+            assertEquals("local-secret", secrets.values.getValue("password").decodeToString())
+            assertEquals(true, secrets.states.getValue("password"))
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
+    fun `an envelope opener exception keeps a retained local secret`() {
+        val retained = "local-secret".toByteArray()
+        val secrets = prepareSecrets(
+            change(
+                payload = payload(hasPassword = true, hasPrivateKey = false),
+                envelopes = mapOf("password" to envelope()),
+            ),
+            opener = EnvelopeOpener { _, _ -> error("device unwrap failed") },
+            retainedSecrets = mapOf("password" to retained),
+        )
+        try {
+            assertEquals("local-secret", secrets.values.getValue("password").decodeToString())
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
     fun `an envelope opener exception is normalized and fails closed`() {
         val error = expectSecretFailure {
             prepareSecrets(

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt
@@ -14,10 +14,10 @@ import one.zephyr.mobile.security.MobileAad
  * (core-security) and the binding identity needed to rebuild the AAD. core-data deliberately only
  * sees the [EnvelopeOpener] port, so the mirror writer cannot reach key material.
  *
- * A rejection returns null to the mirror writer, which aborts the complete page without advancing
- * its revision or cursor. Incremental non-secret patches keep the local plaintext instead of
- * requiring a fresh envelope; only a ciphertext that is actually present is opened here, and it
- * is opened under the revision stamped on the envelope itself.
+ * A rejection returns null. The mirror writer then either keeps a previously
+ * opened local secret (incremental non-secret patches) or fails the page.
+ * Ciphertext is opened first under the envelope's own revision, then under
+ * the change-feed revision for older main ends.
  */
 class DeviceEnvelopeOpener(
     private val identity: DeviceIdentity,
@@ -35,37 +35,42 @@ class DeviceEnvelopeOpener(
 
     override fun open(change: SyncChange, fieldName: String): ByteArray? {
         val envelope = change.secretEnvelopes[fieldName] ?: return null
-        /* AAD is bound to the revision the ciphertext was sealed under, not
-         * the change-feed revision. Incremental name/host edits reuse the
-         * previous envelope; opening it with change.revision is an AAD
-         * mismatch that aborts the whole page and freezes the cursor. */
-        val expected = MobileAad.SecretInput(
-            serverId = serverId(),
-            userId = userId,
-            deviceId = deviceId,
-            entityType = change.entityType,
-            entityId = change.entityId,
-            fieldName = fieldName,
-            entityRevision = envelope.entityRevision,
-            keyVersion = envelope.keyVersion,
-        )
-        return try {
-            identity.withPrivateKey { privateKey ->
-                DeviceEnvelopeCrypto.openSecretEnvelope(
-                    envelope = envelope,
-                    expected = expected,
-                    knownKeyVersions = knownKeyVersions(),
-                    privateKey = privateKey,
-                )
+        /* Prefer the revision stamped on the envelope (the one the ciphertext
+         * was sealed under). Fall back to the change-feed revision for older
+         * main ends that resealed every patch at the entity revision. */
+        val revisions = linkedSetOf(envelope.entityRevision, change.revision)
+            .filter { it > 0L }
+        var lastRejection: String? = null
+        for (revision in revisions) {
+            val expected = MobileAad.SecretInput(
+                serverId = serverId(),
+                userId = userId,
+                deviceId = deviceId,
+                entityType = change.entityType,
+                entityId = change.entityId,
+                fieldName = fieldName,
+                entityRevision = revision,
+                keyVersion = envelope.keyVersion,
+            )
+            try {
+                return identity.withPrivateKey { privateKey ->
+                    DeviceEnvelopeCrypto.openSecretEnvelope(
+                        envelope = envelope,
+                        expected = expected,
+                        knownKeyVersions = knownKeyVersions(),
+                        privateKey = privateKey,
+                    )
+                }
+            } catch (rejection: EnvelopeRejection) {
+                lastRejection = rejection.code
+            } catch (_: Exception) {
+                lastRejection = "envelope_open_failed"
             }
-        } catch (rejection: EnvelopeRejection) {
-            onRejected(change.entityType + "/" + change.entityId + "/" + fieldName, rejection.code)
-            null
-        } catch (failure: Exception) {
-            // A cipher failure is reported the same way as a structural rejection: the message is
-            // never surfaced, because it could echo ciphertext into a log.
-            onRejected(change.entityType + "/" + change.entityId + "/" + fieldName, "envelope_open_failed")
-            null
         }
+        onRejected(
+            change.entityType + "/" + change.entityId + "/" + fieldName,
+            lastRejection ?: "envelope_open_failed",
+        )
+        return null
     }
 }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/DrawBackdropModifier.kt
@@ -311,17 +311,22 @@ private class DrawBackdropNode(
             drawContent()
             onDrawFront?.invoke(this)
 
-            exportedBackdrop?.graphicsLayer?.let { layer ->
-                recordLayer(layer) {
+            val exported = exportedBackdrop
+            exported?.graphicsLayer?.let { layer ->
+                if (recordLayer(layer) {
                     onDrawBehind?.invoke(this)
                     drawBackdropLayer()
                     onDrawSurface?.invoke(this)
                     onDrawFront?.invoke(this)
+                }) {
+                    exported.notifyRecorded()
                 }
             }
         } catch (failure: Throwable) {
-            GlassRuntime.disableEffects()
-            android.util.Log.e("ZephyrGlass", "backdrop draw failed; glass disabled", failure)
+            /* A single bad frame (0x0 record, Adreno quirk) must not kill
+             * glass for the rest of the process. Skip this draw; next frame
+             * retries. AGSL compile failures still disable shaders. */
+            android.util.Log.w("ZephyrGlass", "backdrop draw skipped this frame", failure)
             onDrawSurface?.invoke(this)
             drawContent()
         }
@@ -362,8 +367,7 @@ private class DrawBackdropNode(
             graphicsLayer?.renderEffect = effectScope.renderEffect
             padding = effectScope.padding
         } catch (failure: Throwable) {
-            GlassRuntime.disableEffects()
-            android.util.Log.e("ZephyrGlass", "backdrop effect failed; glass disabled", failure)
+            android.util.Log.w("ZephyrGlass", "backdrop effect skipped this frame", failure)
             graphicsLayer?.renderEffect = null
             padding = 0f
         }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/glass/Internal.kt
@@ -49,8 +49,7 @@ internal fun DrawScope.recordLayer(
         }
         true
     } catch (failure: Throwable) {
-        GlassRuntime.disableEffects()
-        android.util.Log.e("ZephyrGlass", "graphics layer record failed; glass disabled", failure)
+        android.util.Log.w("ZephyrGlass", "graphics layer record skipped this frame", failure)
         false
     }
 }

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt
@@ -34,13 +34,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import one.zephyr.mobile.ui.component.Icon
@@ -48,10 +50,12 @@ import one.zephyr.mobile.ui.component.Text
 import one.zephyr.mobile.ui.glass.Highlight
 import one.zephyr.mobile.ui.glass.InnerShadow
 import one.zephyr.mobile.ui.glass.LocalBackdrop
+import one.zephyr.mobile.ui.glass.Shadow
 import one.zephyr.mobile.ui.glass.blur
 import one.zephyr.mobile.ui.glass.drawBackdrop
 import one.zephyr.mobile.ui.glass.lens
-import one.zephyr.mobile.ui.glass.vibrancy
+import one.zephyr.mobile.ui.glass.rememberCombinedBackdrop
+import one.zephyr.mobile.ui.glass.rememberLayerBackdrop
 import one.zephyr.mobile.ui.theme.IslandSpec
 import one.zephyr.mobile.ui.theme.ZephyrMotionTokens
 import one.zephyr.mobile.ui.theme.ZephyrTextStyles
@@ -104,43 +108,53 @@ fun FloatingIsland(
         )
         val innerWidth = IslandGeometry.innerWidth(outerWidth, IslandSpec.innerPadding.value)
         val slotWidth = IslandGeometry.slotWidth(innerWidth, destinations.size)
-        val backdrop = LocalBackdrop.current
+        val contentBackdrop = LocalBackdrop.current
+        val capsuleBackdrop = rememberLayerBackdrop()
+        val selectedBackdrop = rememberCombinedBackdrop(contentBackdrop, capsuleBackdrop)
         val outerShape = RoundedCornerShape(IslandSpec.outerHeight / 2)
         val pillShape = RoundedCornerShape(IslandSpec.selectedPillRadius)
+        val isDark = palette.dark
 
         Box(
             modifier = Modifier
                 .width(outerWidth.dp)
                 .height(IslandSpec.outerHeight)
-                .shadow(
-                    elevation = 12.dp,
-                    shape = outerShape,
-                    ambientColor = palette.islandShadow,
-                    spotColor = palette.islandShadow,
-                )
                 .drawBackdrop(
-                    backdrop = backdrop,
+                    backdrop = contentBackdrop,
                     shape = { outerShape },
                     effects = {
-                        vibrancy()
-                        blur(16f.dp.toPx())
+                        blur(8f.dp.toPx())
                         lens(
-                            refractionHeight = 16f.dp.toPx(),
+                            refractionHeight = 12f.dp.toPx(),
                             refractionAmount = 24f.dp.toPx(),
-                            depthEffect = true,
+                            chromaticAberration = true,
                         )
                     },
-                    highlight = { Highlight.Default.copy(alpha = if (palette.dark) 0.5f else 0.7f) },
-                    shadow = null,
+                    highlight = {
+                        Highlight.Default.copy(alpha = if (isDark) 0.6f else 1f)
+                    },
+                    shadow = {
+                        Shadow(
+                            radius = 32f.dp,
+                            offset = DpOffset(0f.dp, 16f.dp),
+                            color = Color.Black.copy(alpha = if (isDark) 0.4f else 0.16f),
+                        )
+                    },
                     innerShadow = {
                         InnerShadow(
-                            radius = 6.dp,
-                            color = if (palette.dark) Color.White.copy(alpha = 0.08f) else Color.Black.copy(alpha = 0.04f),
+                            radius = 8f.dp,
+                            color = Color.Black.copy(alpha = if (isDark) 0.5f else 0.2f),
                         )
                     },
                     onDrawSurface = {
-                        drawRect(palette.surfaces.floating.copy(alpha = if (palette.dark) 0.22f else 0.28f))
+                        val tint = if (isDark) {
+                            Color(0xFF202020).copy(alpha = 0.10f)
+                        } else {
+                            Color.White.copy(alpha = 0.10f)
+                        }
+                        drawRect(tint)
                     },
+                    exportedBackdrop = capsuleBackdrop,
                 )
                 .clip(outerShape)
                 .padding(IslandSpec.innerPadding),
@@ -155,25 +169,27 @@ fun FloatingIsland(
                     }
                     .width(slotWidth.dp)
                     .height(IslandSpec.selectedPillHeight)
+                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
                     .drawBackdrop(
-                        backdrop = backdrop,
+                        backdrop = selectedBackdrop,
                         shape = { pillShape },
                         effects = {
                             lens(
-                                refractionHeight = 8f.dp.toPx(),
+                                refractionHeight = 10f.dp.toPx(),
                                 refractionAmount = 14f.dp.toPx(),
                                 chromaticAberration = true,
                             )
                         },
-                        highlight = {
-                            Highlight.Default.copy(
-                                width = 0.75f.dp,
-                                alpha = 0.85f,
+                        highlight = { Highlight.Default },
+                        shadow = null,
+                        innerShadow = {
+                            InnerShadow(
+                                radius = 8f.dp,
+                                color = Color.Black.copy(alpha = 0.8f),
                             )
                         },
-                        shadow = null,
                         onDrawSurface = {
-                            drawRect(palette.islandSelection.copy(alpha = 0.32f))
+                            drawRect(Color.White.copy(alpha = 0.08f))
                         },
                     )
                     .clip(pillShape),

--- a/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
+++ b/zephyr_one/mobile/tests/android-liquid-glass-contract.test.mjs
@@ -71,17 +71,17 @@ test('FloatingIsland integrates Liquid Glass with backdrop sampling and refracti
   const islandSource = readSource('core-ui/src/main/kotlin/one/zephyr/mobile/ui/island/FloatingIsland.kt');
   assert.ok(islandSource.includes('one.zephyr.mobile.ui.glass.drawBackdrop'));
   assert.ok(islandSource.includes('one.zephyr.mobile.ui.glass.LocalBackdrop'));
+  assert.ok(islandSource.includes('rememberCombinedBackdrop'));
+  assert.ok(islandSource.includes('rememberLayerBackdrop'));
+  assert.ok(islandSource.includes('exportedBackdrop = capsuleBackdrop'));
   assert.ok(islandSource.includes('lens('));
-  assert.ok(islandSource.includes('vibrancy()'));
   assert.ok(islandSource.includes('chromaticAberration = true'));
   assert.ok(islandSource.includes('Highlight.Default'));
+  assert.ok(islandSource.includes('Shadow('));
+  assert.equal(islandSource.includes('Modifier.shadow('), false, 'Material elevation hides liquid glass');
   assert.ok(
-    islandSource.includes('palette.surfaces.floating.copy(alpha = if (palette.dark) 0.22f else 0.28f)'),
+    islandSource.includes('Color.White.copy(alpha = 0.10f)') || islandSource.includes('Color.White.copy(alpha = 0.08f)'),
     'island surface tint must stay translucent enough to show the sampled backdrop',
-  );
-  assert.ok(
-    islandSource.includes('palette.islandSelection.copy(alpha = 0.32f)'),
-    'selected pill tint must stay translucent enough to show the sampled backdrop',
   );
   assert.equal(
     islandSource.includes('0.82f') || islandSource.includes('0.90f') || islandSource.includes('0.72f'),
@@ -130,11 +130,19 @@ test('glass GPU path can disable itself instead of crashing composition', () => 
 
   const internal = fs.readFileSync(path.join(GLASS_ROOT, 'Internal.kt'), 'utf8');
   assert.ok(internal.includes('if (size.width <= 0 || size.height <= 0) return false'));
-  assert.ok(internal.includes('GlassRuntime.disableEffects()'));
+  assert.equal(
+    internal.includes('GlassRuntime.disableEffects()'),
+    false,
+    'a single GraphicsLayer.record failure must not kill glass for the process',
+  );
 
   const draw = fs.readFileSync(path.join(GLASS_ROOT, 'DrawBackdropModifier.kt'), 'utf8');
-  assert.ok(draw.includes('GlassRuntime.disableEffects()'));
-  assert.ok(draw.includes('backdrop draw failed; glass disabled'));
+  assert.equal(
+    draw.includes('GlassRuntime.disableEffects()'),
+    false,
+    'a single backdrop draw failure must not kill glass for the process',
+  );
+  assert.ok(draw.includes('exported.notifyRecorded()'));
 });
 
 test('All Liquid Glass Kotlin sources are pure ASCII', () => {

--- a/zephyr_one/mobile/tests/mobile-sync-diagnostics.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-sync-diagnostics.test.mjs
@@ -26,12 +26,14 @@ test('incremental secret downlink seals and opens under the field revision', () 
   const hydrate = fs.readFileSync(path.join(here, '..', '..', '..', 'mobile-v1-routes.js'), 'utf8');
   assert.match(hydrate, /this\.store\.fieldRevision\(/);
   assert.match(hydrate, /unsupported: true/);
+  assert.match(hydrate, /needsSecretDownlink/);
+  assert.match(hydrate, /mask\.length === 0 \|\| secretTouched/);
   const store = fs.readFileSync(path.join(here, '..', '..', '..', 'mobile-v1-store.js'), 'utf8');
   assert.match(store, /fieldRevision\(ownerUserId, entityType, entityId, fieldPath\)/);
 
   const opener = read('core-sync/src/main/kotlin/one/zephyr/mobile/sync/DeviceEnvelopeOpener.kt');
-  assert.match(opener, /entityRevision = envelope\.entityRevision/);
-  assert.doesNotMatch(opener, /entityRevision = change\.revision/);
+  assert.match(opener, /envelope\.entityRevision/);
+  assert.match(opener, /change\.revision/);
 
   const writer = read('core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt');
   assert.match(writer, /retainedSecretsFor/);

--- a/zephyr_one/mobile/tests/mobile-v1-owned-sync-projection.test.mjs
+++ b/zephyr_one/mobile/tests/mobile-v1-owned-sync-projection.test.mjs
@@ -300,7 +300,7 @@ test('activity events stored under username still project to the bound userId', 
   }
 });
 
-test('a name-only change reseals the password under the password field revision', () => {
+test('a name-only change keeps hasPassword and does not reseal the password', () => {
   const connection = {
     id: 'connection-rename',
     ownerUserId: user.userId,
@@ -322,13 +322,9 @@ test('a name-only change reseals the password under the password field revision'
       residency: () => 'owned',
     }],
   ]);
-  api.store = { fieldRevision: (_owner, type, id, field) => (field === 'password' ? 1 : 3) };
-  let sealedRevision = null;
-  api.ownedSecretEnvelopeFields = function ownedSecretEnvelopeFields(input) {
-    sealedRevision = this.store.fieldRevision(
-      user.userId, input.entityType, input.entityId, 'password',
-    ) || input.entityRevision;
-    return { secretEnvelopes: { password: { v: 1, entityRevision: sealedRevision } } };
+  api.store = { fieldRevision: (_owner, type, id, field) => (field === 'password' ? 2 : null) };
+  api.ownedSecretEnvelopeFields = () => {
+    throw new Error('name-only incremental changes must not reseal secrets');
   };
 
   const hydrated = api.hydrateChange(user, {
@@ -345,8 +341,7 @@ test('a name-only change reseals the password under the password field revision'
   assert.equal(hydrated.payload.name, 'renamed-host');
   assert.equal(hydrated.payload.hasPassword, true);
   assert.equal(hydrated.payload.password, undefined);
-  assert.equal(sealedRevision, 1);
-  assert.equal(hydrated.secretEnvelopes.password.entityRevision, 1);
+  assert.equal(hydrated.secretEnvelopes, undefined);
 });
 
 test('a full-replacement change still seals stored secrets', () => {


### PR DESCRIPTION
## Why

The pre60 APK on the test device still dies on the second sync with `internal_error` and then retries forever. The screenshot is that retry loop.

`last_acked_cursor` is stuck at 49. Change 50 is a connection rename (`fieldMask: ["name"]`, entity revision 3). Change 51 is an `activityEvent`. The rename resealed the *unchanged* password under revision 3; One opened it with the wrong AAD, `prepareSecrets` failed the whole page, and the cursor never moved.

The island still had no liquid-glass look: Material `Modifier.shadow`, an opaque surface, no `CombinedBackdrop` / `exportedBackdrop` (the Kyant `LiquidBottomTabs` recipe), and a single `GraphicsLayer.record` miss that called `GlassRuntime.disableEffects()` for the rest of the process.

## What changed

**Sync**
- Incremental non-secret patches (`name` / host / tags) keep `hasPassword` and omit `secretEnvelopes`.
- Empty `fieldMask` (bootstrap / full replacement) and a secret whose field-revision equals this change still reseal.
- Opener tries `envelope.entityRevision` then `change.revision`.
- A rejected envelope with a retained local secret no longer fails the page (`internal_error`).
- Unprojectable rows stay `unsupported` and still advance the cursor (from #107).

**Glass** (aligned with [Kyant0/AndroidLiquidGlass](https://github.com/Kyant0/AndroidLiquidGlass) `LiquidBottomTabs`)
- Capsule samples the root backdrop, exports itself, selected pill samples `CombinedBackdrop`.
- Drop Material elevation; Kyant-style `Shadow` / `InnerShadow` / `lens` / 10% white tint.
- A single record/draw miss skips the frame; it does not disable GPU glass.

## Verify
- Node: `mobile-v1-owned-sync-projection`, `mobile-v1-secrets`, `mobile-v1-residency-security`, `mobile-sync-diagnostics`, `android-liquid-glass-contract`.
- After merge: Docker `v1.1.537` + `zom-v1.0.0pre61`. Test box `zephyr-e2e-1521` is already on `v1.1.536`; it needs this server image *and* the new APK. Success = `last_acked_cursor` past 51 and the island showing refraction, not a solid bar.
