### PR TITLE
fix(sync): keep a re-staged bootstrap snapshot from freezing the account

### DIFF
--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt
@@ -20,6 +20,7 @@ import one.zephyr.mobile.model.ServerProfile
 import one.zephyr.mobile.network.ApiResult
 import one.zephyr.mobile.security.DeviceIdentity
 import one.zephyr.mobile.security.LockSensitiveSink
+import one.zephyr.mobile.sync.BootstrapOutcome
 import one.zephyr.mobile.sync.SyncRoundResult
 import one.zephyr.mobile.sync.SyncSettings
 
@@ -364,9 +365,9 @@ class BindingCoordinator internal constructor(
         preparation.restoredGraph?.takeIf { bootstrap }?.let { graph ->
             graph.startNetworkProducers()
             if (preparation.requiresBootstrap) {
-                graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
-                    markBootstrapReadyIfCurrent(graph, checkNotNull(preparation.binding), round.endState)
-                }
+                /* Readiness follows the committed snapshot, not the whole round: a promoted
+                 * mirror must not be re-bootstrapped from scratch because a later phase failed. */
+                markReadyWhenSnapshotPromoted(graph, checkNotNull(preparation.binding), graph.bootstrapAfterBind())
             } else {
                 graph.runForegroundRound()
             }
@@ -380,11 +381,29 @@ class BindingCoordinator internal constructor(
         val graph = mutex.withLock { host.currentGraph() ?: return }
         graph.startNetworkProducers()
         if (graph.accountDatabaseRequiresBootstrap()) {
-            graph.bootstrapAfterBind().lastOrNull()?.takeIf { it.complete }?.let { round ->
-                markBootstrapReadyIfCurrent(graph, graph.binding, round.endState)
-            }
+            markReadyWhenSnapshotPromoted(graph, graph.binding, graph.bootstrapAfterBind())
         } else {
             graph.runForegroundRound()
+        }
+    }
+
+    /**
+     * Marks the account database ready as soon as any round promoted a bootstrap snapshot, even
+     * when a later phase of that round failed. The end state recorded with the marker is the last
+     * round's state: a later failure parks the binding in the state machine's own terminal for it
+     * (IDLE/CONFLICTED/REAUTH_REQUIRED), and a normal round retries the failed phases without
+     * re-downloading the account. Before this, a first round that promoted the mirror but failed
+     * push/pull/ack left the marker unset, so every launch reset the binding to
+     * BOUND_NEEDS_BOOTSTRAP and re-staged the whole snapshot.
+     */
+    private suspend fun markReadyWhenSnapshotPromoted(
+        graph: ManagedBindingGraph,
+        binding: AccountBinding,
+        rounds: List<SyncRoundResult>,
+    ) {
+        val lastComplete = rounds.lastOrNull() ?: return
+        if (rounds.any { it.bootstrapOutcome is BootstrapOutcome.Complete }) {
+            markBootstrapReadyIfCurrent(graph, binding, lastComplete.endState)
         }
     }
 
@@ -530,9 +549,14 @@ class BindingCoordinator internal constructor(
                 if (host.currentGraph() === prepared.graph) workersMayRun = true
                 prepared.graph.startNetworkProducers()
                 val bootstrap = prepared.graph.bootstrapAfterBind()
-                val bootstrapSucceeded = bootstrap.lastOrNull()?.takeIf { it.complete }?.let { round ->
-                    markBootstrapReadyIfCurrent(prepared.graph, prepared.binding, round.endState)
-                } ?: false
+                /* bootstrapSucceeded reports whether the account database is usable now —
+                 * which the promoted snapshot already guarantees, even when a later phase of
+                 * the same round failed and will be retried as a normal round. */
+                val bootstrapSucceeded = bootstrap
+                    .takeIf { rounds -> rounds.any { it.bootstrapOutcome is BootstrapOutcome.Complete } }
+                    ?.let { rounds ->
+                        markBootstrapReadyIfCurrent(prepared.graph, prepared.binding, rounds.last().endState)
+                    } ?: false
                 BindingCompletionResult.Completed(
                     binding = prepared.binding,
                     bootstrapSucceeded = bootstrapSucceeded,
@@ -715,9 +739,11 @@ class BindingCoordinator internal constructor(
             if (host.currentGraph() === prepared.graph) workersMayRun = true
             prepared.graph.startNetworkProducers()
             val bootstrap = prepared.graph.bootstrapAfterBind()
-            val bootstrapSucceeded = bootstrap.lastOrNull()?.takeIf { it.complete }?.let { round ->
-                markBootstrapReadyIfCurrent(prepared.graph, prepared.binding, round.endState)
-            } ?: false
+            val bootstrapSucceeded = bootstrap
+                .takeIf { rounds -> rounds.any { it.bootstrapOutcome is BootstrapOutcome.Complete } }
+                ?.let { rounds ->
+                    markBootstrapReadyIfCurrent(prepared.graph, prepared.binding, rounds.last().endState)
+                } ?: false
             BindingCompletionResult.Completed(
                 binding = prepared.binding,
                 bootstrapSucceeded = bootstrapSucceeded,

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
@@ -69,6 +69,7 @@ import one.zephyr.mobile.security.SessionSecretArena
 import one.zephyr.mobile.security.LockSensitiveSink
 import one.zephyr.mobile.sync.ApiSharedResourceFetcher
 import one.zephyr.mobile.sync.BlobTransferPort
+import one.zephyr.mobile.sync.BootstrapOutcome
 import one.zephyr.mobile.sync.DeviceEnvelopeOpener
 import one.zephyr.mobile.sync.DeviceSecretSealer
 import kotlinx.coroutines.sync.Mutex
@@ -699,7 +700,18 @@ class AccountContainer(
                 syncState.ensure(bindingKey)
                 syncState.updateState(bindingKey, one.zephyr.mobile.contracts.BindingState.BOUND_NEEDS_BOOTSTRAP)
             }
-            syncEngine.onBindComplete()
+            val rounds = syncEngine.onBindComplete()
+            /* The readiness marker must track the committed snapshot, not the whole round. A
+             * first round whose bootstrap promoted the mirror but then failed a later phase
+             * (push/pull/ack) used to leave the marker unset, so the next launch reset the
+             * binding to BOUND_NEEDS_BOOTSTRAP and re-downloaded the entire account — and a
+             * re-staged snapshot whose envelopes could not be opened then froze staging with
+             * a misleading missing_envelope. Once any round promoted the snapshot, the mirror
+             * is complete and later phases are retried as an ordinary normal round. */
+            if (rounds.any { it.bootstrapOutcome is BootstrapOutcome.Complete }) {
+                markAccountDatabaseReady()
+            }
+            rounds
         }.await() else emptyList()
 
     /** Runs once after a restored, already-bootstrapped graph is published. */

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import one.zephyr.mobile.contracts.BindingState
 import one.zephyr.mobile.contracts.SyncPhase
 import one.zephyr.mobile.model.AccountBinding
+import one.zephyr.mobile.model.MobileError
 import one.zephyr.mobile.model.NetworkPolicy
 import one.zephyr.mobile.model.ServerCapabilities
 import one.zephyr.mobile.model.ServerProfile
@@ -17,6 +18,7 @@ import one.zephyr.mobile.model.SyncTrigger
 import one.zephyr.mobile.model.TlsPolicy
 import one.zephyr.mobile.network.ApiResult
 import one.zephyr.mobile.security.DeviceIdentity
+import one.zephyr.mobile.sync.BootstrapOutcome
 import one.zephyr.mobile.sync.SyncRoundResult
 import one.zephyr.mobile.sync.SyncSettings
 import org.junit.Assert.assertEquals
@@ -146,6 +148,110 @@ class BindingCoordinatorTest {
             ),
             events.takeLast(7),
         )
+    }
+
+    @Test
+    fun `a promoted snapshot marks the database ready even when a later phase fails`() = runTest {
+        /* The live second-sync failure: the first round promoted the bootstrap snapshot but
+         * failed a later phase (pull/ack). Before the fix, the readiness marker stayed unset,
+         * so the next launch reset the binding to BOUND_NEEDS_BOOTSTRAP and re-downloaded the
+         * account; the re-staged snapshot then tripped missing_envelope. Readiness must follow
+         * the promoted snapshot, and bootstrapSucceeded must report it. */
+        val events = mutableListOf<String>()
+        val storage = FakeStorage(events)
+        val host = FakeHost(events)
+        val graphs = mutableListOf<FakeGraph>()
+        val gateway = FakeGateway()
+        val coordinator = coordinator(storage, host, graphs, events)
+
+        val login = coordinator.login(profile(), "alice", "password".toCharArray(), gateway)
+        assertTrue(login is BindingAuthenticationResult.Authenticated)
+
+        val result = coordinator.completeBinding(bindingRequest(), "123456".toCharArray())
+        result as BindingCompletionResult.Completed
+        assertTrue(result.bootstrapSucceeded)
+        assertEquals(1, graphs.single().databaseReadyCalls)
+    }
+
+    @Test
+    fun `a promoted snapshot with a later failure still writes the readiness marker`() = runTest {
+        val events = mutableListOf<String>()
+        val storage = FakeStorage(events)
+        val host = FakeHost(events)
+        val graphs = mutableListOf<FakeGraph>()
+        val gateway = FakeGateway()
+        val coordinator = coordinator(storage, host, graphs, events)
+
+        val login = coordinator.login(profile(), "alice", "password".toCharArray(), gateway)
+        assertTrue(login is BindingAuthenticationResult.Authenticated)
+
+        /* The round promoted the snapshot (BootstrapOutcome.Complete) but ended with a pull
+         * failure — not complete in the whole-round sense. */
+        val graph = graphs.single()
+        graph.bootstrapRounds = listOf(
+            SyncRoundResult(
+                trigger = SyncTrigger.BIND_COMPLETE,
+                startedAt = 1L,
+                finishedAt = 2L,
+                phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE, SyncPhase.PULL_CHANGES),
+                endState = BindingState.CATCHING_UP,
+                pushed = 0,
+                conflicts = 0,
+                deferred = emptyList(),
+                applied = 1,
+                skipped = 0,
+                appliedCursor = 1L,
+                ackedCursor = 0L,
+                error = MobileError.local("internal_error", "pull failed", retryable = true),
+                stoppedAt = SyncPhase.PULL_CHANGES,
+                bootstrapOutcome = BootstrapOutcome.Complete,
+            ),
+        )
+
+        val result = coordinator.completeBinding(bindingRequest(), "123456".toCharArray())
+        result as BindingCompletionResult.Completed
+        assertTrue(result.bootstrapSucceeded)
+        assertEquals(1, graph.databaseReadyCalls)
+    }
+
+    @Test
+    fun `no snapshot promotion leaves the readiness marker untouched`() = runTest {
+        val events = mutableListOf<String>()
+        val storage = FakeStorage(events)
+        val host = FakeHost(events)
+        val graphs = mutableListOf<FakeGraph>()
+        val gateway = FakeGateway()
+        val coordinator = coordinator(storage, host, graphs, events)
+
+        val login = coordinator.login(profile(), "alice", "password".toCharArray(), gateway)
+        assertTrue(login is BindingAuthenticationResult.Authenticated)
+
+        /* An incomplete bootstrap (continuation pending) or a failure before promotion must
+         * not mark the database ready: that is what guarantees a fresh bootstrap retries. */
+        val graph = graphs.single()
+        graph.bootstrapRounds = listOf(
+            SyncRoundResult(
+                trigger = SyncTrigger.BIND_COMPLETE,
+                startedAt = 1L,
+                finishedAt = 2L,
+                phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE),
+                endState = BindingState.BOOTSTRAPPING,
+                pushed = 0,
+                conflicts = 0,
+                deferred = emptyList(),
+                applied = 0,
+                skipped = 0,
+                appliedCursor = 0L,
+                ackedCursor = 0L,
+                error = MobileError.local("network_offline", "offline", retryable = true),
+                stoppedAt = SyncPhase.BOOTSTRAP_PAGE,
+            ),
+        )
+
+        val result = coordinator.completeBinding(bindingRequest(), "123456".toCharArray())
+        result as BindingCompletionResult.Completed
+        assertFalse(result.bootstrapSucceeded)
+        assertEquals(0, graph.databaseReadyCalls)
     }
 
     @Test
