### PR TITLE
fix(android): surface sync diagnostics and keep the home list live

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/ZephyrOneRoot.kt
@@ -1186,7 +1186,7 @@ private fun RootDestination(
 
             ConnectionListRoute(
                 viewModel = viewModel(
-                    key = "connections",
+                    key = "connections-" + ownerUserId,
                     factory = ConnectionListViewModel.factory(
                         connections = account.connections,
                         settings = account.settings,

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
@@ -47,6 +47,31 @@ class SecretReconciliationTest {
     }
 
     @Test
+    fun `live name-only page with presence and no envelope does not freeze the cursor`() {
+        val secrets = prepareSecrets(
+            change(
+                payload = JsonObject(
+                    mapOf(
+                        "ownerUserId" to JsonPrimitive("8f9d1961-1fbb-436c-ab4a-09aaf7c42bce"),
+                        "name" to JsonPrimitive("home1"),
+                        "hasPassword" to JsonPrimitive(true),
+                        "hasPrivateKey" to JsonPrimitive(false),
+                    ),
+                ),
+                fieldMask = listOf("name"),
+            ),
+            opener = EnvelopeOpener { _, _ -> error("must not open") },
+        )
+        try {
+            assertEquals(true, secrets.states.getValue("password"))
+            assertEquals(false, secrets.states.getValue("privateKey"))
+            assertTrue(secrets.values["password"] == null)
+        } finally {
+            secrets.close()
+        }
+    }
+
+    @Test
     fun `incremental name patch without a local secret does not freeze the cursor`() {
         val secrets = prepareSecrets(
             change(

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt
@@ -386,7 +386,7 @@ class SyncActor(
             try {
                 store.resetBootstrap()
             } catch (failure: SecretReconciliationException) {
-                return BootstrapAttempt.Failed(secretReconciliationFailure())
+                return BootstrapAttempt.Failed(secretReconciliationFailure(failure))
             }
         }
 
@@ -413,7 +413,7 @@ class SyncActor(
             } catch (violation: ResidencyViolationException) {
                 return BootstrapAttempt.Failed(residencyFailure(violation))
             } catch (failure: SecretReconciliationException) {
-                return BootstrapAttempt.Failed(secretReconciliationFailure())
+                return BootstrapAttempt.Failed(secretReconciliationFailure(failure))
             }
             // A rejected first page must not advance even the snapshot cursor. Staging is invisible
             // and reset on recovery, so persisting the join only after validation is crash-safe.
@@ -432,7 +432,7 @@ class SyncActor(
                 } catch (violation: ResidencyViolationException) {
                     return BootstrapAttempt.Failed(residencyFailure(violation))
                 } catch (failure: SecretReconciliationException) {
-                    return BootstrapAttempt.Failed(secretReconciliationFailure())
+                    return BootstrapAttempt.Failed(secretReconciliationFailure(failure))
                 }
                 acc.applied += staged
                 return BootstrapAttempt.Finished(BootstrapOutcome.Complete)
@@ -493,9 +493,17 @@ class SyncActor(
             } catch (violation: ResidencyViolationException) {
                 return residencyFailure(violation)
             } catch (failure: SecretReconciliationException) {
-                return secretReconciliationFailure()
+                return secretReconciliationFailure(failure)
             } catch (failure: SecretPayloadViolationException) {
                 return malformedResponse("unsafe inbound secret payload")
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                return MobileError.local(
+                    code = "internal_error",
+                    message = "local change apply failed",
+                    retryable = true,
+                ).withLocalDiagnostic("sync.pull: " + failure::class.java.simpleName)
             }
             acc.applied += applied.applied
             acc.skipped += applied.skipped
@@ -512,14 +520,19 @@ class SyncActor(
         MobileError.local(
             code = "shared_residency_violation",
             message = violation.message ?: "server change did not prove ownership",
+        ).withLocalDiagnostic(
+            (violation.message ?: "server change did not prove ownership")
+                .lineSequence()
+                .first()
+                .take(180),
         )
 
-    private fun secretReconciliationFailure(): MobileError =
+    private fun secretReconciliationFailure(failure: SecretReconciliationException): MobileError =
         MobileError.local(
             code = "internal_error",
             message = "secret envelope reconciliation failed",
             retryable = true,
-        )
+        ).withLocalDiagnostic("sync.pull: " + failure.failure.name.lowercase())
 
     private suspend fun pushPending(acc: RoundAccumulator): MobileError? {
         val queued = store.pendingOperations()
@@ -838,7 +851,7 @@ class SyncActor(
                         code = "internal_error",
                         message = "local ACK commit failed",
                         retryable = true,
-                    )
+                    ).withLocalDiagnostic("sync.ack: local commit failed")
                 }
             }
         }

--- a/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorTest.kt
+++ b/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorTest.kt
@@ -414,6 +414,43 @@ class SyncActorTest {
         val result = actor(transport, store).request(SyncTrigger.INTERVAL).single()
 
         assertEquals("internal_error", result.error?.code)
+        assertEquals(
+            "sync.pull: envelope_rejected",
+            result.error?.details?.get("clientLocalDiagnostic"),
+        )
+        assertEquals(40L, store.appliedCursor)
+        assertEquals(40L, store.ackedCursor)
+        assertTrue(transport.ackedCursors.isEmpty())
+        assertEquals(SyncPhase.PULL_CHANGES, result.stoppedAt)
+        assertEquals(
+            "sync.pull: envelope_rejected",
+            store.recordedFailures.single().details["clientLocalDiagnostic"],
+        )
+    }
+
+    @Test
+    fun `an unexpected apply fault keeps the cursor and records a local diagnostic`() = runTest {
+        val transport = FakeSyncTransport()
+        transport.changePages.add(
+            ApiResult.Success(
+                ChangePage(
+                    fromCursor = 40,
+                    nextCursor = 41,
+                    hasMore = false,
+                    changes = listOf(change(41, revision = 8)),
+                ),
+                null,
+            ),
+        )
+        val store = FakeSyncLocalStore(BindingState.IDLE)
+        store.appliedCursor = 40
+        store.ackedCursor = 40
+        store.applyChangesFailure = IllegalStateException("room write failed")
+
+        val result = actor(transport, store).request(SyncTrigger.INTERVAL).single()
+
+        assertEquals("internal_error", result.error?.code)
+        assertEquals("sync.pull: IllegalStateException", result.error?.details?.get("clientLocalDiagnostic"))
         assertEquals(40L, store.appliedCursor)
         assertEquals(40L, store.ackedCursor)
         assertTrue(transport.ackedCursors.isEmpty())
@@ -1084,6 +1121,7 @@ class SyncActorTest {
         val interrupted = actor(transport, store).request(SyncTrigger.INTERVAL).single()
 
         assertEquals("internal_error", interrupted.error?.code)
+        assertEquals("sync.ack: local commit failed", interrupted.error?.details?.get("clientLocalDiagnostic"))
         assertEquals(listOf("op-1"), store.queue.map { it.opId })
         assertEquals(setOf("op-1"), store.retainedJournalOpIds)
         assertTrue(store.completed.isEmpty())
@@ -1351,6 +1389,7 @@ class SyncActorTest {
         val result = subject.request(SyncTrigger.INTERVAL).single()
 
         assertEquals("shared_residency_violation", result.error?.code)
+        assertEquals("missing ownerUserId", result.error?.details?.get("clientLocalDiagnostic"))
         assertEquals(SyncPhase.PULL_CHANGES, result.stoppedAt)
         assertEquals(0L, store.appliedCursor)
         assertEquals(0L, store.ackedCursor)

--- a/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Components.kt
+++ b/zephyr_one/mobile/android/core-ui/src/main/kotlin/one/zephyr/mobile/ui/component/Components.kt
@@ -117,7 +117,15 @@ fun SyncStatusPill(status: SyncStatus, modifier: Modifier = Modifier) {
         status.bindingState == BindingState.FATAL_INCOMPATIBLE -> "版本不兼容" to palette.status.error
         status.isRunning -> "同步中" to palette.brand.accent
         status.pendingCount > 0 -> "待同步 " + status.pendingCount to palette.status.pendingSync
-        lastError != null -> lastError.code.take(22) to palette.status.error
+        lastError != null -> {
+            val detail = lastError.message.substringBefore(" · code=").trim().take(40)
+            val label = if (detail.isNotEmpty() && detail != lastError.code) {
+                lastError.code.take(18) + "·" + detail
+            } else {
+                lastError.code.take(22)
+            }
+            label to palette.status.error
+        }
         status.lastSuccessAt != null -> "已同步" to palette.status.success
         else -> "未同步" to palette.status.offline
     }

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListScreen.kt
@@ -209,12 +209,17 @@ private fun DashboardHeader(
 @Composable
 private fun SyncPill(status: SyncStatus, localMode: Boolean, onClick: (() -> Unit)?) {
     val palette = ZephyrTheme.palette
+    val failedPrefix = stringResource(R.string.connections_sync_failed)
+    val failedLabel = status.lastError?.let { error ->
+        val detail = error.message.substringBefore(" · code=").trim().take(64)
+        if (detail.isEmpty() || detail == error.code) failedPrefix else failedPrefix + "·" + detail
+    }
     val (label, color) = when {
         localMode -> stringResource(R.string.connections_local_mode) to palette.status.offline
         status.conflictCount > 0 -> stringResource(R.string.connection_conflict) to palette.status.conflict
         status.isRunning -> stringResource(R.string.connections_syncing) to palette.status.pendingSync
         status.pendingCount > 0 -> stringResource(R.string.connection_pending) to palette.status.pendingSync
-        status.lastError != null -> stringResource(R.string.connections_sync_failed) to palette.status.error
+        failedLabel != null -> failedLabel to palette.status.error
         status.lastSuccessAt != null -> stringResource(R.string.connections_synced) to palette.status.success
         else -> stringResource(R.string.connections_not_synced) to palette.status.offline
     }

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListViewModel.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionListViewModel.kt
@@ -92,19 +92,19 @@ class ConnectionListViewModel(
             bound = localMode || status.bindingState.isBound,
             lastSyncedAt = status.lastSuccessAt,
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), PageState.InitialLoading)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, PageState.InitialLoading)
 
     /** The recents strip is derived from the same rows so it can never disagree with the list. */
     val recents: StateFlow<List<Connection>> = merged
         .map { rows -> ConnectionFilters.recents(rows ?: emptyList()) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), emptyList())
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val availableTags: StateFlow<List<String>> = merged
         .map { rows -> ConnectionFilters.availableTags(rows ?: emptyList()) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), emptyList())
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val favouriteIds: StateFlow<Set<String>> = favourites
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), emptySet())
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
 
     // ---- filter intents ----------------------------------------------------------------------
 
@@ -173,8 +173,6 @@ class ConnectionListViewModel(
     }
 
     companion object {
-        private const val STOP_TIMEOUT_MS = 5_000L
-
         const val MSG_DELETED = "已删除，待同步"
         const val MSG_DELETE_DENIED = "你没有删除此连接的权限"
         const val MSG_DELETE_FAILED = "删除未完成，请重试"


### PR DESCRIPTION
## 现网怎么跑出来的

测机 `zephyr-e2e-1521` 已是 **v1.1.538**。设备 `491bd90b-8fd4-4338-8844-d73d52b0f9b7` 服务端 `last_acked_cursor=54`，`lastError` 为空。

对这台设备把现网页走完：

- JSON 桥 `since=0` / `since=49` / `since=54` 全绿
- One 同一套 Go CBOR 编解码 0 字段丢失
- One 同一套 Go Link 客户端连跑 3 轮 bootstrap/changes/ack 全成功
- 用 Android apply 规则对着现网页模拟：0 失败

seq 50 是连接改名：`mask=["name"]`、`ownerUserId` 在、`hasPassword=true`、没有信封。#112 之后服务端这条已经不重封密码。

所以「第二次同步失败 + 首页要刷新才有连接」不在服务端，在 One Android。

## 客户端修了什么

1. **错误详情**：信封失败、residency 失败、ACK 提交失败、未捕获 apply 异常都写入 bounded `clientLocalDiagnostic`。首页 pill 显示 `同步失败·sync.pull: envelope_rejected` 这类文案，不再只剩 `internal_error`。
2. **首页列表**：`ConnectionListViewModel` 改 `SharingStarted.Eagerly`，第一次 bootstrap 写 Room 时订阅还在。ViewModel key 带上 `ownerUserId`。
3. **测试**：现网页 name-only 无信封不掐 cursor；诊断会进 `recordedFailures`。

## 测机限制

测机 3.8G，Gradle + Kotlin daemon 会被 OOM kill。JVM 单测交给本 PR 的 mobile CI。Docker 不必重发。合入后发 **zom-v1.0.0pre65** 装到设备上再点一次同步，pill 会带具体诊断。
