### PR TITLE
fix(android): classify existing mirror rows before secret reconciliation

### DIFF
--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
@@ -48,7 +48,22 @@ enum class SecretReconciliationFailure {
 class SecretReconciliationException(
     val failure: SecretReconciliationFailure,
     cause: Throwable? = null,
-) : IllegalStateException("secret reconciliation failed: " + failure.name.lowercase(), cause)
+    val entityType: String? = null,
+    val entityId: String? = null,
+    val fieldName: String? = null,
+) : IllegalStateException("secret reconciliation failed: " + failure.name.lowercase(), cause) {
+    fun withContext(
+        entityType: String,
+        entityId: String,
+        fieldName: String? = null,
+    ): SecretReconciliationException = SecretReconciliationException(
+        failure = failure,
+        entityType = this.entityType ?: entityType,
+        entityId = this.entityId ?: entityId,
+        fieldName = this.fieldName ?: fieldName,
+        cause = cause,
+    )
+}
 
 /**
  * Applies server changes to the account-scoped local mirror.
@@ -146,9 +161,18 @@ class MirrorWriter(
                     // tombstone keeps the delete durable: an inbound UPSERT older than the tombstone
                     // revision must not resurrect the row (SYNC_STATE_MACHINE.md 7.4). UPSERTs newer
                     // than the delete still apply — a later server-side recreation is legitimate.
-                    db.mirrorDao().revisionOf(change.entityType, change.entityId)
-                        ?: db.tombstoneDao().find(change.entityType, change.entityId)?.revision
-                            .also { revisions[key] = it }
+                    //
+                    // Cache both branches. The previous code cached only the tombstone branch;
+                    // an existing mirror row therefore left localRevision null, which made an
+                    // already-mirrored name-only change require a new secret envelope after an
+                    // app restart even though the change did not modify that secret.
+                    val resolvedRevision = rememberResolvedRevision(
+                        revisions = revisions,
+                        key = key,
+                        mirrorRevision = db.mirrorDao().revisionOf(change.entityType, change.entityId),
+                        tombstoneRevision = db.tombstoneDao().find(change.entityType, change.entityId)?.revision,
+                    )
+                    resolvedRevision
                 }
                 if (!PushPrediction.shouldApplyChange(localRevision, change.action, change.revision)) continue
                 applicableIndexes += index
@@ -622,8 +646,10 @@ internal fun prepareSecrets(
 
     val states = LinkedHashMap<String, Boolean>()
     val values = LinkedHashMap<String, ByteArray>()
+    var currentField: String? = null
     try {
         for (fieldName in spec.secretFields) {
+            currentField = fieldName
             val element = change.payload[presenceFlag(fieldName)]
             val declared = when (element) {
                 null -> throw SecretReconciliationException(
@@ -680,6 +706,15 @@ internal fun prepareSecrets(
         return PreparedSecrets(states, values)
     } catch (failure: Throwable) {
         values.values.forEach { it.fill(0) }
+        if (failure is SecretReconciliationException && failure.entityType == null) {
+            throw SecretReconciliationException(
+                failure = failure.failure,
+                entityType = change.entityType,
+                entityId = change.entityId,
+                fieldName = currentField,
+                cause = failure.cause,
+            )
+        }
         throw failure
     }
 }
@@ -697,6 +732,17 @@ internal fun shouldRemoveSnapshotSecret(
 }
 
 internal data class EntityKey(val entityType: String, val entityId: String)
+
+internal fun rememberResolvedRevision(
+    revisions: MutableMap<EntityKey, Long?>,
+    key: EntityKey,
+    mirrorRevision: Long?,
+    tombstoneRevision: Long?,
+): Long? {
+    val resolved = mirrorRevision ?: tombstoneRevision
+    revisions[key] = resolved
+    return resolved
+}
 
 private fun BootstrapStagingRow.toMirror(now: Long): MirrorEntityRow {
     val payload = SecretPayloadSanitizer.sanitizeForStorage(entityType, EntityCodec.parse(payloadJson))

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/MirrorRevisionCacheTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/MirrorRevisionCacheTest.kt
@@ -1,0 +1,39 @@
+package one.zephyr.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MirrorRevisionCacheTest {
+
+    @Test
+    fun `an existing mirror revision is cached before secret policy runs`() {
+        val revisions = mutableMapOf<EntityKey, Long?>()
+        val key = EntityKey("connection", "c-1")
+
+        val resolved = rememberResolvedRevision(
+            revisions = revisions,
+            key = key,
+            mirrorRevision = 2L,
+            tombstoneRevision = 7L,
+        )
+
+        assertEquals(2L, resolved)
+        assertEquals(2L, revisions[key])
+    }
+
+    @Test
+    fun `a tombstone revision is cached when the mirror row is absent`() {
+        val revisions = mutableMapOf<EntityKey, Long?>()
+        val key = EntityKey("connection", "c-1")
+
+        val resolved = rememberResolvedRevision(
+            revisions = revisions,
+            key = key,
+            mirrorRevision = null,
+            tombstoneRevision = 7L,
+        )
+
+        assertEquals(7L, resolved)
+        assertEquals(7L, revisions[key])
+    }
+}

--- a/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt
+++ b/zephyr_one/mobile/android/core-sync/src/main/kotlin/one/zephyr/mobile/sync/SyncActor.kt
@@ -386,7 +386,7 @@ class SyncActor(
             try {
                 store.resetBootstrap()
             } catch (failure: SecretReconciliationException) {
-                return BootstrapAttempt.Failed(secretReconciliationFailure(failure))
+                return BootstrapAttempt.Failed(secretReconciliationFailure("sync.bootstrap.reset", failure))
             }
         }
 
@@ -413,7 +413,7 @@ class SyncActor(
             } catch (violation: ResidencyViolationException) {
                 return BootstrapAttempt.Failed(residencyFailure(violation))
             } catch (failure: SecretReconciliationException) {
-                return BootstrapAttempt.Failed(secretReconciliationFailure(failure))
+                return BootstrapAttempt.Failed(secretReconciliationFailure("sync.bootstrap.stage", failure))
             }
             // A rejected first page must not advance even the snapshot cursor. Staging is invisible
             // and reset on recovery, so persisting the join only after validation is crash-safe.
@@ -432,7 +432,7 @@ class SyncActor(
                 } catch (violation: ResidencyViolationException) {
                     return BootstrapAttempt.Failed(residencyFailure(violation))
                 } catch (failure: SecretReconciliationException) {
-                    return BootstrapAttempt.Failed(secretReconciliationFailure(failure))
+                    return BootstrapAttempt.Failed(secretReconciliationFailure("sync.bootstrap.promote", failure))
                 }
                 acc.applied += staged
                 return BootstrapAttempt.Finished(BootstrapOutcome.Complete)
@@ -493,7 +493,7 @@ class SyncActor(
             } catch (violation: ResidencyViolationException) {
                 return residencyFailure(violation)
             } catch (failure: SecretReconciliationException) {
-                return secretReconciliationFailure(failure)
+                return secretReconciliationFailure("sync.pull.apply", failure)
             } catch (failure: SecretPayloadViolationException) {
                 return malformedResponse("unsafe inbound secret payload")
             } catch (cancelled: CancellationException) {
@@ -527,12 +527,20 @@ class SyncActor(
                 .take(180),
         )
 
-    private fun secretReconciliationFailure(failure: SecretReconciliationException): MobileError =
+    private fun secretReconciliationFailure(
+        phase: String,
+        failure: SecretReconciliationException,
+    ): MobileError =
         MobileError.local(
             code = "internal_error",
             message = "secret envelope reconciliation failed",
             retryable = true,
-        ).withLocalDiagnostic("sync.pull: " + failure.failure.name.lowercase())
+        ).withLocalDiagnostic(
+            "$phase: ${failure.failure.name.lowercase()}" +
+                failure.entityType?.let { ": entity=$it/${failure.entityId}" }.orEmpty() +
+                failure.fieldName?.let { ": field=$it" }.orEmpty() +
+                failure.cause?.let { ": cause=${it::class.java.simpleName}" }.orEmpty(),
+        )
 
     private suspend fun pushPending(acc: RoundAccumulator): MobileError? {
         val queued = store.pendingOperations()

--- a/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorTest.kt
+++ b/zephyr_one/mobile/android/core-sync/src/test/kotlin/one/zephyr/mobile/sync/SyncActorTest.kt
@@ -415,7 +415,7 @@ class SyncActorTest {
 
         assertEquals("internal_error", result.error?.code)
         assertEquals(
-            "sync.pull: envelope_rejected",
+            "sync.pull.apply: envelope_rejected",
             result.error?.details?.get("clientLocalDiagnostic"),
         )
         assertEquals(40L, store.appliedCursor)
@@ -423,7 +423,7 @@ class SyncActorTest {
         assertTrue(transport.ackedCursors.isEmpty())
         assertEquals(SyncPhase.PULL_CHANGES, result.stoppedAt)
         assertEquals(
-            "sync.pull: envelope_rejected",
+            "sync.pull.apply: envelope_rejected",
             store.recordedFailures.single().details["clientLocalDiagnostic"],
         )
     }


### PR DESCRIPTION
See live pre66 evidence: repeated `sync.pull: missing_envelope` after process restart. The fix caches an existing mirror revision before secret reconciliation, keeps bootstrap and change-feed error phases distinct, and includes entity/field context in diagnostics. Targeted core-data/core-sync tests pass on the test host.