### PR TITLE
test(ios): make the handle-not-a-counter check deterministic

### DIFF
--- a/zephyr_one/mobile/ios/Tests/ZephyrCoreTests/SecurityScopedFileProviderTests.swift
+++ b/zephyr_one/mobile/ios/Tests/ZephyrCoreTests/SecurityScopedFileProviderTests.swift
@@ -243,8 +243,8 @@ final class SecurityScopedFileProviderTests: XCTestCase {
         XCTAssertEqual(first.count, 34)
         XCTAssertTrue(first.dropFirst(2).allSatisfy { "0123456789abcdef".contains($0) })
         /* A counter increases (weakly) in open order. Random handles clear the
-         * increasing-order property with probability 1 - 1/8! ≈ 99.99998% over
-         * eight sampled handles, while a counter never can — a deterministic
+         * increasing-order property with probability 1 - 1/8! ~= 99.99998% over
+         * eight sampled handles, while a counter never can - a deterministic
          * discriminator with no false-positive flake. (The previous
          * hasSuffix("1") && hasSuffix("2") check failed 1/256 runs even on the
          * correct random implementation.) */

--- a/zephyr_one/mobile/ios/Tests/ZephyrCoreTests/SecurityScopedFileProviderTests.swift
+++ b/zephyr_one/mobile/ios/Tests/ZephyrCoreTests/SecurityScopedFileProviderTests.swift
@@ -242,7 +242,20 @@ final class SecurityScopedFileProviderTests: XCTestCase {
         // "h_" plus 16 bytes of hex.
         XCTAssertEqual(first.count, 34)
         XCTAssertTrue(first.dropFirst(2).allSatisfy { "0123456789abcdef".contains($0) })
-        XCTAssertFalse(first.hasSuffix("1") && second.hasSuffix("2"), "a handle must not be a counter")
+        /* A counter increases (weakly) in open order. Random handles clear the
+         * increasing-order property with probability 1 - 1/8! ≈ 99.99998% over
+         * eight sampled handles, while a counter never can — a deterministic
+         * discriminator with no false-positive flake. (The previous
+         * hasSuffix("1") && hasSuffix("2") check failed 1/256 runs even on the
+         * correct random implementation.) */
+        var previous = UInt64.max
+        for index in 0..<8 {
+            let handle = try await provider.open(path: "/docs/a.txt", mode: "read")
+            try await provider.close(handle: handle)
+            let tail = UInt64(String(handle.dropFirst(2).suffix(8)), radix: 16) ?? UInt64.max
+            XCTAssertLessThan(tail, previous, "handle \(index) must not trend upward like a counter")
+            previous = tail
+        }
     }
 
     func testAnUnknownHandleIsRefusedRatherThanIgnored() async throws {

--- a/zephyr_one/mobile/ios/Tests/ZephyrCoreTests/SecurityScopedFileProviderTests.swift
+++ b/zephyr_one/mobile/ios/Tests/ZephyrCoreTests/SecurityScopedFileProviderTests.swift
@@ -242,20 +242,20 @@ final class SecurityScopedFileProviderTests: XCTestCase {
         // "h_" plus 16 bytes of hex.
         XCTAssertEqual(first.count, 34)
         XCTAssertTrue(first.dropFirst(2).allSatisfy { "0123456789abcdef".contains($0) })
-        /* A counter increases (weakly) in open order. Random handles clear the
-         * increasing-order property with probability 1 - 1/8! ~= 99.99998% over
-         * eight sampled handles, while a counter never can - a deterministic
-         * discriminator with no false-positive flake. (The previous
-         * hasSuffix("1") && hasSuffix("2") check failed 1/256 runs even on the
-         * correct random implementation.) */
-        var previous = UInt64.max
-        for index in 0..<8 {
+        /* A counter increases (weakly) in open order; random handles make the
+         * whole sampled sequence increasing with probability 1/8! only. Assert
+         * the sequence is NOT increasing overall: a counter always fails this,
+         * random handles fail with probability 1/8! ~= 0.0025% (156x less flaky
+         * than the previous hasSuffix("1") && hasSuffix("2") check, which failed
+         * 1/256 runs even on the correct random implementation). */
+        var tails: [UInt64] = []
+        for _ in 0..<8 {
             let handle = try await provider.open(path: "/docs/a.txt", mode: "read")
             try await provider.close(handle: handle)
-            let tail = UInt64(String(handle.dropFirst(2).suffix(8)), radix: 16) ?? UInt64.max
-            XCTAssertLessThan(tail, previous, "handle \(index) must not trend upward like a counter")
-            previous = tail
+            tails.append(UInt64(String(handle.dropFirst(2).suffix(8)), radix: 16) ?? UInt64.max)
         }
+        let increasing = zip(tails, tails.dropFirst()).allSatisfy { $0 < $1 }
+        XCTAssertFalse(increasing, "eight handles in a row must not be monotonically increasing like a counter")
     }
 
     func testAnUnknownHandleIsRefusedRatherThanIgnored() async throws {


### PR DESCRIPTION
## 问题

合并 #117 后的 release dispatch 构建里 ios job 随机挂掉：

```
SecurityScopedFileProviderTests.swift:245
XCTAssertFalse failed - a handle must not be a counter
```

## 根因

断言 `!(first.hasSuffix("1") && second.hasSuffix("2"))` 本身是概率性的：实现是真正的 `SystemRandomNumberGenerator` 128-bit hex，两个随机句柄恰好分别以 1、2 结尾的概率是 (1/16)² = **1/256**。这条断言是为计数器实现写的守卫，随机实现踩中的概率每次 CI 约 0.4%。PR #117 的 ios job 是绿的——这只是霉运，与代码无关。

## 修复

把"不是计数器"改成可判定的**顺序性质**：连续打开 8 个句柄，尾 8 hex 转成的 UInt64 不按打开顺序单调递增。

- 计数器实现：句柄永远递增 → **必挂**（确定性判别）。
- 随机实现：8 个值恰好全降序的概率 1/8! ≈ 0.0025%，比原断言低 156 倍；解析失败的碰撞走 UInt64.max 哨兵保持断言成立。

无产品代码改动。