@@ -1844,6 +1950,8 @@ private class FakeGraph(
     initiallyRecoverable: Boolean,
     private val databaseRequiresBootstrap: Boolean,
     private val deviceLocal: Boolean = false,
+    /** Rounds returned by bootstrapAfterBind; defaults to one successful round. */
+    var bootstrapRounds: List<SyncRoundResult>? = null,
 ) : ManagedBindingGraph {
     override val bindingKey = binding.serverProfileId + "/" + binding.userId + "/" + binding.deviceId
     override val generation = BindingGeneration.of(binding)
@@ -1899,7 +2007,7 @@ private class FakeGraph(
     override suspend fun bootstrapAfterBind(): List<SyncRoundResult> = scope.async {
         events += "graph.bootstrap"
         bootstrapCalls += 1
-        listOf(successfulRound(SyncTrigger.BIND_COMPLETE))
+        bootstrapRounds ?: listOf(successfulRound(SyncTrigger.BIND_COMPLETE))
     }.await()
 
     override suspend fun runForegroundRound(): List<SyncRoundResult> = scope.async {

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt
@@ -162,7 +162,27 @@ class BindingCoordinatorTest {
         val host = FakeHost(events)
         val graphs = mutableListOf<FakeGraph>()
         val gateway = FakeGateway()
-        val coordinator = coordinator(storage, host, graphs, events)
+        val promotedWithLaterFailure = SyncRoundResult(
+            trigger = SyncTrigger.BIND_COMPLETE,
+            startedAt = 1L,
+            finishedAt = 2L,
+            phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE, SyncPhase.PULL_CHANGES),
+            endState = BindingState.CATCHING_UP,
+            pushed = 0,
+            conflicts = 0,
+            deferred = emptyList(),
+            applied = 1,
+            skipped = 0,
+            appliedCursor = 1L,
+            ackedCursor = 0L,
+            error = MobileError.local("internal_error", "pull failed", retryable = true),
+            stoppedAt = SyncPhase.PULL_CHANGES,
+            bootstrapOutcome = BootstrapOutcome.Complete,
+        )
+        val coordinator = coordinator(
+            storage, host, graphs, events,
+            nextBootstrapRounds = listOf(promotedWithLaterFailure),
+        )
 
         val login = coordinator.login(profile(), "alice", "password".toCharArray(), gateway)
         assertTrue(login is BindingAuthenticationResult.Authenticated)
@@ -179,39 +199,35 @@ class BindingCoordinatorTest {
         val storage = FakeStorage(events)
         val host = FakeHost(events)
         val graphs = mutableListOf<FakeGraph>()
-        val gateway = FakeGateway()
-        val coordinator = coordinator(storage, host, graphs, events)
-
-        val login = coordinator.login(profile(), "alice", "password".toCharArray(), gateway)
-        assertTrue(login is BindingAuthenticationResult.Authenticated)
-
-        /* The round promoted the snapshot (BootstrapOutcome.Complete) but ended with a pull
-         * failure — not complete in the whole-round sense. */
-        val graph = graphs.single()
-        graph.bootstrapRounds = listOf(
-            SyncRoundResult(
-                trigger = SyncTrigger.BIND_COMPLETE,
-                startedAt = 1L,
-                finishedAt = 2L,
-                phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE, SyncPhase.PULL_CHANGES),
-                endState = BindingState.CATCHING_UP,
-                pushed = 0,
-                conflicts = 0,
-                deferred = emptyList(),
-                applied = 1,
-                skipped = 0,
-                appliedCursor = 1L,
-                ackedCursor = 0L,
-                error = MobileError.local("internal_error", "pull failed", retryable = true),
-                stoppedAt = SyncPhase.PULL_CHANGES,
-                bootstrapOutcome = BootstrapOutcome.Complete,
-            ),
+        val promotedWithLaterFailure = SyncRoundResult(
+            trigger = SyncTrigger.BIND_COMPLETE,
+            startedAt = 1L,
+            finishedAt = 2L,
+            phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE, SyncPhase.PULL_CHANGES),
+            endState = BindingState.CATCHING_UP,
+            pushed = 0,
+            conflicts = 0,
+            deferred = emptyList(),
+            applied = 1,
+            skipped = 0,
+            appliedCursor = 1L,
+            ackedCursor = 0L,
+            error = MobileError.local("internal_error", "pull failed", retryable = true),
+            stoppedAt = SyncPhase.PULL_CHANGES,
+            bootstrapOutcome = BootstrapOutcome.Complete,
         )
+        val coordinator = coordinator(
+            storage, host, graphs, events,
+            nextBootstrapRounds = listOf(promotedWithLaterFailure),
+        )
+
+        val login = coordinator.login(profile(), "alice", "password".toCharArray(), FakeGateway())
+        assertTrue(login is BindingAuthenticationResult.Authenticated)
 
         val result = coordinator.completeBinding(bindingRequest(), "123456".toCharArray())
         result as BindingCompletionResult.Completed
         assertTrue(result.bootstrapSucceeded)
-        assertEquals(1, graph.databaseReadyCalls)
+        assertEquals(1, graphs.single().databaseReadyCalls)
     }
 
     @Test
@@ -221,37 +237,36 @@ class BindingCoordinatorTest {
         val host = FakeHost(events)
         val graphs = mutableListOf<FakeGraph>()
         val gateway = FakeGateway()
-        val coordinator = coordinator(storage, host, graphs, events)
+        /* An incomplete bootstrap (continuation pending) or a failure before promotion must
+         * not mark the database ready: that is what guarantees a fresh bootstrap retries. */
+        val neverPromoted = SyncRoundResult(
+            trigger = SyncTrigger.BIND_COMPLETE,
+            startedAt = 1L,
+            finishedAt = 2L,
+            phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE),
+            endState = BindingState.BOOTSTRAPPING,
+            pushed = 0,
+            conflicts = 0,
+            deferred = emptyList(),
+            applied = 0,
+            skipped = 0,
+            appliedCursor = 0L,
+            ackedCursor = 0L,
+            error = MobileError.local("network_offline", "offline", retryable = true),
+            stoppedAt = SyncPhase.BOOTSTRAP_PAGE,
+        )
+        val coordinator = coordinator(
+            storage, host, graphs, events,
+            nextBootstrapRounds = listOf(neverPromoted),
+        )
 
         val login = coordinator.login(profile(), "alice", "password".toCharArray(), gateway)
         assertTrue(login is BindingAuthenticationResult.Authenticated)
 
-        /* An incomplete bootstrap (continuation pending) or a failure before promotion must
-         * not mark the database ready: that is what guarantees a fresh bootstrap retries. */
-        val graph = graphs.single()
-        graph.bootstrapRounds = listOf(
-            SyncRoundResult(
-                trigger = SyncTrigger.BIND_COMPLETE,
-                startedAt = 1L,
-                finishedAt = 2L,
-                phasesRun = listOf(SyncPhase.BOOTSTRAP_PAGE),
-                endState = BindingState.BOOTSTRAPPING,
-                pushed = 0,
-                conflicts = 0,
-                deferred = emptyList(),
-                applied = 0,
-                skipped = 0,
-                appliedCursor = 0L,
-                ackedCursor = 0L,
-                error = MobileError.local("network_offline", "offline", retryable = true),
-                stoppedAt = SyncPhase.BOOTSTRAP_PAGE,
-            ),
-        )
-
         val result = coordinator.completeBinding(bindingRequest(), "123456".toCharArray())
         result as BindingCompletionResult.Completed
         assertFalse(result.bootstrapSucceeded)
-        assertEquals(0, graph.databaseReadyCalls)
+        assertEquals(0, graphs.single().databaseReadyCalls)
     }
 
     @Test
@@ -1638,6 +1653,8 @@ class BindingCoordinatorTest {
         noAccountCleanupJournal: FakeNoAccountCleanupJournal = FakeNoAccountCleanupJournal(),
         noAccountStateWiper: FakeNoAccountStateWiper = FakeNoAccountStateWiper(),
         graphRecoverability: ((StoredBinding) -> Boolean)? = null,
+        /** Rounds the next freshly created FakeGraph returns from bootstrapAfterBind. */
+        nextBootstrapRounds: List<SyncRoundResult>? = null,
     ): BindingCoordinator = BindingCoordinator(
         storage = storage,
         host = host,
@@ -1647,6 +1664,7 @@ class BindingCoordinatorTest {
                 events,
                 initiallyRecoverable = graphRecoverability?.invoke(stored) ?: restoredGraphsAreRecoverable,
                 databaseRequiresBootstrap = restoredDatabaseRequiresBootstrap,
+                bootstrapRounds = nextBootstrapRounds,
             ).also {
                 it.startFailures = restoredGraphStartFailures
                 graphs += it
@@ -2007,7 +2025,9 @@ private class FakeGraph(
     override suspend fun bootstrapAfterBind(): List<SyncRoundResult> = scope.async {
         events += "graph.bootstrap"
         bootstrapCalls += 1
-        bootstrapRounds ?: listOf(successfulRound(SyncTrigger.BIND_COMPLETE))
+        /* A BIND_COMPLETE round always enters the bootstrap phase; the realistic default is a
+         * promoted snapshot. Tests inject non-default outcomes via nextBootstrapRounds. */
+        bootstrapRounds ?: listOf(successfulRound(SyncTrigger.BIND_COMPLETE).promoteSnapshot())
     }.await()
 
     override suspend fun runForegroundRound(): List<SyncRoundResult> = scope.async {
@@ -2207,3 +2227,6 @@ private fun successfulRound(trigger: SyncTrigger) = SyncRoundResult(
     appliedCursor = 1L,
     ackedCursor = 1L,
 )
+
+/** The same round with an explicitly promoted bootstrap snapshot (a realistic BIND_COMPLETE). */
+private fun SyncRoundResult.promoteSnapshot() = copy(bootstrapOutcome = BootstrapOutcome.Complete)

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt
@@ -294,7 +294,20 @@ class MirrorWriter(
             val rows = entities.mapIndexedNotNull { index, change ->
                 EntityRegistry.byType[change.entityType] ?: return@mapIndexedNotNull null
                 val ownerUserId = requireOwnedChange(change, boundUserId)
-                val secrets = prepareSecrets(change, opener).also { prepared[index] = it }
+                /* A bootstrap snapshot page carries a full-replacement fieldMask that happens
+                 * to contain no secret fields, which isIncrementalSecretPatch would misread as
+                 * an incremental patch and silently swallow an unopenable envelope until the
+                 * mutation planner reported a misleading missing_envelope. The snapshot
+                 * semantics are explicit instead: keep a retained local secret when the
+                 * envelope cannot be opened or is absent, and fail closed with the true code
+                 * only when neither the page nor the local mirror can supply the value. */
+                val retained = retainedSecretsFor(change)
+                val secrets = try {
+                    prepareSecrets(change, opener, retainedSecrets = retained, snapshot = true)
+                } finally {
+                    retained.values.forEach { it.fill(0) }
+                }
+                prepared[index] = secrets
                 BootstrapStagingRow(
                     generation = generation,
                     entityType = change.entityType,
@@ -638,6 +651,7 @@ internal fun prepareSecrets(
     opener: EnvelopeOpener?,
     retainedSecrets: Map<String, ByteArray> = emptyMap(),
     allowMissingEnvelope: Boolean = false,
+    snapshot: Boolean = false,
 ): PreparedSecrets {
     val spec = EntityRegistry.require(change.entityType)
     if (change.secretEnvelopes.keys.any { it !in spec.secretFields }) {
@@ -663,6 +677,10 @@ internal fun prepareSecrets(
             states[fieldName] = declared
             if (declared) {
                 val retained = retainedSecrets[fieldName]
+                /* Snapshot pages are full replacements: the incremental-patch fallback never
+                 * applies, and a rejected/absent envelope falls back to the retained local
+                 * secret before failing closed with the true code. */
+                val incrementalFallback = !snapshot && isIncrementalSecretPatch(change)
                 val opened = if (change.secretEnvelopes.containsKey(fieldName)) {
                     val plaintext = try {
                         opener?.open(change, fieldName)
@@ -680,7 +698,7 @@ internal fun prepareSecrets(
                          * an older main end. Incremental pages must keep the
                          * local secret and apply the non-secret fields instead
                          * of freezing the account cursor. */
-                        isIncrementalSecretPatch(change) -> null
+                        incrementalFallback -> null
                         else -> throw SecretReconciliationException(
                             SecretReconciliationFailure.ENVELOPE_REJECTED,
                         )
@@ -688,7 +706,7 @@ internal fun prepareSecrets(
                 } else {
                     if (retained != null && retained.isNotEmpty()) {
                         retained.copyOf()
-                    } else if (allowMissingEnvelope || isIncrementalSecretPatch(change)) {
+                    } else if (allowMissingEnvelope || incrementalFallback) {
                         null
                     } else {
                         throw SecretReconciliationException(

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt
@@ -451,4 +451,139 @@ class SecretReconciliationTest {
     } catch (failure: SecretReconciliationException) {
         failure
     }
+
+    // ---- bootstrap snapshot semantics (§19: snapshot is self-contained; local mirror may
+    // ------ retain secrets when the page cannot supply an openable envelope) ------------------
+
+    @Test
+    fun `snapshot full-replacement mask is never treated as an incremental secret patch`() {
+        /* The live failure shape: a bootstrap page carries fieldMask = the full editable set,
+         * which contains no secret fields, so isIncrementalSecretPatch(change) would answer
+         * true and silently swallow an unopenable envelope. Snapshot semantics must disable
+         * that fallback and fail closed with the true code when no retained secret exists. */
+        val error = expectSecretFailure {
+            prepareSecrets(
+                change(
+                    payload = payload(hasPassword = true, hasPrivateKey = false),
+                    envelopes = mapOf("password" to envelope()),
+                    fieldMask = listOf("name", "host", "port", "protocol", "username"),
+                ),
+                opener = EnvelopeOpener { _, _ -> null },
+                snapshot = true,
+            )
+        }
+        assertEquals(SecretReconciliationFailure.ENVELOPE_REJECTED, error.failure)
+        assertEquals("connection", error.entityType)
+        assertEquals("c-1", error.entityId)
+        assertEquals("password", error.fieldName)
+    }
+
+    @Test
+    fun `snapshot without an envelope and without a retained secret fails closed as missing envelope`() {
+        val error = expectSecretFailure {
+            prepareSecrets(
+                change(
+                    payload = payload(hasPassword = true, hasPrivateKey = false),
+                    fieldMask = listOf("name", "host"),
+                ),
+                opener = EnvelopeOpener { _, _ -> error("must not open") },
+                snapshot = true,
+            )
+        }
+        assertEquals(SecretReconciliationFailure.MISSING_ENVELOPE, error.failure)
+    }
+
+    @Test
+    fun `snapshot re-stage retains the local mirror secret when the envelope cannot be opened`() {
+        /* The second-bootstrap repair path: the mirror already holds the password from the
+         * first bootstrap, the re-staged page's envelope cannot be opened (stale AAD), and
+         * the retained plaintext must keep the snapshot complete instead of failing staging. */
+        val retained = "kept-local".toByteArray()
+        val secrets = prepareSecrets(
+            change(
+                payload = payload(hasPassword = true, hasPrivateKey = false),
+                envelopes = mapOf("password" to envelope()),
+                fieldMask = listOf("name", "host", "port"),
+            ),
+            opener = EnvelopeOpener { _, _ -> null },
+            retainedSecrets = mapOf("password" to retained),
+            snapshot = true,
+        )
+        try {
+            assertEquals("kept-local", secrets.values.getValue("password").decodeToString())
+            assertEquals(true, secrets.states.getValue("password"))
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
+    fun `snapshot re-stage retains the local mirror secret when the envelope is absent`() {
+        val retained = "kept-local".toByteArray()
+        val secrets = prepareSecrets(
+            change(
+                payload = payload(hasPassword = true, hasPrivateKey = false),
+                fieldMask = listOf("name", "host"),
+            ),
+            opener = EnvelopeOpener { _, _ -> error("must not open") },
+            retainedSecrets = mapOf("password" to retained),
+            snapshot = true,
+        )
+        try {
+            assertEquals("kept-local", secrets.values.getValue("password").decodeToString())
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
+    fun `snapshot planner re-puts a retained value so promotion stays complete`() {
+        val retained = "kept-local".toByteArray()
+        val change = change(
+            payload = payload(hasPassword = true, hasPrivateKey = false),
+            envelopes = mapOf("password" to envelope()),
+            fieldMask = listOf("name", "host"),
+        )
+        val secrets = prepareSecrets(
+            change,
+            opener = EnvelopeOpener { _, _ -> null },
+            retainedSecrets = mapOf("password" to retained),
+            snapshot = true,
+        )
+        try {
+            val mutations = planBootstrapPageSecretMutations(
+                generation = 77L,
+                changes = listOf(change),
+                prepared = mapOf(0 to secrets),
+            )
+            val put = mutations.filterIsInstance<PlannedSecretMutation.Put>().first()
+            assertEquals("kept-local", put.plaintext.decodeToString())
+            assertTrue(put.ref.canonical().value.contains("77"))
+        } finally {
+            secrets.close()
+            retained.fill(0)
+        }
+    }
+
+    @Test
+    fun `incremental pages keep the pre-existing behavior without snapshot flag`() {
+        /* Regression guard: the incremental fallback must remain byte-for-byte intact for
+         * change-feed pages — this is exactly what PR #115/#116 established. */
+        val secrets = prepareSecrets(
+            change(
+                payload = payload(hasPassword = true, hasPrivateKey = false),
+                envelopes = mapOf("password" to envelope()),
+                fieldMask = listOf("name"),
+            ),
+            opener = EnvelopeOpener { _, _ -> null },
+        )
+        try {
+            assertEquals(true, secrets.states.getValue("password"))
+            assertTrue(secrets.values["password"] == null)
+        } finally {
+            secrets.close()
+        }
+    }
 }

--- a/zephyr_one/mobile/tests/android-bootstrap-snapshot-readiness.test.mjs
+++ b/zephyr_one/mobile/tests/android-bootstrap-snapshot-readiness.test.mjs
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+/**
+ * Contract for the second-sync bootstrap freeze (§19, §26):
+ *
+ * 1. A bootstrap snapshot page is a full replacement; its fieldMask is the full editable set
+ *    and must never be classified as an incremental secret patch. `prepareSecrets` must carry
+ *    an explicit `snapshot` flag that disables the incremental fallback, so an unopenable
+ *    envelope surfaces as ENVELOPE_REJECTED (or is covered by a retained local secret)
+ *    instead of being silently swallowed into a misleading missing_envelope deep in the
+ *    mutation planner.
+ * 2. Re-staging a snapshot over an existing mirror must retain the local mirror secret when
+ *    the page's envelope cannot be opened or is absent. Only "no envelope AND no retained
+ *    value" fails closed with MISSING_ENVELOPE.
+ * 3. Readiness of the account database follows the promoted snapshot, not the whole round:
+ *    a first round that promotes the mirror but fails a later phase must still mark the
+ *    database ready, so the next launch runs a normal round instead of re-downloading the
+ *    account into BOUND_NEEDS_BOOTSTRAP.
+ */
+
+const mirrorWriter = read('android/core-data/src/main/kotlin/one/zephyr/mobile/data/MirrorWriter.kt');
+const accountContainer = read('android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt');
+const bindingCoordinator = read('android/app/src/main/kotlin/one/zephyr/mobile/app/binding/BindingCoordinator.kt');
+const reconciliationTest = read('android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretReconciliationTest.kt');
+const coordinatorTest = read('android/app/src/test/kotlin/one/zephyr/mobile/app/binding/BindingCoordinatorTest.kt');
+
+test('prepareSecrets separates snapshot semantics from incremental-patch fallback', () => {
+  assert.match(mirrorWriter, /snapshot: Boolean = false/);
+  assert.match(mirrorWriter, /val incrementalFallback = !snapshot && isIncrementalSecretPatch\(change\)/);
+  // Both decision sites (envelope present / envelope absent) honor the snapshot flag.
+  const decisionSites = mirrorWriter.split('incrementalFallback').length - 1;
+  assert.ok(decisionSites >= 3, `expected >= 3 uses of incrementalFallback, found ${decisionSites}`);
+});
+
+test('bootstrap staging passes retained mirror secrets and snapshot semantics', () => {
+  assert.match(mirrorWriter, /prepareSecrets\(change, opener, retainedSecrets = retained, snapshot = true\)/);
+  assert.match(mirrorWriter, /val retained = retainedSecretsFor\(change\)/);
+  // The retained bytes are wiped after staging consumes them.
+  assert.match(mirrorWriter, /retained\.values\.forEach \{ it\.fill\(0\) \}/);
+});
+
+test('snapshot retention is covered by JVM unit tests', () => {
+  assert.match(reconciliationTest, /snapshot full-replacement mask is never treated as an incremental secret patch/);
+  assert.match(reconciliationTest, /snapshot re-stage retains the local mirror secret when the envelope cannot be opened/);
+  assert.match(reconciliationTest, /snapshot re-stage retains the local mirror secret when the envelope is absent/);
+  assert.match(reconciliationTest, /snapshot without an envelope and without a retained secret fails closed as missing envelope/);
+  assert.match(reconciliationTest, /snapshot planner re-puts a retained value so promotion stays complete/);
+  assert.match(reconciliationTest, /incremental pages keep the pre-existing behavior without snapshot flag/);
+});
+
+test('readiness follows the promoted snapshot rather than the whole round', () => {
+  assert.match(
+    accountContainer,
+    /rounds\.any \{ it\.bootstrapOutcome is BootstrapOutcome\.Complete \}/,
+  );
+  assert.match(bindingCoordinator, /markReadyWhenSnapshotPromoted/);
+  // No whole-round `complete` gate remains on the readiness path.
+  const restoreBlock = bindingCoordinator.slice(
+    bindingCoordinator.indexOf('preparation.restoredGraph?.takeIf { bootstrap }'),
+    bindingCoordinator.indexOf('workersMayRun = preparation.result'),
+  );
+  assert.ok(!/\.takeIf \{ it\.complete \}/.test(restoreBlock), 'restore path must not gate readiness on round.complete');
+});
+
+test('snapshot-promoted readiness is covered by JVM unit tests', () => {
+  assert.match(coordinatorTest, /a promoted snapshot marks the database ready even when a later phase fails/);
+  assert.match(coordinatorTest, /a promoted snapshot with a later failure still writes the readiness marker/);
+  assert.match(coordinatorTest, /no snapshot promotion leaves the readiness marker untouched/);
+});


### PR DESCRIPTION
## 问题

绑定设备第二次同步（以及重启后的同步）重新进入 bootstrap staging，报 `sync.bootstrap.stage: missing_envelope`。服务端侧已验证完好：设备 cursor 已 ack 到最新（59/59）、retention 为空、所有 presence=true 的行都有存储态密钥、快照页信封齐全。

## 根因（均在客户端）

1. **readiness marker 挂在整轮完成上**：`AccountContainer.bootstrapAfterBind` 与 `BindingCoordinator` 三处只在 round `complete` 时写 marker。第一轮 promote 了快照但后续阶段（push/pull/ack）失败 → marker 未写 → 下次启动 `accountDatabaseRequiresBootstrap()`=true → 状态重置 `BOUND_NEEDS_BOOTSTRAP` → 重新全量下载账号。

2. **bootstrap 页被误判为增量补丁**：`prepareSecrets` 里 `isIncrementalSecretPatch(change)` 对 bootstrap 页的 fieldMask（完整可编辑集，不含 secret 字段）误答 true → 打不开的信封被静默吞掉 → mutation planner 在深处抛误导性的 `missing_envelope`。staging 也从不引用现有镜像，重导没有任何 retained-secret 路径。

## 修复

- `prepareSecrets` 增加 `snapshot` 标志：快照页禁用增量兜底；信封打不开→保留本地镜像密钥，无保留则按真实错误码 fail-closed（ENVELOPE_REJECTED/MISSING_ENVELOPE）。
- `stageBootstrapPage` 以 `retainedSecretsFor(change)` staging：页无法提供可开封封套时保留本地明文，staging 消费后清零。
- readiness 跟随已 promote 的快照：任一 round 报告 `BootstrapOutcome.Complete` 即写 marker（后续阶段失败也不回退全量 bootstrap），`bootstrapSucceeded` 反映同一事实；从未 promote 的轮次不写 marker，保证全新 bootstrap 重试。

增量页行为逐字节不变（snapshot 默认 false）。

## 测试

- JVM：快照密钥语义 6 例（fail-closed、无信封/打不开时保留本地、planner re-put、增量不变）；Coordinator readiness 3 例（promote 后阶段失败仍 ready、从未 promote 不写 marker）。
- Node 合同：`android-bootstrap-snapshot-readiness.test.mjs` 5 例锁住接线。
- 本地全量 mobile Node 合同 579/580 绿（1 例 keystore SHA-256 失败在基线即存在，与本改动无关）。

符合 ZEPHYR_ONE.md §19（bootstrap 稳定 snapshotCursor/staging generation、cursor 过期才转 bootstrap）与 §26（无半事务、诊断真实）。