### PR TITLE
fix(android): keep an existing secret when a change page omits its envelope

### DIFF
--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
@@ -159,6 +159,12 @@ class MirrorWriter(
                             change,
                             opener,
                             retainedSecrets = retained,
+                            // A change-feed patch of an already-mirrored row must not
+                            // freeze the account when the page omits envelopes. Live
+                            // v1.1.538 seq 50 was a name-only connection upsert with
+                            // hasPassword=true and no password envelope; One pre65
+                            // reported sync.pull: missing_envelope and stopped the cursor.
+                            allowMissingEnvelope = localRevision != null,
                         )
                     } finally {
                         retained.values.forEach { it.fill(0) }
@@ -534,9 +540,10 @@ internal fun planPageSecretMutations(
             val plaintext = secrets.values[fieldName]
             if (plaintext != null) {
                 add(PlannedSecretMutation.Put(ref, plaintext))
-            } else if (!isIncrementalSecretPatch(change)) {
-                throw SecretReconciliationException(SecretReconciliationFailure.MISSING_ENVELOPE)
             }
+            // Presence true without new plaintext keeps the stored secret.
+            // prepareSecrets is the gate for missing envelopes; this planner
+            // must not undo an incremental keep by failing the whole page.
         }
     }
 }.coalesced()
@@ -606,6 +613,7 @@ internal fun prepareSecrets(
     change: SyncChange,
     opener: EnvelopeOpener?,
     retainedSecrets: Map<String, ByteArray> = emptyMap(),
+    allowMissingEnvelope: Boolean = false,
 ): PreparedSecrets {
     val spec = EntityRegistry.require(change.entityType)
     if (change.secretEnvelopes.keys.any { it !in spec.secretFields }) {
@@ -654,7 +662,7 @@ internal fun prepareSecrets(
                 } else {
                     if (retained != null && retained.isNotEmpty()) {
                         retained.copyOf()
-                    } else if (isIncrementalSecretPatch(change)) {
+                    } else if (allowMissingEnvelope || isIncrementalSecretPatch(change)) {
                         null
                     } else {
                         throw SecretReconciliationException(

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
@@ -47,6 +47,59 @@ class SecretReconciliationTest {
     }
 
     @Test
+    fun `an already-mirrored row with empty mask and no envelope does not freeze the cursor`() {
+        val change = change(
+            payload = payload(hasPassword = true, hasPrivateKey = false),
+            fieldMask = emptyList(),
+        )
+        val secrets = prepareSecrets(
+            change,
+            opener = EnvelopeOpener { _, _ -> error("must not open") },
+            allowMissingEnvelope = true,
+        )
+        try {
+            assertEquals(true, secrets.states.getValue("password"))
+            assertTrue(secrets.values["password"] == null)
+            val mutations = planPageSecretMutations(
+                changes = listOf(change),
+                page = ApplicablePage(setOf(0), mapOf(0 to secrets)),
+            )
+            assertTrue(mutations.none { it.ref.partsOrNull()?.fieldName == "password" && it is PlannedSecretMutation.Put })
+        } finally {
+            secrets.close()
+        }
+    }
+
+    @Test
+    fun `live seq50 name-only page with empty decoded mask still plans without a password put`() {
+        val change = change(
+            payload = JsonObject(
+                mapOf(
+                    "ownerUserId" to JsonPrimitive("8f9d1961-1fbb-436c-ab4a-09aaf7c42bce"),
+                    "name" to JsonPrimitive("home1"),
+                    "hasPassword" to JsonPrimitive(true),
+                    "hasPrivateKey" to JsonPrimitive(false),
+                ),
+            ),
+            fieldMask = emptyList(),
+        )
+        val secrets = prepareSecrets(
+            change,
+            opener = EnvelopeOpener { _, _ -> error("must not open") },
+            allowMissingEnvelope = true,
+        )
+        try {
+            val mutations = planPageSecretMutations(
+                changes = listOf(change),
+                page = ApplicablePage(setOf(0), mapOf(0 to secrets)),
+            )
+            assertTrue(mutations.none { it is PlannedSecretMutation.Put })
+        } finally {
+            secrets.close()
+        }
+    }
+
+    @Test
     fun `live name-only page with presence and no envelope does not freeze the cursor`() {
         val secrets = prepareSecrets(
             change(


### PR DESCRIPTION
## Live evidence

pre65 pill:

`Zephyr Link 同步失败·internal_error sync.pull: missing_envelope`

Device `491bd90b-8fd4-4338-8844-d73d52b0f9b7` on `zephyr-e2e-1521` / v1.1.538:

- server `last_acked_cursor=54`, `lastError` empty
- JSON/CBOR/Go Link 3-round bootstrap/changes/ack all succeed
- seq 50: `connection` upsert, `mask=["name"]`, `hasPassword=true`, **no** `password` envelope

`#112` already stopped the server from resealing that rename. pre65 still died because Android applied the page as a snapshot: presence true + no envelope + empty/decoded-empty `fieldMask` → `MISSING_ENVELOPE` → cursor frozen.

## Fix

- Change-feed apply of an **already-mirrored** row allows a missing envelope and keeps the stored secret
- Bootstrap snapshots still fail closed
- `planPageSecretMutations` no longer fails the page when presence is true without new plaintext
- Tests cover the live seq-50 shape with empty `fieldMask` (the decode-default that matches the diagnostic)

No Docker rebuild. Mobile `zom-v1.0.0pre66` after merge.
