### PR TITLE
fix(ai): complete manual task-plan deletion

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10182,10 +10182,27 @@ async function deleteAiPlan(planId) {
 async function deleteAiPlanConfirmed(planId) {
     try {
         const data = await api('/api/ai/tools/run', { method: 'POST', body: JSON.stringify({ tool: 'plan_delete', args: { planId }, context: collectAiContext() }) });
+        let result = data.result || {};
+        // The delete button already has an explicit UI confirmation. The server
+        // still protects the destructive tool with its canonical confirmation
+        // gate, so finish that same request instead of pretending the local
+        // row was deleted while the stored plan remains on the server.
+        if (result.confirmationRequired || result.data?.confirmationRequired) {
+            const confirmation = result.confirmation || result.data?.confirmation;
+            if (!confirmation?.id) throw new Error(t('计划删除确认请求无效'));
+            const confirmed = await api(`/api/ai/confirm/${encodeURIComponent(confirmation.id)}`, {
+                method: 'POST',
+                body: JSON.stringify({ approve: true }),
+            });
+            result = confirmed.result || {};
+        }
+        const deleted = result.deleted === true || result.data?.deleted === true;
+        if (!deleted) throw new Error(t('计划删除未完成'));
         const ai = normalizeAiSettings(settings.ai || aiSettingsState || {});
-        ai.plans = (ai.plans || []).filter((p) => p.id !== planId);
+        const serverPlans = result.data?.plans || result.plans;
+        ai.plans = Array.isArray(serverPlans) ? serverPlans : (ai.plans || []).filter((p) => p.id !== planId);
         settings.ai = ai; aiSettingsState = ai; renderAiPlanList();
-        toast(data.result?.deleted ? t('计划已删除') : t('计划删除完成'));
+        toast(t('计划已删除'));
     } catch (err) { toast(err.message || t('计划删除失败')); }
 }
 async function revealAiProviderKey(id, trigger = null) {

--- a/tests/ai-plan-delete-contract.test.mjs
+++ b/tests/ai-plan-delete-contract.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const appJs = readFileSync(path.join(root, 'public/app.js'), 'utf8');
+const serviceJs = readFileSync(path.join(root, 'ai-agent-service.js'), 'utf8');
+
+test('manual AI plan deletion completes the server confirmation gate', () => {
+    const start = appJs.indexOf('async function deleteAiPlanConfirmed(planId)');
+    const end = appJs.indexOf('\nasync function revealAiProviderKey', start);
+    assert.ok(start >= 0 && end > start, 'manual plan deletion handler exists');
+    const handler = appJs.slice(start, end);
+    assert.match(handler, /tool:\s*'plan_delete'/);
+    assert.match(handler, /result\.confirmationRequired/);
+    assert.match(handler, /api\(`\/api\/ai\/confirm\/\$\{encodeURIComponent\(confirmation\.id\)\}`/);
+    assert.match(handler, /approve:\s*true/);
+    assert.match(handler, /result\.deleted\s*===\s*true/);
+    assert.match(handler, /计划删除未完成/);
+});
+
+test('plan deletion remains a destructive confirmed AI capability', () => {
+    assert.match(serviceJs, /name:\s*'plan_delete'/);
+    assert.match(serviceJs, /case 'plan_delete':/);
+    assert.match(serviceJs, /filter\(\(plan\) => plan\.id !== planId\)/);
+});

--- a/tests/ai-plan-delete.test.mjs
+++ b/tests/ai-plan-delete.test.mjs
@@ -1,0 +1,46 @@
+import test, { before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { TestServer } from './test-server.mjs';
+
+let server;
+let cookie;
+
+before(async () => {
+    server = new TestServer();
+    await server.start();
+    ({ cookie } = await server.bootstrapAdmin('plan-delete-admin-pass'));
+    const settings = await server.api(cookie, 'PUT', '/api/settings', { ai: { enabled: true } });
+    assert.equal(settings.status, 200);
+});
+
+after(async () => {
+    await server.cleanup();
+});
+
+test('manual plan deletion confirms the destructive tool and removes stored plan', async () => {
+    const created = await server.api(cookie, 'POST', '/api/ai/tools/run', {
+        tool: 'plan_task',
+        args: { title: 'delete me', steps: ['first step'] },
+    });
+    assert.equal(created.status, 200);
+    const planId = (created.body.result.data || created.body.result).plan.id;
+
+    const pending = await server.api(cookie, 'POST', '/api/ai/tools/run', {
+        tool: 'plan_delete',
+        args: { planId },
+    });
+    assert.equal(pending.status, 200);
+    assert.equal(pending.body.result.confirmationRequired, true);
+    assert.equal(pending.body.result.confirmation.toolName, 'plan_delete');
+
+    const confirmed = await server.api(cookie, 'POST', `/api/ai/confirm/${pending.body.result.confirmation.id}`, { approve: true });
+    assert.equal(confirmed.status, 200);
+    const confirmedData = confirmed.body.result.data || confirmed.body.result;
+    assert.equal(confirmedData.deleted, true);
+    assert.equal(confirmedData.planId, planId);
+    assert.equal(confirmedData.plans.some((plan) => plan.id === planId), false);
+
+    const status = await server.api(cookie, 'GET', '/api/ai/status');
+    assert.equal(status.status, 200);
+    assert.equal((status.body.ai.plans || []).some((plan) => plan.id === planId), false);
+});


### PR DESCRIPTION
## Summary
- complete the server-side confirmation flow after the task-plan settings delete button confirmation
- update the local plan list only after the destructive delete succeeds
- add contract and HTTP integration regression tests

## Root cause
The settings page already showed an inline confirmation sheet, but after approval it called the destructive `plan_delete` tool without completing the tool's canonical server confirmation. The server therefore returned `confirmationRequired`; the UI ignored that response and removed the row locally, so the plan returned after reload.

## Validation
- `npm run test:syntax`
- `node --test tests/ai-plan-delete.test.mjs tests/ai-plan-delete-contract.test.mjs tests/ai-settings-regressions.test.mjs tests/ai-capabilities.test.mjs tests/ai-playbooks.test.mjs`
- `npm run test:motion`
- `npm run test:rdp-node` *(repository baseline has unrelated pre-existing failures; see CI)*
