### PR TITLE
fix(android): accept AI downlink pages and expose main-end AI on One

### DIFF
--- a/tests/mobile-v1-ai-provider-entities.test.mjs
+++ b/tests/mobile-v1-ai-provider-entities.test.mjs
@@ -341,3 +341,54 @@ test('renaming an AI provider does not stamp apiKey as a secret change', () => {
     context.cleanup();
   }
 });
+
+test('owned-sync wire keeps hasApiKey and numeric option fields for One', () => {
+  const context = fresh();
+  try {
+    const alice = { userId: 'alice' };
+    context.service.create(alice, {
+      id: 'provider-options',
+      name: 'Options',
+      type: 'openai-compatible',
+      baseUrl: 'https://api.example.invalid/v1',
+      apiKey: 'sk-live-secret',
+      defaultModel: 'gpt-4o',
+      config: {
+        apiMode: 'chat',
+        options: {
+          max_tokens: 4096,
+          max_output_tokens: 8192,
+          presence_penalty: 0.2,
+          frequency_penalty: 0.1,
+          vision: true,
+        },
+      },
+      models: [{
+        id: 'gpt-4o',
+        label: 'GPT-4o',
+        contextWindowTokens: 128000,
+        maxOutputTokens: 16384,
+      }],
+    }, { changedSecretFields: ['apiKey'] });
+    const projected = context.adapter.read(alice, 'provider-options');
+    const { projectPayload } = require(path.join(root, 'mobile-v1-entities.js'));
+    const spec = enabledRegistry.entities.find((entity) => entity.type === 'aiProvider');
+    const wire = projectPayload(spec, projected);
+    assert.equal(wire.apiKey, undefined);
+    assert.equal(wire.hasApiKey, true);
+    assert.equal(wire.config.options.max_tokens, 4096);
+    assert.equal(wire.config.options.max_output_tokens, 8192);
+    assert.equal(wire.config.options.presence_penalty, 0.2);
+    assert.equal(wire.models[0].contextWindowTokens, 128000);
+    assert.equal(wire.models[0].maxOutputTokens, 16384);
+    const page = context.bridge.store.changePage(alice.userId, 0, 20);
+    const created = page.changes.find((change) => change.entityType === 'aiProvider');
+    assert.ok(created);
+    const serialized = JSON.stringify(created);
+    assert.equal(created.payload?.apiKey, undefined);
+    assert.ok(!serialized.includes('sk-live-secret'));
+    assert.ok(!serialized.includes('"apiKey"'));
+  } finally {
+    context.cleanup();
+  }
+});

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiPlatformHost.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiPlatformHost.kt
@@ -8,14 +8,21 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.security.MessageDigest
 import java.security.SecureRandom
+import java.util.UUID
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import one.zephyr.mobile.app.di.AccountContainer
+import one.zephyr.mobile.data.repository.LocalAiMemory
+import one.zephyr.mobile.data.repository.LocalAiPlan
+import one.zephyr.mobile.data.repository.LocalAiPlanStep
 import one.zephyr.mobile.feature.notes.SftpPort
 import one.zephyr.mobile.network.MobileJson
 
@@ -38,6 +45,12 @@ internal class AndroidAiPlatformHost(
     private val lifecycleLock = Any()
     @Volatile private var active: ActiveHost? = null
     @Volatile private var closed = false
+    private val http: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(12, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .build()
 
     /**
      * Starts the loopback bridge on demand.
@@ -127,6 +140,15 @@ internal class AndroidAiPlatformHost(
             catalog += tool("sftp_rename_v1", "重命名/移动远程路径。", listOf("connectionId", "oldPath", "newPath"), false, "high")
             catalog += tool("sftp_delete_v1", "删除远程文件或目录。", listOf("connectionId", "path"), false, "high")
         }
+        catalog += tool("web_search", "搜索公开网页（DuckDuckGo HTML）。", listOf("query"), true, "low")
+        catalog += tool("fetch_url", "抓取公开 http/https 页面正文。", listOf("url"), true, "low")
+        catalog += tool("memory_search", "搜索本机长期 Memory。", listOf("query"), true, "low")
+        catalog += tool("memory_save", "保存一条本机长期 Memory。", listOf("title", "content"), false, "high")
+        catalog += tool("list_env_vars", "列出对本机 AI 可见的环境变量元数据，不含值。", emptyList(), true, "low")
+        catalog += tool("get_env_var", "读取一条已对 AI 暴露值的环境变量。", listOf("name"), false, "high")
+        catalog += tool("plan_task", "创建一条本机任务计划。", listOf("title"), false, "low")
+        catalog += tool("plan_update", "更新本机任务计划状态或步骤。", listOf("id"), false, "high")
+        catalog += tool("plan_delete", "删除一条本机任务计划。", listOf("id"), false, "high")
         return JsonObject(mapOf("tools" to JsonArray(catalog)))
     }
 
@@ -163,6 +185,15 @@ internal class AndroidAiPlatformHost(
             "sftp_mkdir_v1" -> sftpMkdir(args)
             "sftp_rename_v1" -> sftpRename(args)
             "sftp_delete_v1" -> sftpDelete(args)
+            "web_search" -> webSearch(args)
+            "fetch_url" -> fetchUrl(args)
+            "memory_search" -> memorySearch(args)
+            "memory_save" -> memorySave(args)
+            "list_env_vars" -> listEnvVars()
+            "get_env_var" -> getEnvVar(args)
+            "plan_task" -> planTask(args)
+            "plan_update" -> planUpdate(args)
+            "plan_delete" -> planDelete(args)
             else -> return error("unknown_tool", "工具不存在")
         }
         return JsonObject(mapOf("ok" to JsonPrimitive(true), "result" to result))
@@ -537,6 +568,147 @@ internal class AndroidAiPlatformHost(
             requireSftp()!!.delete(h, args.string("path"), args["recursive"]?.let { (it as? JsonPrimitive)?.content == "true" } ?: false)
             JsonObject(mapOf("deleted" to JsonPrimitive(true)))
         }
+    }
+
+    private suspend fun webSearch(args: JsonObject): JsonElement {
+        val query = args.string("query").trim()
+        if (query.isEmpty()) return error("invalid_tool_arguments", "query 不能为空")
+        val maxResults = args.string("maxResults").toIntOrNull()?.coerceIn(1, 12) ?: 6
+        return try {
+            JsonArray(AndroidAiWebTools.search(http, query, maxResults).map { hit ->
+                JsonObject(
+                    mapOf(
+                        "title" to JsonPrimitive(hit.title),
+                        "url" to JsonPrimitive(hit.url),
+                        "snippet" to JsonPrimitive(hit.snippet),
+                    ),
+                )
+            })
+        } catch (failure: Exception) {
+            error("web_search_failed", failure.message ?: "网页搜索失败")
+        }
+    }
+
+    private suspend fun fetchUrl(args: JsonObject): JsonElement {
+        val url = args.string("url").trim()
+        if (url.isEmpty()) return error("invalid_tool_arguments", "url 不能为空")
+        val maxChars = args.string("maxChars").toIntOrNull()?.coerceIn(1000, 120_000) ?: 24_000
+        return try {
+            JsonObject(mapOf("text" to JsonPrimitive(AndroidAiWebTools.fetch(http, url, maxChars))))
+        } catch (failure: Exception) {
+            error("fetch_url_failed", failure.message ?: "抓取失败")
+        }
+    }
+
+    private suspend fun memorySearch(args: JsonObject): JsonElement {
+        val query = args.string("query").trim().lowercase()
+        val catalog = account.localAi.load()
+        val hits = catalog.memories.filter { it.enabled }.filter { memory ->
+            query.isEmpty() ||
+                memory.title.lowercase().contains(query) ||
+                memory.content.lowercase().contains(query) ||
+                memory.tags.any { it.lowercase().contains(query) }
+        }.take(catalog.context.memoryItems.coerceAtLeast(1))
+        return JsonArray(
+            hits.map { memory ->
+                JsonObject(
+                    mapOf(
+                        "id" to JsonPrimitive(memory.id),
+                        "title" to JsonPrimitive(memory.title),
+                        "scope" to JsonPrimitive(memory.scope),
+                        "content" to JsonPrimitive(memory.content.take(4_000)),
+                    ),
+                )
+            },
+        )
+    }
+
+    private suspend fun memorySave(args: JsonObject): JsonElement {
+        val title = args.string("title").trim()
+        val content = args.string("content").trim()
+        if (title.isEmpty() || content.isEmpty()) return error("invalid_tool_arguments", "title 和 content 不能为空")
+        val item = LocalAiMemory(
+            title = title.take(200),
+            content = content.take(16_000),
+            scope = args.string("scope").ifBlank { "global" },
+            project = args.string("project"),
+            tags = args.array("tags"),
+            enabled = true,
+        )
+        account.localAi.upsertMemory(item)
+        return JsonObject(mapOf("saved" to JsonPrimitive(true), "title" to JsonPrimitive(item.title)))
+    }
+
+    private suspend fun listEnvVars(): JsonElement {
+        val catalog = account.localAi.load()
+        return JsonArray(
+            catalog.environment.filter { it.enabled && it.visibleToAi }.map { env ->
+                JsonObject(
+                    mapOf(
+                        "id" to JsonPrimitive(env.id),
+                        "name" to JsonPrimitive(env.name),
+                        "description" to JsonPrimitive(env.description),
+                        "valueVisibleToAi" to JsonPrimitive(env.valueVisibleToAi),
+                    ),
+                )
+            },
+        )
+    }
+
+    private suspend fun getEnvVar(args: JsonObject): JsonElement {
+        val name = args.string("name").trim()
+        if (name.isEmpty()) return error("invalid_tool_arguments", "name 不能为空")
+        val catalog = account.localAi.load()
+        val env = catalog.environment.firstOrNull { it.enabled && it.visibleToAi && it.name.equals(name, ignoreCase = true) }
+            ?: return error("env_not_found", "环境变量不存在或未对 AI 可见")
+        if (!env.valueVisibleToAi) return error("env_value_hidden", "该变量值未对 AI 开放")
+        val chars = account.localAi.environmentValue(env.id) ?: return error("env_empty", "环境变量没有值")
+        return try {
+            JsonObject(mapOf("name" to JsonPrimitive(env.name), "value" to JsonPrimitive(String(chars))))
+        } finally {
+            chars.fill('\u0000')
+        }
+    }
+
+    private suspend fun planTask(args: JsonObject): JsonElement {
+        val title = args.string("title").trim()
+        if (title.isEmpty()) return error("invalid_tool_arguments", "title 不能为空")
+        val steps = args.array("steps").ifEmpty {
+            args.string("steps").lineSequence().map(String::trim).filter(String::isNotEmpty).toList()
+        }
+        val plan = LocalAiPlan(
+            id = UUID.randomUUID().toString(),
+            title = title.take(200),
+            status = "planned",
+            risk = args.string("risk"),
+            note = args.string("note"),
+            steps = steps.mapIndexed { index, step -> LocalAiPlanStep(id = "${index + 1}", title = step) },
+        )
+        account.localAi.upsertPlan(plan)
+        return JsonObject(mapOf("id" to JsonPrimitive(plan.id), "title" to JsonPrimitive(plan.title), "status" to JsonPrimitive(plan.status)))
+    }
+
+    private suspend fun planUpdate(args: JsonObject): JsonElement {
+        val id = args.string("id").trim()
+        if (id.isEmpty()) return error("invalid_tool_arguments", "id 不能为空")
+        val catalog = account.localAi.load()
+        val current = catalog.plans.firstOrNull { it.id == id } ?: return error("plan_not_found", "计划不存在")
+        val next = current.copy(
+            title = args.string("title").ifBlank { current.title },
+            status = args.string("status").ifBlank { current.status },
+            risk = args.string("risk").ifBlank { current.risk },
+            note = args.string("note").ifBlank { current.note },
+            updatedAt = System.currentTimeMillis(),
+        )
+        account.localAi.upsertPlan(next)
+        return JsonObject(mapOf("id" to JsonPrimitive(next.id), "status" to JsonPrimitive(next.status)))
+    }
+
+    private suspend fun planDelete(args: JsonObject): JsonElement {
+        val id = args.string("id").trim()
+        if (id.isEmpty()) return error("invalid_tool_arguments", "id 不能为空")
+        account.localAi.deletePlan(id)
+        return JsonObject(mapOf("deleted" to JsonPrimitive(true), "id" to JsonPrimitive(id)))
     }
 
     private suspend fun runSftp(args: JsonObject, block: suspend () -> JsonElement): JsonElement {

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiWebTools.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AndroidAiWebTools.kt
@@ -1,0 +1,83 @@
+package one.zephyr.mobile.app
+
+import java.net.URI
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/** Public-web helpers used by the local AI host. Mirrors the main-end DuckDuckGo HTML path. */
+internal object AndroidAiWebTools {
+    data class SearchHit(val title: String, val url: String, val snippet: String)
+
+    fun search(http: OkHttpClient, query: String, maxResults: Int): List<SearchHit> {
+        val url = "https://duckduckgo.com/html/?q=" + java.net.URLEncoder.encode(query, Charsets.UTF_8.name())
+        val html = requestText(http, url)
+        return parseDuckDuckGo(html, maxResults)
+    }
+
+    fun fetch(http: OkHttpClient, url: String, maxChars: Int): String {
+        val parsed = URI(url)
+        if (parsed.scheme != "http" && parsed.scheme != "https") {
+            throw IllegalArgumentException("仅支持 http/https URL")
+        }
+        val body = requestText(http, parsed.toString())
+        return stripHtml(body).take(maxChars.coerceIn(1, 120_000))
+    }
+
+    fun parseDuckDuckGo(html: String, maxResults: Int): List<SearchHit> {
+        val out = ArrayList<SearchHit>(maxResults)
+        val primary = Regex(
+            """<a[^>]+class="result__a"[^>]+href="([^"]+)"[^>]*>([\s\S]*?)</a>[\s\S]*?<a[^>]+class="result__snippet"[^>]*>([\s\S]*?)</a>""",
+            RegexOption.IGNORE_CASE,
+        )
+        for (match in primary.findAll(html)) {
+            if (out.size >= maxResults) break
+            val link = unwrapDuckDuckGo(htmlDecode(match.groupValues[1]))
+            out += SearchHit(stripHtml(match.groupValues[2]), link, stripHtml(match.groupValues[3]))
+        }
+        if (out.isEmpty()) {
+            val simple = Regex("""<a[^>]+href="([^"]+)"[^>]*>([\s\S]{5,220}?)</a>""", RegexOption.IGNORE_CASE)
+            for (match in simple.findAll(html)) {
+                if (out.size >= maxResults) break
+                val title = stripHtml(match.groupValues[2])
+                val link = htmlDecode(match.groupValues[1])
+                if (title.isNotBlank() && link.startsWith("http")) {
+                    out += SearchHit(title, link, "")
+                }
+            }
+        }
+        return out
+    }
+
+    fun stripHtml(value: String): String =
+        htmlDecode(value.replace(Regex("(?is)<script[^>]*>.*?</script>|<style[^>]*>.*?</style>|<[^>]+>"), " "))
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    internal fun htmlDecode(value: String): String = value
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&nbsp;", " ")
+
+    private fun unwrapDuckDuckGo(link: String): String = try {
+        val parsed = link.toHttpUrl()
+        parsed.queryParameter("uddg") ?: link
+    } catch (_: Exception) {
+        link
+    }
+
+    private fun requestText(http: OkHttpClient, url: String): String {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", "Mozilla/5.0 ZephyrAI/1.0")
+            .get()
+            .build()
+        http.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw IllegalStateException("HTTP ${response.code}")
+            return response.body?.string().orEmpty()
+        }
+    }
+}

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/AppDestinations.kt
@@ -620,10 +620,15 @@ internal fun DiagnosticsLiveDestination(
 @Composable
 internal fun AiSettingsLiveDestination(
     account: AccountContainer,
-    @Suppress("UNUSED_PARAMETER") ownerUserId: String,
+    ownerUserId: String,
     onBack: () -> Unit,
 ) {
     val discoverer = remember(account) { AiModelDiscoverer(account) }
+    val providers by account.ownedAi.observeProviders(ownerUserId).collectAsState(initial = emptyList())
+    val memories by account.ownedAi.observeMemories(ownerUserId).collectAsState(initial = emptyList())
+    val skills by account.ownedAi.observeSkills(ownerUserId).collectAsState(initial = emptyList())
+    val env by account.ownedAi.observeEnv(ownerUserId).collectAsState(initial = emptyList())
+    val conversations by account.ownedAi.observeConversations(ownerUserId).collectAsState(initial = emptyList())
     one.zephyr.mobile.feature.tools.AiSettingsLiveRoute(
         localAi = account.localAi,
         bound = !account.isLocalMode,
@@ -636,6 +641,13 @@ internal fun AiSettingsLiveDestination(
                     one.zephyr.mobile.feature.tools.ModelDiscoveryResult(emptyList(), outcome.reason)
             }
         },
+        mainSyncCounts = one.zephyr.mobile.feature.tools.MainAiSyncCounts(
+            providers = providers.size,
+            memories = memories.size,
+            skills = skills.size,
+            env = env.size,
+            conversations = conversations.size,
+        ),
     )
 }
 

--- a/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
+++ b/zephyr_one/mobile/android/app/src/main/kotlin/one/zephyr/mobile/app/di/AccountContainer.kt
@@ -34,6 +34,7 @@ import one.zephyr.mobile.data.repository.ConflictRepository
 import one.zephyr.mobile.data.repository.ConnectionRepository
 import one.zephyr.mobile.data.repository.LocalAiRepository
 import one.zephyr.mobile.data.repository.NoteRepository
+import one.zephyr.mobile.data.repository.OwnedAiRepository
 import one.zephyr.mobile.data.repository.ResourceRepository
 import one.zephyr.mobile.data.repository.SettingsRepository
 import one.zephyr.mobile.data.repository.SharedResourceStore
@@ -282,6 +283,9 @@ class AccountContainer(
 
     /** Full local AI authority. Server binding is never required to edit or run it. */
     val localAi: LocalAiRepository = LocalAiRepository(database, secretStore)
+
+    /** Bound-account AI entities that ride the owned-sync change feed. */
+    val ownedAi: OwnedAiRepository = OwnedAiRepository(database, writeGateway)
 
     internal val localAiWorkspace: LocalAiWorkspace = LocalAiWorkspace(
         File(context.noBackupFilesDir, "ai-workspaces/$generation"),

--- a/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/AndroidAiWebToolsTest.kt
+++ b/zephyr_one/mobile/android/app/src/test/kotlin/one/zephyr/mobile/app/AndroidAiWebToolsTest.kt
@@ -1,0 +1,41 @@
+package one.zephyr.mobile.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidAiWebToolsTest {
+
+    @Test
+    fun `parses duckduckgo result anchors and unwraps uddg`() {
+        val html = """
+            <a class="result__a" href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fdocs">Example Docs</a>
+            <a class="result__snippet">Official documentation</a>
+        """.trimIndent()
+
+        val hits = AndroidAiWebTools.parseDuckDuckGo(html, 6)
+
+        assertEquals(1, hits.size)
+        assertEquals("Example Docs", hits[0].title)
+        assertEquals("https://example.com/docs", hits[0].url)
+        assertEquals("Official documentation", hits[0].snippet)
+    }
+
+    @Test
+    fun `falls back to generic http anchors when result class is missing`() {
+        val html = """<a href="https://zephyr.example/ai">Zephyr AI</a>"""
+
+        val hits = AndroidAiWebTools.parseDuckDuckGo(html, 3)
+
+        assertEquals(1, hits.size)
+        assertEquals("Zephyr AI", hits[0].title)
+        assertEquals("https://zephyr.example/ai", hits[0].url)
+    }
+
+    @Test
+    fun `stripHtml drops tags and collapses whitespace`() {
+        val text = AndroidAiWebTools.stripHtml("<html><script>alert(1)</script><p>Hello&nbsp;<b>AI</b></p></html>")
+        assertEquals("Hello AI", text)
+        assertTrue(text.none { it == '<' })
+    }
+}

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/EntityCodec.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/EntityCodec.kt
@@ -63,9 +63,19 @@ object EntityCodec {
     fun float(payload: JsonObject, key: String, fallback: Float): Float =
         (payload[key] as? JsonPrimitive)?.doubleOrNull?.toFloat() ?: fallback
 
+    fun doubleOrNull(payload: JsonObject, key: String): Double? =
+        (payload[key] as? JsonPrimitive)?.doubleOrNull
+
+    fun obj(payload: JsonObject, key: String): JsonObject? = payload[key] as? JsonObject
+
     fun stringList(payload: JsonObject, key: String): List<String> =
         (payload[key] as? kotlinx.serialization.json.JsonArray)
             ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            ?: emptyList()
+
+    fun objectList(payload: JsonObject, key: String): List<JsonObject> =
+        (payload[key] as? kotlinx.serialization.json.JsonArray)
+            ?.mapNotNull { it as? JsonObject }
             ?: emptyList()
 
     /**
@@ -116,6 +126,11 @@ object EntityCodec {
                 .filter { it.isNotEmpty() }
                 .joinToString(" ")
         "snippet" -> text(payload, "name") to text(payload, "command")
+        "aiProvider" -> text(payload, "name") to text(payload, "type")
+        "aiMemory" -> text(payload, "title") to text(payload, "content")
+        "aiSkill" -> text(payload, "name") to text(payload, "description")
+        "aiConversation" -> text(payload, "title") to listOf(text(payload, "providerId"), text(payload, "model")).filter { it.isNotEmpty() }.joinToString(" ")
+        "aiMessage" -> text(payload, "role") to text(payload, "content")
         else -> null
     }
 }

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/SecretPayloadSanitizer.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/SecretPayloadSanitizer.kt
@@ -229,12 +229,24 @@ object SecretPayloadSanitizer {
         if (nested.isEmpty()) destination.remove(segment) else destination[segment] = JsonObject(nested)
     }
 
-    private fun isSecretAlias(normalized: String): Boolean =
-        normalized in EXACT_SECRET_ALIASES || SECRET_MARKERS.any(normalized::contains)
+    private fun isSecretAlias(normalized: String): Boolean {
+        if (normalized in SAFE_NUMERIC_ALIASES) return false
+        if (isPresenceFlagAlias(normalized)) return false
+        return normalized in EXACT_SECRET_ALIASES || SECRET_MARKERS.any(normalized::contains)
+    }
+
+    /**
+     * Registry presence flags (`hasApiKey`, `hasValue`, `hasPassword`) are metadata, not
+     * secret material. Substring markers like `apikey`/`password` would otherwise reject a
+     * canonical downlink page and freeze the account cursor. `normalizeKey` already strips
+     * case, so `hasApiKey` arrives as `hasapikey`.
+     */
+    private fun isPresenceFlagAlias(normalized: String): Boolean =
+        normalized.startsWith("has") && normalized.removePrefix("has") in PRESENCE_FLAG_FIELDS
 
     /** Local writes may not forge server presence metadata; SecretState is its only source. */
     private fun isLocalSecretKey(normalized: String): Boolean =
-        isSecretAlias(normalized) || normalized in PRESENCE_ALIASES
+        isSecretAlias(normalized) || normalized in PRESENCE_ALIASES || isPresenceFlagAlias(normalized)
 
     private fun normalizeKey(value: String): String = buildString(value.length) {
         for (character in Normalizer.normalize(value, Normalizer.Form.NFKC).lowercase(Locale.ROOT)) {
@@ -287,6 +299,8 @@ object SecretPayloadSanitizer {
         "secretkey",
         "secretenvelope",
         "secretenvelopes",
+        "token",
+        "clienttoken",
     )
 
     private val SECRET_MARKERS = listOf(
@@ -300,12 +314,42 @@ object SecretPayloadSanitizer {
         "bearertoken",
         "clientsecret",
         "secret",
-        "token",
         "secretkey",
         "envelope",
-        "presence",
         "authorization",
         "bearer",
+    )
+
+    /**
+     * Exact token/presence keys stay secret (`token`, `clientToken`). Substrings such as
+     * `max_tokens` and `presence_penalty` are published AI provider options and must ride
+     * the owned-sync wire.
+     */
+    private val SAFE_NUMERIC_ALIASES = setOf(
+        "maxtokens",
+        "maxoutputtokens",
+        "contextwindowtokens",
+        "presencepenalty",
+        "frequencypenalty",
+        "maximagestokens",
+        "windowtokens",
+        "toolresultchars",
+        "maxinputchars",
+        "maxtoolrounds",
+        "memoryitems",
+        "maximagesperrequest",
+        "maximagebytes",
+    )
+
+    /** Secret field names whose `hasX` flag is emitted by projectPayload. */
+    private val PRESENCE_FLAG_FIELDS = setOf(
+        "password",
+        "privatekey",
+        "passphrase",
+        "apikey",
+        "value",
+        "token",
+        "clienttoken",
     )
 
     private val PRESENCE_ALIASES = setOf("presence", "haspresence")

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/mapper/ResourceMappers.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/mapper/ResourceMappers.kt
@@ -1,10 +1,19 @@
 package one.zephyr.mobile.data.mapper
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import one.zephyr.mobile.data.EntityCodec
 import one.zephyr.mobile.data.db.MirrorEntityRow
 import one.zephyr.mobile.model.ActivityEvent
+import one.zephyr.mobile.model.AiConversationRecord
+import one.zephyr.mobile.model.AiEnv
+import one.zephyr.mobile.model.AiMemory
+import one.zephyr.mobile.model.AiMessageRecord
+import one.zephyr.mobile.model.AiModel
+import one.zephyr.mobile.model.AiProvider
+import one.zephyr.mobile.model.AiProviderConfig
+import one.zephyr.mobile.model.AiSkill
 import one.zephyr.mobile.model.CapabilitySet
 import one.zephyr.mobile.model.ClientToken
 import one.zephyr.mobile.model.JumpHost
@@ -204,5 +213,291 @@ object ResourceMappers {
             "group" to JsonPrimitive(snippet.group),
             "autoRun" to JsonPrimitive(snippet.autoRun),
         ),
+    )
+
+    fun aiProvider(row: MirrorEntityRow, conflicted: Boolean = false): AiProvider {
+        val payload = EntityCodec.parse(row.payloadJson)
+        val presence = EntityCodec.parse(row.secretPresenceJson)
+        val config = EntityCodec.obj(payload, "config") ?: JsonObject(emptyMap())
+        val options = EntityCodec.obj(config, "options") ?: JsonObject(emptyMap())
+        return AiProvider(
+            id = row.entityId,
+            ownerUserId = row.ownerUserId,
+            name = EntityCodec.text(payload, "name"),
+            type = EntityCodec.text(payload, "type", "openai-compatible"),
+            baseUrl = EntityCodec.text(payload, "baseUrl"),
+            defaultModel = EntityCodec.text(payload, "defaultModel"),
+            models = EntityCodec.objectList(payload, "models").map(::aiModel),
+            config = AiProviderConfig(
+                apiMode = EntityCodec.text(config, "apiMode", "auto"),
+                temperature = EntityCodec.doubleOrNull(options, "temperature"),
+                topP = EntityCodec.doubleOrNull(options, "top_p") ?: EntityCodec.doubleOrNull(options, "topP"),
+                maxTokens = EntityCodec.intOrNull(options, "max_tokens") ?: EntityCodec.intOrNull(options, "maxTokens"),
+                maxOutputTokens = EntityCodec.intOrNull(options, "max_output_tokens")
+                    ?: EntityCodec.intOrNull(options, "maxOutputTokens"),
+                presencePenalty = EntityCodec.doubleOrNull(options, "presence_penalty")
+                    ?: EntityCodec.doubleOrNull(options, "presencePenalty"),
+                frequencyPenalty = EntityCodec.doubleOrNull(options, "frequency_penalty")
+                    ?: EntityCodec.doubleOrNull(options, "frequencyPenalty"),
+                vision = EntityCodec.bool(options, "vision", true),
+                usePreviousResponseId = EntityCodec.bool(options, "use_previous_response_id", false),
+                reasoningEffort = EntityCodec.string(options, "reasoning_effort")
+                    ?: EntityCodec.string(options, "reasoningEffort"),
+                windowTokens = EntityCodec.intOrNull(options, "context")
+                    ?: EntityCodec.intOrNull(options, "windowTokens"),
+            ),
+            visibility = EntityCodec.text(payload, "visibility", "private"),
+            shareWithUsers = EntityCodec.bool(payload, "shareWithUsers", false),
+            shareWithAdmins = EntityCodec.bool(payload, "shareWithAdmins", false),
+            sharedUserIds = EntityCodec.stringList(payload, "sharedUserIds"),
+            enabled = EntityCodec.bool(payload, "enabled", true),
+            apiKey = SecretPresence(EntityCodec.bool(presence, "hasApiKey", EntityCodec.bool(payload, "hasApiKey", false))),
+            revision = row.revision,
+            createdAt = EntityCodec.long(payload, "createdAt", 0L),
+            updatedAt = row.serverUpdatedAt ?: row.localUpdatedAt,
+            deletedAt = row.deletedAt,
+            residency = Residency.OWNED,
+            capabilities = CapabilitySet.owner,
+            syncState = syncStateOf(row, conflicted),
+        )
+    }
+
+    fun aiProviderValues(provider: AiProvider): JsonObject {
+        val options = buildMap<String, kotlinx.serialization.json.JsonElement> {
+            provider.config.temperature?.let { put("temperature", JsonPrimitive(it)) }
+            provider.config.topP?.let { put("top_p", JsonPrimitive(it)) }
+            provider.config.maxTokens?.let { put("max_tokens", JsonPrimitive(it)) }
+            provider.config.maxOutputTokens?.let { put("max_output_tokens", JsonPrimitive(it)) }
+            provider.config.presencePenalty?.let { put("presence_penalty", JsonPrimitive(it)) }
+            provider.config.frequencyPenalty?.let { put("frequency_penalty", JsonPrimitive(it)) }
+            put("vision", JsonPrimitive(provider.config.vision))
+            put("use_previous_response_id", JsonPrimitive(provider.config.usePreviousResponseId))
+            provider.config.reasoningEffort?.let { put("reasoning_effort", JsonPrimitive(it)) }
+            provider.config.windowTokens?.let { put("context", JsonPrimitive(it)) }
+        }
+        return JsonObject(
+            mapOf(
+                "name" to JsonPrimitive(provider.name),
+                "type" to JsonPrimitive(provider.type),
+                "baseUrl" to JsonPrimitive(provider.baseUrl),
+                "defaultModel" to JsonPrimitive(provider.defaultModel),
+                "models" to JsonArray(provider.models.map(::aiModelValues)),
+                "config" to JsonObject(
+                    mapOf(
+                        "apiMode" to JsonPrimitive(provider.config.apiMode),
+                        "options" to JsonObject(options),
+                    ),
+                ),
+                "visibility" to JsonPrimitive(provider.visibility),
+                "shareWithUsers" to JsonPrimitive(provider.shareWithUsers),
+                "shareWithAdmins" to JsonPrimitive(provider.shareWithAdmins),
+                "sharedUserIds" to JsonArrays.of(provider.sharedUserIds),
+                "enabled" to JsonPrimitive(provider.enabled),
+            ),
+        )
+    }
+
+    fun aiMemory(row: MirrorEntityRow, conflicted: Boolean = false): AiMemory {
+        val payload = EntityCodec.parse(row.payloadJson)
+        return AiMemory(
+            id = row.entityId,
+            ownerUserId = row.ownerUserId,
+            title = EntityCodec.text(payload, "title"),
+            content = EntityCodec.text(payload, "content"),
+            scope = EntityCodec.text(payload, "scope", "global"),
+            project = EntityCodec.text(payload, "project"),
+            projects = EntityCodec.stringList(payload, "projects"),
+            tags = EntityCodec.stringList(payload, "tags"),
+            connectionIds = EntityCodec.stringList(payload, "connectionIds"),
+            enabled = EntityCodec.bool(payload, "enabled", true),
+            revision = row.revision,
+            updatedAt = row.serverUpdatedAt ?: row.localUpdatedAt,
+            deletedAt = row.deletedAt,
+            syncState = syncStateOf(row, conflicted),
+        )
+    }
+
+    fun aiMemoryValues(memory: AiMemory): JsonObject = JsonObject(
+        mapOf(
+            "title" to JsonPrimitive(memory.title),
+            "content" to JsonPrimitive(memory.content),
+            "scope" to JsonPrimitive(memory.scope),
+            "project" to JsonPrimitive(memory.project),
+            "projects" to JsonArrays.of(memory.projects),
+            "tags" to JsonArrays.of(memory.tags),
+            "connectionIds" to JsonArrays.of(memory.connectionIds),
+        ),
+    )
+
+    fun aiSkill(row: MirrorEntityRow, conflicted: Boolean = false): AiSkill {
+        val payload = EntityCodec.parse(row.payloadJson)
+        return AiSkill(
+            id = row.entityId,
+            ownerUserId = row.ownerUserId,
+            name = EntityCodec.text(payload, "name"),
+            description = EntityCodec.text(payload, "description"),
+            prompt = EntityCodec.text(payload, "prompt"),
+            enabled = EntityCodec.bool(payload, "enabled", true),
+            revision = row.revision,
+            updatedAt = row.serverUpdatedAt ?: row.localUpdatedAt,
+            deletedAt = row.deletedAt,
+            syncState = syncStateOf(row, conflicted),
+        )
+    }
+
+    fun aiSkillValues(skill: AiSkill): JsonObject = JsonObject(
+        mapOf(
+            "name" to JsonPrimitive(skill.name),
+            "description" to JsonPrimitive(skill.description),
+            "prompt" to JsonPrimitive(skill.prompt),
+            "enabled" to JsonPrimitive(skill.enabled),
+        ),
+    )
+
+    fun aiEnv(row: MirrorEntityRow, conflicted: Boolean = false): AiEnv {
+        val payload = EntityCodec.parse(row.payloadJson)
+        val presence = EntityCodec.parse(row.secretPresenceJson)
+        return AiEnv(
+            id = row.entityId,
+            ownerUserId = row.ownerUserId,
+            name = EntityCodec.text(payload, "name"),
+            enabled = EntityCodec.bool(payload, "enabled", true),
+            visibleToAi = EntityCodec.bool(payload, "visibleToAi", false),
+            value = SecretPresence(EntityCodec.bool(presence, "hasValue", EntityCodec.bool(payload, "hasValue", false))),
+            revision = row.revision,
+            updatedAt = row.serverUpdatedAt ?: row.localUpdatedAt,
+            deletedAt = row.deletedAt,
+            syncState = syncStateOf(row, conflicted),
+        )
+    }
+
+    fun aiEnvValues(env: AiEnv): JsonObject = JsonObject(
+        mapOf(
+            "name" to JsonPrimitive(env.name),
+            "enabled" to JsonPrimitive(env.enabled),
+            "visibleToAi" to JsonPrimitive(env.visibleToAi),
+        ),
+    )
+
+    fun aiConversation(row: MirrorEntityRow, conflicted: Boolean = false): AiConversationRecord {
+        val payload = EntityCodec.parse(row.payloadJson)
+        return AiConversationRecord(
+            id = row.entityId,
+            ownerUserId = row.ownerUserId,
+            title = EntityCodec.text(payload, "title"),
+            providerId = EntityCodec.text(payload, "providerId"),
+            model = EntityCodec.text(payload, "model"),
+            archived = EntityCodec.bool(payload, "archived", false),
+            revision = row.revision,
+            createdAt = EntityCodec.long(payload, "createdAt", 0L),
+            updatedAt = row.serverUpdatedAt ?: row.localUpdatedAt,
+            deletedAt = row.deletedAt,
+            syncState = syncStateOf(row, conflicted),
+        )
+    }
+
+    fun aiConversationValues(conversation: AiConversationRecord): JsonObject = JsonObject(
+        mapOf(
+            "title" to JsonPrimitive(conversation.title),
+            "providerId" to JsonPrimitive(conversation.providerId),
+            "model" to JsonPrimitive(conversation.model),
+            "archived" to JsonPrimitive(conversation.archived),
+        ),
+    )
+
+    fun aiMessage(row: MirrorEntityRow, conflicted: Boolean = false): AiMessageRecord {
+        val payload = EntityCodec.parse(row.payloadJson)
+        return AiMessageRecord(
+            id = row.entityId,
+            ownerUserId = row.ownerUserId,
+            conversationId = EntityCodec.text(payload, "conversationId"),
+            role = EntityCodec.text(payload, "role"),
+            content = EntityCodec.text(payload, "content"),
+            attachments = EntityCodec.stringList(payload, "attachments"),
+            revision = row.revision,
+            createdAt = EntityCodec.long(payload, "createdAt", 0L),
+            updatedAt = row.serverUpdatedAt ?: row.localUpdatedAt,
+            deletedAt = row.deletedAt,
+            syncState = syncStateOf(row, conflicted),
+        )
+    }
+
+    fun aiMessageValues(message: AiMessageRecord): JsonObject = JsonObject(
+        mapOf(
+            "conversationId" to JsonPrimitive(message.conversationId),
+            "role" to JsonPrimitive(message.role),
+            "content" to JsonPrimitive(message.content),
+            "attachments" to JsonArrays.of(message.attachments),
+        ),
+    )
+
+    private fun aiModel(payload: JsonObject): AiModel {
+        val input = EntityCodec.obj(payload, "input") ?: JsonObject(emptyMap())
+        val output = EntityCodec.obj(payload, "output") ?: JsonObject(emptyMap())
+        return AiModel(
+            id = EntityCodec.text(payload, "id"),
+            label = EntityCodec.text(payload, "label", EntityCodec.text(payload, "id")),
+            hidden = EntityCodec.bool(payload, "hidden", false),
+            reasoning = EntityCodec.bool(payload, "reasoning", false),
+            reasoningConfigured = EntityCodec.bool(payload, "reasoningConfigured", false),
+            tools = EntityCodec.bool(payload, "tools", true),
+            parallelToolCalls = EntityCodec.bool(payload, "parallelToolCalls", true),
+            contextWindowTokens = EntityCodec.intOrNull(payload, "contextWindowTokens"),
+            maxOutputTokens = EntityCodec.intOrNull(payload, "maxOutputTokens"),
+            temperature = EntityCodec.doubleOrNull(payload, "temperature"),
+            topP = EntityCodec.doubleOrNull(payload, "topP"),
+            maxImagesPerRequest = EntityCodec.intOrNull(payload, "maxImagesPerRequest"),
+            maxImageBytes = EntityCodec.longOrNull(payload, "maxImageBytes"),
+            reasoningEffort = EntityCodec.string(payload, "reasoningEffort"),
+            promptCache = EntityCodec.text(payload, "promptCache", "auto"),
+            apiMode = EntityCodec.string(payload, "apiMode"),
+            inputImage = EntityCodec.bool(input, "image", EntityCodec.bool(payload, "inputImage", true)),
+            inputPdf = EntityCodec.bool(input, "pdf", EntityCodec.bool(payload, "inputPdf", false)),
+            inputAudio = EntityCodec.bool(input, "audio", EntityCodec.bool(payload, "inputAudio", false)),
+            inputVideo = EntityCodec.bool(input, "video", EntityCodec.bool(payload, "inputVideo", false)),
+            outputImage = EntityCodec.bool(output, "image", EntityCodec.bool(payload, "outputImage", false)),
+            outputAudio = EntityCodec.bool(output, "audio", EntityCodec.bool(payload, "outputAudio", false)),
+        )
+    }
+
+    private fun aiModelValues(model: AiModel): JsonObject = JsonObject(
+        buildMap {
+            put("id", JsonPrimitive(model.id))
+            put("label", JsonPrimitive(model.label))
+            put("hidden", JsonPrimitive(model.hidden))
+            put("reasoning", JsonPrimitive(model.reasoning))
+            put("reasoningConfigured", JsonPrimitive(model.reasoningConfigured))
+            put("tools", JsonPrimitive(model.tools))
+            put("parallelToolCalls", JsonPrimitive(model.parallelToolCalls))
+            put("promptCache", JsonPrimitive(model.promptCache))
+            put(
+                "input",
+                JsonObject(
+                    mapOf(
+                        "image" to JsonPrimitive(model.inputImage),
+                        "pdf" to JsonPrimitive(model.inputPdf),
+                        "audio" to JsonPrimitive(model.inputAudio),
+                        "video" to JsonPrimitive(model.inputVideo),
+                    ),
+                ),
+            )
+            put(
+                "output",
+                JsonObject(
+                    mapOf(
+                        "image" to JsonPrimitive(model.outputImage),
+                        "audio" to JsonPrimitive(model.outputAudio),
+                    ),
+                ),
+            )
+            model.contextWindowTokens?.let { put("contextWindowTokens", JsonPrimitive(it)) }
+            model.maxOutputTokens?.let { put("maxOutputTokens", JsonPrimitive(it)) }
+            model.temperature?.let { put("temperature", JsonPrimitive(it)) }
+            model.topP?.let { put("topP", JsonPrimitive(it)) }
+            model.maxImagesPerRequest?.let { put("maxImagesPerRequest", JsonPrimitive(it)) }
+            model.maxImageBytes?.let { put("maxImageBytes", JsonPrimitive(it)) }
+            model.reasoningEffort?.let { put("reasoningEffort", JsonPrimitive(it)) }
+            model.apiMode?.let { put("apiMode", JsonPrimitive(it)) }
+        },
     )
 }

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/LocalAiRepository.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/LocalAiRepository.kt
@@ -85,8 +85,10 @@ class LocalAiRepository(
 
     suspend fun upsertMemory(item: LocalAiMemory) = updateList(item.id, { it.memories }, { c, list -> c.copy(memories = list) }, item)
     suspend fun upsertSkill(item: LocalAiSkill) = updateList(item.id, { it.skills }, { c, list -> c.copy(skills = list) }, item)
+    suspend fun upsertPlan(item: LocalAiPlan) = updateList(item.id, { it.plans }, { c, list -> c.copy(plans = list) }, item)
     suspend fun deleteMemory(id: String) { val c = load(); save(c.copy(memories = c.memories.filterNot { it.id == id })) }
     suspend fun deleteSkill(id: String) { val c = load(); save(c.copy(skills = c.skills.filterNot { it.id == id })) }
+    suspend fun deletePlan(id: String) { val c = load(); save(c.copy(plans = c.plans.filterNot { it.id == id })) }
 
     private suspend inline fun <reified T> updateList(
         id: String,
@@ -99,10 +101,16 @@ class LocalAiRepository(
         val patched: T = when (item) {
             is LocalAiMemory -> item.copy(id = resolved) as T
             is LocalAiSkill -> item.copy(id = resolved) as T
+            is LocalAiPlan -> item.copy(id = resolved) as T
             else -> item
         }
         val list = get(current).filterNot {
-            when (it) { is LocalAiMemory -> it.id == resolved; is LocalAiSkill -> it.id == resolved; else -> false }
+            when (it) {
+                is LocalAiMemory -> it.id == resolved
+                is LocalAiSkill -> it.id == resolved
+                is LocalAiPlan -> it.id == resolved
+                else -> false
+            }
         } + patched
         save(copy(current, list))
     }
@@ -148,6 +156,7 @@ data class LocalAiCatalog(
     val environment: List<LocalAiEnvironment> = emptyList(),
     val memories: List<LocalAiMemory> = emptyList(),
     val skills: List<LocalAiSkill> = emptyList(),
+    val plans: List<LocalAiPlan> = emptyList(),
     val sandbox: LocalAiSandbox = LocalAiSandbox(),
     val syncFromMainEnabled: Boolean = false,
 ) {
@@ -156,7 +165,7 @@ data class LocalAiCatalog(
         context = context.normalized(), memoryMaxItems = memoryMaxItems.coerceIn(1, 2000),
         providers = providers.distinctBy { it.id }, mcpServers = mcpServers.distinctBy { it.id },
         environment = environment.distinctBy { it.id }, memories = memories.distinctBy { it.id }.take(memoryMaxItems),
-        skills = skills.distinctBy { it.id },
+        skills = skills.distinctBy { it.id }, plans = plans.distinctBy { it.id }.take(200),
     )
 }
 
@@ -173,4 +182,14 @@ data class LocalAiCatalog(
 @Serializable data class LocalAiEnvironment(val id: String = "", val name: String = "", val description: String = "", val enabled: Boolean = true, val visibleToAi: Boolean = false, val valueVisibleToAi: Boolean = false)
 @Serializable data class LocalAiMemory(val id: String = "", val title: String = "", val scope: String = "global", val project: String = "", val connectionIds: List<String> = emptyList(), val tags: List<String> = emptyList(), val content: String = "", val enabled: Boolean = true, val updatedAt: Long = System.currentTimeMillis())
 @Serializable data class LocalAiSkill(val id: String = "", val name: String = "", val description: String = "", val prompt: String = "", val enabled: Boolean = true, val updatedAt: Long = System.currentTimeMillis())
+@Serializable data class LocalAiPlanStep(val id: String = "", val title: String = "", val status: String = "pending", val note: String = "", val error: String = "")
+@Serializable data class LocalAiPlan(
+    val id: String = "",
+    val title: String = "",
+    val status: String = "planned",
+    val risk: String = "",
+    val steps: List<LocalAiPlanStep> = emptyList(),
+    val note: String = "",
+    val updatedAt: Long = System.currentTimeMillis(),
+)
 @Serializable data class LocalAiSandbox(val enabled: Boolean = true, val workspaceQuotaMb: Int = 256, val timeoutSeconds: Int = 60, val networkDefault: Boolean = false, val allowedCommands: List<String> = listOf("cat", "grep", "sed", "awk", "head", "tail", "wc", "sort", "uniq", "cut", "tr", "sha256sum"))

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/OwnedAiRepository.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/repository/OwnedAiRepository.kt
@@ -1,0 +1,225 @@
+package one.zephyr.mobile.data.repository
+
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.JsonObject
+import one.zephyr.mobile.contracts.SyncAction
+import one.zephyr.mobile.data.LocalEdit
+import one.zephyr.mobile.data.LocalEditResult
+import one.zephyr.mobile.data.LocalWriteGateway
+import one.zephyr.mobile.data.db.ZephyrDatabase
+import one.zephyr.mobile.data.mapper.ResourceMappers
+import one.zephyr.mobile.model.AiConversationRecord
+import one.zephyr.mobile.model.AiEnv
+import one.zephyr.mobile.model.AiMemory
+import one.zephyr.mobile.model.AiMessageRecord
+import one.zephyr.mobile.model.AiProvider
+import one.zephyr.mobile.model.AiSkill
+import one.zephyr.mobile.model.SecretState
+
+/**
+ * Owned AI entities that ride the main-end change feed.
+ *
+ * Local catalog ([LocalAiRepository]) is device authority and never required for a bound
+ * account to apply these rows. This repository is the only path that turns a mirrored
+ * aiProvider/aiMemory/aiSkill/aiEnv/aiConversation/aiMessage into a local write that can
+ * push back.
+ */
+class OwnedAiRepository(
+    private val db: ZephyrDatabase,
+    private val gateway: LocalWriteGateway,
+) {
+
+    fun observeProviders(ownerUserId: String): Flow<List<AiProvider>> =
+        db.mirrorDao().observeByType(AiProvider.ENTITY_TYPE, ownerUserId)
+            .map { rows -> rows.map(ResourceMappers::aiProvider) }
+            .flowOn(Dispatchers.Default)
+
+    fun observeMemories(ownerUserId: String): Flow<List<AiMemory>> =
+        db.mirrorDao().observeByType(AiMemory.ENTITY_TYPE, ownerUserId)
+            .map { rows -> rows.map(ResourceMappers::aiMemory) }
+            .flowOn(Dispatchers.Default)
+
+    fun observeSkills(ownerUserId: String): Flow<List<AiSkill>> =
+        db.mirrorDao().observeByType(AiSkill.ENTITY_TYPE, ownerUserId)
+            .map { rows -> rows.map(ResourceMappers::aiSkill) }
+            .flowOn(Dispatchers.Default)
+
+    fun observeEnv(ownerUserId: String): Flow<List<AiEnv>> =
+        db.mirrorDao().observeByType(AiEnv.ENTITY_TYPE, ownerUserId)
+            .map { rows -> rows.map(ResourceMappers::aiEnv) }
+            .flowOn(Dispatchers.Default)
+
+    fun observeConversations(ownerUserId: String): Flow<List<AiConversationRecord>> =
+        db.mirrorDao().observeByType(AiConversationRecord.ENTITY_TYPE, ownerUserId)
+            .map { rows -> rows.map(ResourceMappers::aiConversation) }
+            .flowOn(Dispatchers.Default)
+
+    suspend fun listProviders(ownerUserId: String): List<AiProvider> =
+        db.mirrorDao().listByType(AiProvider.ENTITY_TYPE, ownerUserId).map(ResourceMappers::aiProvider)
+
+    suspend fun listMemories(ownerUserId: String): List<AiMemory> =
+        db.mirrorDao().listByType(AiMemory.ENTITY_TYPE, ownerUserId).map(ResourceMappers::aiMemory)
+
+    suspend fun listSkills(ownerUserId: String): List<AiSkill> =
+        db.mirrorDao().listByType(AiSkill.ENTITY_TYPE, ownerUserId).map(ResourceMappers::aiSkill)
+
+    suspend fun listEnv(ownerUserId: String): List<AiEnv> =
+        db.mirrorDao().listByType(AiEnv.ENTITY_TYPE, ownerUserId).map(ResourceMappers::aiEnv)
+
+    suspend fun listConversations(ownerUserId: String): List<AiConversationRecord> =
+        db.mirrorDao().listByType(AiConversationRecord.ENTITY_TYPE, ownerUserId).map(ResourceMappers::aiConversation)
+
+    suspend fun listMessages(ownerUserId: String, conversationId: String): List<AiMessageRecord> =
+        db.mirrorDao().listByType(AiMessageRecord.ENTITY_TYPE, ownerUserId)
+            .map(ResourceMappers::aiMessage)
+            .filter { it.conversationId == conversationId }
+
+    suspend fun findProvider(id: String): AiProvider? =
+        db.mirrorDao().find(AiProvider.ENTITY_TYPE, id)?.let(ResourceMappers::aiProvider)
+
+    suspend fun findMemory(id: String): AiMemory? =
+        db.mirrorDao().find(AiMemory.ENTITY_TYPE, id)?.let(ResourceMappers::aiMemory)
+
+    suspend fun findSkill(id: String): AiSkill? =
+        db.mirrorDao().find(AiSkill.ENTITY_TYPE, id)?.let(ResourceMappers::aiSkill)
+
+    suspend fun findEnv(id: String): AiEnv? =
+        db.mirrorDao().find(AiEnv.ENTITY_TYPE, id)?.let(ResourceMappers::aiEnv)
+
+    suspend fun findConversation(id: String): AiConversationRecord? =
+        db.mirrorDao().find(AiConversationRecord.ENTITY_TYPE, id)?.let(ResourceMappers::aiConversation)
+
+    suspend fun saveProvider(
+        provider: AiProvider,
+        mask: List<String>,
+        apiKey: SecretState = SecretState.Unchanged,
+        ownerUserId: String,
+        createdLocally: Boolean = false,
+    ): LocalEditResult = gateway.apply(
+        LocalEdit(
+            entityType = AiProvider.ENTITY_TYPE,
+            entityId = provider.id.ifBlank { UUID.randomUUID().toString() },
+            action = SyncAction.UPSERT,
+            requestedMask = mask,
+            values = ResourceMappers.aiProviderValues(provider),
+            secrets = mapOf("apiKey" to apiKey),
+            residency = provider.residency,
+            capabilities = provider.capabilities,
+            createdLocally = createdLocally,
+        ),
+        ownerUserId = ownerUserId,
+    )
+
+    suspend fun saveMemory(
+        memory: AiMemory,
+        mask: List<String>,
+        ownerUserId: String,
+        createdLocally: Boolean = false,
+    ): LocalEditResult = gateway.apply(
+        LocalEdit(
+            entityType = AiMemory.ENTITY_TYPE,
+            entityId = memory.id.ifBlank { UUID.randomUUID().toString() },
+            action = SyncAction.UPSERT,
+            requestedMask = mask,
+            values = ResourceMappers.aiMemoryValues(memory),
+            residency = memory.residency,
+            capabilities = memory.capabilities,
+            createdLocally = createdLocally,
+        ),
+        ownerUserId = ownerUserId,
+    )
+
+    suspend fun saveSkill(
+        skill: AiSkill,
+        mask: List<String>,
+        ownerUserId: String,
+        createdLocally: Boolean = false,
+    ): LocalEditResult = gateway.apply(
+        LocalEdit(
+            entityType = AiSkill.ENTITY_TYPE,
+            entityId = skill.id.ifBlank { UUID.randomUUID().toString() },
+            action = SyncAction.UPSERT,
+            requestedMask = mask,
+            values = ResourceMappers.aiSkillValues(skill),
+            residency = skill.residency,
+            capabilities = skill.capabilities,
+            createdLocally = createdLocally,
+        ),
+        ownerUserId = ownerUserId,
+    )
+
+    suspend fun saveEnv(
+        env: AiEnv,
+        mask: List<String>,
+        value: SecretState = SecretState.Unchanged,
+        ownerUserId: String,
+        createdLocally: Boolean = false,
+    ): LocalEditResult = gateway.apply(
+        LocalEdit(
+            entityType = AiEnv.ENTITY_TYPE,
+            entityId = env.id.ifBlank { UUID.randomUUID().toString() },
+            action = SyncAction.UPSERT,
+            requestedMask = mask,
+            values = ResourceMappers.aiEnvValues(env),
+            secrets = mapOf("value" to value),
+            residency = env.residency,
+            capabilities = env.capabilities,
+            createdLocally = createdLocally,
+        ),
+        ownerUserId = ownerUserId,
+    )
+
+    suspend fun saveConversation(
+        conversation: AiConversationRecord,
+        mask: List<String>,
+        ownerUserId: String,
+        createdLocally: Boolean = false,
+    ): LocalEditResult = gateway.apply(
+        LocalEdit(
+            entityType = AiConversationRecord.ENTITY_TYPE,
+            entityId = conversation.id.ifBlank { UUID.randomUUID().toString() },
+            action = SyncAction.UPSERT,
+            requestedMask = mask,
+            values = ResourceMappers.aiConversationValues(conversation),
+            residency = conversation.residency,
+            capabilities = conversation.capabilities,
+            createdLocally = createdLocally,
+        ),
+        ownerUserId = ownerUserId,
+    )
+
+    suspend fun saveMessage(
+        message: AiMessageRecord,
+        mask: List<String>,
+        ownerUserId: String,
+        createdLocally: Boolean = false,
+    ): LocalEditResult = gateway.apply(
+        LocalEdit(
+            entityType = AiMessageRecord.ENTITY_TYPE,
+            entityId = message.id.ifBlank { UUID.randomUUID().toString() },
+            action = SyncAction.UPSERT,
+            requestedMask = mask,
+            values = ResourceMappers.aiMessageValues(message),
+            residency = message.residency,
+            capabilities = message.capabilities,
+            createdLocally = createdLocally,
+        ),
+        ownerUserId = ownerUserId,
+    )
+
+    suspend fun delete(entityType: String, entityId: String, ownerUserId: String): LocalEditResult =
+        gateway.apply(
+            LocalEdit(
+                entityType = entityType,
+                entityId = entityId,
+                action = SyncAction.DELETE,
+                requestedMask = emptyList(),
+                values = JsonObject(emptyMap()),
+            ),
+            ownerUserId = ownerUserId,
+        )
+}

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretPayloadSanitizerTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretPayloadSanitizerTest.kt
@@ -277,6 +277,108 @@ class SecretPayloadSanitizerTest {
     }
 
     @Test
+    fun `canonical ai provider downlink with option numbers is accepted`() {
+        val payload = JsonObject(
+            mapOf(
+                "ownerUserId" to JsonPrimitive("user-1"),
+                "name" to JsonPrimitive("openai"),
+                "type" to JsonPrimitive("openai-compatible"),
+                "baseUrl" to JsonPrimitive("https://api.openai.com/v1"),
+                "defaultModel" to JsonPrimitive("gpt-4o"),
+                "enabled" to JsonPrimitive(true),
+                "hasApiKey" to JsonPrimitive(true),
+                "config" to JsonObject(
+                    mapOf(
+                        "apiMode" to JsonPrimitive("auto"),
+                        "options" to JsonObject(
+                            mapOf(
+                                "temperature" to JsonPrimitive(0.7),
+                                "top_p" to JsonPrimitive(1.0),
+                                "max_tokens" to JsonPrimitive(4096),
+                                "max_output_tokens" to JsonPrimitive(8192),
+                                "presence_penalty" to JsonPrimitive(0.0),
+                                "frequency_penalty" to JsonPrimitive(0.0),
+                            ),
+                        ),
+                    ),
+                ),
+                "models" to JsonArray(
+                    listOf(
+                        JsonObject(
+                            mapOf(
+                                "id" to JsonPrimitive("gpt-4o"),
+                                "label" to JsonPrimitive("GPT-4o"),
+                                "contextWindowTokens" to JsonPrimitive(128000),
+                                "maxOutputTokens" to JsonPrimitive(16384),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertSame(payload, SecretPayloadSanitizer.requireSafe("aiProvider", payload))
+        requireSafeInboundChanges(
+            listOf(
+                SyncChange(
+                    changeSeq = 1,
+                    entityType = "aiProvider",
+                    entityId = "prov-1",
+                    action = SyncAction.UPSERT,
+                    revision = 3,
+                    changedAt = 4,
+                    payload = payload,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `local ai provider writes still cannot forge hasApiKey`() {
+        val error = expectViolation {
+            SecretPayloadSanitizer.sanitizeLocalEditableValues(
+                entityType = "aiProvider",
+                values = JsonObject(mapOf("hasApiKey" to JsonPrimitive(true), "name" to JsonPrimitive("x"))),
+                acceptedMask = listOf("name"),
+            )
+        }
+        assertEquals(SecretPayloadFailure.RAW_SECRET_FIELD, error.failure)
+    }
+
+    @Test
+    fun `ai knowledge and history payloads without secrets are accepted`() {
+        val memory = JsonObject(
+            mapOf(
+                "ownerUserId" to JsonPrimitive("user-1"),
+                "title" to JsonPrimitive("prod host"),
+                "content" to JsonPrimitive("ssh as deploy"),
+                "scope" to JsonPrimitive("global"),
+            ),
+        )
+        val env = JsonObject(
+            mapOf(
+                "ownerUserId" to JsonPrimitive("user-1"),
+                "name" to JsonPrimitive("OPENAI_BASE"),
+                "enabled" to JsonPrimitive(true),
+                "visibleToAi" to JsonPrimitive(true),
+                "hasValue" to JsonPrimitive(true),
+            ),
+        )
+        val conversation = JsonObject(
+            mapOf(
+                "ownerUserId" to JsonPrimitive("user-1"),
+                "title" to JsonPrimitive("deploy"),
+                "providerId" to JsonPrimitive("prov-1"),
+                "model" to JsonPrimitive("gpt-4o"),
+                "archived" to JsonPrimitive(false),
+            ),
+        )
+        assertSame(memory, SecretPayloadSanitizer.requireSafe("aiMemory", memory))
+        assertSame(env, SecretPayloadSanitizer.requireSafe("aiEnv", env))
+        assertSame(conversation, SecretPayloadSanitizer.requireSafe("aiConversation", conversation))
+    }
+
+    @Test
     fun `delete tombstone is subject to the same raw secret scan`() {
         val change = SyncChange(
             changeSeq = 1,

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretPayloadSanitizerTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/SecretPayloadSanitizerTest.kt
@@ -139,14 +139,14 @@ class SecretPayloadSanitizerTest {
     }
 
     @Test
-    fun `local ai provider config rejects nested token before it is projected`() {
+    fun `local ai provider config rejects nested access_token before it is projected`() {
         val error = expectViolation {
             SecretPayloadSanitizer.sanitizeLocalEditableValues(
                 entityType = "aiProvider",
                 values = JsonObject(
                     mapOf(
                         "config" to JsonObject(
-                            mapOf("transport" to JsonObject(mapOf("tokenValue" to JsonPrimitive(CANARY)))),
+                            mapOf("transport" to JsonObject(mapOf("access_token" to JsonPrimitive(CANARY)))),
                         ),
                     ),
                 ),
@@ -155,6 +155,31 @@ class SecretPayloadSanitizerTest {
         }
 
         assertEquals(SecretPayloadFailure.RAW_SECRET_FIELD, error.failure)
+    }
+
+    @Test
+    fun `local ai provider config keeps numeric token fields that are not credentials`() {
+        val sanitized = SecretPayloadSanitizer.sanitizeLocalEditableValues(
+            entityType = "aiProvider",
+            values = JsonObject(
+                mapOf(
+                    "config" to JsonObject(
+                        mapOf(
+                            "options" to JsonObject(
+                                mapOf(
+                                    "max_tokens" to JsonPrimitive(4096),
+                                    "presence_penalty" to JsonPrimitive(0.1),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            acceptedMask = listOf("config"),
+        )
+        val options = ((sanitized["config"] as JsonObject)["options"] as JsonObject)
+        assertEquals(JsonPrimitive(4096), options["max_tokens"])
+        assertEquals(JsonPrimitive(0.1), options["presence_penalty"])
     }
 
     @Test

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/mapper/AiProviderMapperTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/mapper/AiProviderMapperTest.kt
@@ -1,0 +1,132 @@
+package one.zephyr.mobile.data.mapper
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import one.zephyr.mobile.data.EntityCodec
+import one.zephyr.mobile.data.db.MirrorEntityRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AiProviderMapperTest {
+
+    @Test
+    fun `projects nested max_tokens and presence_penalty without treating them as secrets`() {
+        val payload = JsonObject(
+            mapOf(
+                "ownerUserId" to JsonPrimitive("user-1"),
+                "name" to JsonPrimitive("openai"),
+                "type" to JsonPrimitive("openai-compatible"),
+                "baseUrl" to JsonPrimitive("https://api.openai.com/v1"),
+                "defaultModel" to JsonPrimitive("gpt-4o"),
+                "hasApiKey" to JsonPrimitive(true),
+                "enabled" to JsonPrimitive(true),
+                "config" to JsonObject(
+                    mapOf(
+                        "apiMode" to JsonPrimitive("chat"),
+                        "options" to JsonObject(
+                            mapOf(
+                                "max_tokens" to JsonPrimitive(4096),
+                                "presence_penalty" to JsonPrimitive(0.2),
+                                "frequency_penalty" to JsonPrimitive(0.1),
+                                "vision" to JsonPrimitive(true),
+                            ),
+                        ),
+                    ),
+                ),
+                "models" to JsonArray(
+                    listOf(
+                        JsonObject(
+                            mapOf(
+                                "id" to JsonPrimitive("gpt-4o"),
+                                "label" to JsonPrimitive("GPT-4o"),
+                                "contextWindowTokens" to JsonPrimitive(128000),
+                                "maxOutputTokens" to JsonPrimitive(16384),
+                                "input" to JsonObject(mapOf("image" to JsonPrimitive(true))),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val row = MirrorEntityRow(
+            entityType = "aiProvider",
+            entityId = "prov-1",
+            ownerUserId = "user-1",
+            revision = 3,
+            payloadJson = EntityCodec.encode(payload),
+            secretPresenceJson = EntityCodec.encode(JsonObject(mapOf("hasApiKey" to JsonPrimitive(true)))),
+            deletedAt = null,
+            serverUpdatedAt = 10L,
+            localUpdatedAt = 10L,
+        )
+
+        val provider = ResourceMappers.aiProvider(row)
+
+        assertEquals("openai", provider.name)
+        assertEquals(4096, provider.config.maxTokens)
+        assertEquals(0.2, provider.config.presencePenalty!!, 0.0)
+        assertEquals(0.1, provider.config.frequencyPenalty!!, 0.0)
+        assertTrue(provider.apiKey.hasValue)
+        assertEquals("gpt-4o", provider.models.single().id)
+        assertEquals(128000, provider.models.single().contextWindowTokens)
+        assertTrue(provider.models.single().inputImage)
+
+        val values = ResourceMappers.aiProviderValues(provider)
+        val options = ((values["config"] as JsonObject)["options"] as JsonObject)
+        assertEquals(JsonPrimitive(4096), options["max_tokens"])
+        assertEquals(JsonPrimitive(0.2), options["presence_penalty"])
+    }
+
+    @Test
+    fun `ai memory and env projections keep presence-only secrets`() {
+        val memory = ResourceMappers.aiMemory(
+            row(
+                "aiMemory",
+                JsonObject(
+                    mapOf(
+                        "title" to JsonPrimitive("prod"),
+                        "content" to JsonPrimitive("deploy as root"),
+                        "scope" to JsonPrimitive("global"),
+                    ),
+                ),
+            ),
+        )
+        val env = ResourceMappers.aiEnv(
+            row(
+                "aiEnv",
+                JsonObject(
+                    mapOf(
+                        "name" to JsonPrimitive("OPENAI_BASE"),
+                        "enabled" to JsonPrimitive(true),
+                        "visibleToAi" to JsonPrimitive(true),
+                        "hasValue" to JsonPrimitive(true),
+                    ),
+                ),
+                presence = JsonObject(mapOf("hasValue" to JsonPrimitive(true))),
+            ),
+        )
+
+        assertEquals("prod", memory.title)
+        assertEquals("deploy as root", memory.content)
+        assertEquals("OPENAI_BASE", env.name)
+        assertTrue(env.value.hasValue)
+    }
+
+    private fun row(
+        type: String,
+        payload: JsonObject,
+        presence: JsonObject = JsonObject(emptyMap()),
+    ): MirrorEntityRow = MirrorEntityRow(
+        entityType = type,
+        entityId = "$type-1",
+        ownerUserId = "user-1",
+        revision = 1,
+        payloadJson = EntityCodec.encode(payload),
+        secretPresenceJson = EntityCodec.encode(presence),
+        deletedAt = null,
+        serverUpdatedAt = 1L,
+        localUpdatedAt = 1L,
+    )
+}

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/repository/LocalAiPlanCatalogTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/repository/LocalAiPlanCatalogTest.kt
@@ -1,0 +1,23 @@
+package one.zephyr.mobile.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalAiPlanCatalogTest {
+
+    @Test
+    fun `normalized catalog keeps distinct plans and drops blank assistant names`() {
+        val catalog = LocalAiCatalog(
+            assistantName = "   ",
+            plans = listOf(
+                LocalAiPlan(id = "p1", title = "deploy"),
+                LocalAiPlan(id = "p1", title = "duplicate"),
+                LocalAiPlan(id = "p2", title = "rollback"),
+            ),
+        ).normalized()
+
+        assertEquals("Zephyr AI", catalog.assistantName)
+        assertEquals(listOf("p1", "p2"), catalog.plans.map { it.id })
+        assertEquals("deploy", catalog.plans.first().title)
+    }
+}

--- a/zephyr_one/mobile/android/core-model/src/main/kotlin/one/zephyr/mobile/model/Resources.kt
+++ b/zephyr_one/mobile/android/core-model/src/main/kotlin/one/zephyr/mobile/model/Resources.kt
@@ -166,3 +166,159 @@ data class ActivityEvent(
 ) {
     companion object { const val ENTITY_TYPE = "activityEvent" }
 }
+
+data class AiProvider(
+    val id: String,
+    val ownerUserId: String,
+    val name: String,
+    val type: String = "openai-compatible",
+    val baseUrl: String = "",
+    val defaultModel: String = "",
+    val models: List<AiModel> = emptyList(),
+    val config: AiProviderConfig = AiProviderConfig(),
+    val visibility: String = "private",
+    val shareWithUsers: Boolean = false,
+    val shareWithAdmins: Boolean = false,
+    val sharedUserIds: List<String> = emptyList(),
+    val enabled: Boolean = true,
+    val apiKey: SecretPresence = SecretPresence.absent,
+    val revision: Long = 0,
+    val createdAt: Long = 0,
+    val updatedAt: Long = 0,
+    val deletedAt: Long? = null,
+    val residency: Residency = Residency.OWNED,
+    val capabilities: CapabilitySet = CapabilitySet.owner,
+    val syncState: SyncState = SyncState.SYNCED,
+) {
+    companion object { const val ENTITY_TYPE = "aiProvider" }
+}
+
+data class AiModel(
+    val id: String,
+    val label: String = id,
+    val hidden: Boolean = false,
+    val reasoning: Boolean = false,
+    val reasoningConfigured: Boolean = false,
+    val tools: Boolean = true,
+    val parallelToolCalls: Boolean = true,
+    val contextWindowTokens: Int? = null,
+    val maxOutputTokens: Int? = null,
+    val temperature: Double? = null,
+    val topP: Double? = null,
+    val maxImagesPerRequest: Int? = null,
+    val maxImageBytes: Long? = null,
+    val reasoningEffort: String? = null,
+    val promptCache: String = "auto",
+    val apiMode: String? = null,
+    val inputImage: Boolean = true,
+    val inputPdf: Boolean = false,
+    val inputAudio: Boolean = false,
+    val inputVideo: Boolean = false,
+    val outputImage: Boolean = false,
+    val outputAudio: Boolean = false,
+)
+
+data class AiProviderConfig(
+    val apiMode: String = "auto",
+    val temperature: Double? = null,
+    val topP: Double? = null,
+    val maxTokens: Int? = null,
+    val maxOutputTokens: Int? = null,
+    val presencePenalty: Double? = null,
+    val frequencyPenalty: Double? = null,
+    val vision: Boolean = true,
+    val usePreviousResponseId: Boolean = false,
+    val reasoningEffort: String? = null,
+    val windowTokens: Int? = null,
+)
+
+data class AiMemory(
+    val id: String,
+    val ownerUserId: String,
+    val title: String,
+    val content: String = "",
+    val scope: String = "global",
+    val project: String = "",
+    val projects: List<String> = emptyList(),
+    val tags: List<String> = emptyList(),
+    val connectionIds: List<String> = emptyList(),
+    val enabled: Boolean = true,
+    val revision: Long = 0,
+    val updatedAt: Long = 0,
+    val deletedAt: Long? = null,
+    val residency: Residency = Residency.OWNED,
+    val capabilities: CapabilitySet = CapabilitySet.owner,
+    val syncState: SyncState = SyncState.SYNCED,
+) {
+    companion object { const val ENTITY_TYPE = "aiMemory" }
+}
+
+data class AiSkill(
+    val id: String,
+    val ownerUserId: String,
+    val name: String,
+    val description: String = "",
+    val prompt: String = "",
+    val enabled: Boolean = true,
+    val revision: Long = 0,
+    val updatedAt: Long = 0,
+    val deletedAt: Long? = null,
+    val residency: Residency = Residency.OWNED,
+    val capabilities: CapabilitySet = CapabilitySet.owner,
+    val syncState: SyncState = SyncState.SYNCED,
+) {
+    companion object { const val ENTITY_TYPE = "aiSkill" }
+}
+
+data class AiEnv(
+    val id: String,
+    val ownerUserId: String,
+    val name: String,
+    val enabled: Boolean = true,
+    val visibleToAi: Boolean = false,
+    val value: SecretPresence = SecretPresence.absent,
+    val revision: Long = 0,
+    val updatedAt: Long = 0,
+    val deletedAt: Long? = null,
+    val residency: Residency = Residency.OWNED,
+    val capabilities: CapabilitySet = CapabilitySet.owner,
+    val syncState: SyncState = SyncState.SYNCED,
+) {
+    companion object { const val ENTITY_TYPE = "aiEnv" }
+}
+
+data class AiConversationRecord(
+    val id: String,
+    val ownerUserId: String,
+    val title: String = "",
+    val providerId: String = "",
+    val model: String = "",
+    val archived: Boolean = false,
+    val revision: Long = 0,
+    val createdAt: Long = 0,
+    val updatedAt: Long = 0,
+    val deletedAt: Long? = null,
+    val residency: Residency = Residency.OWNED,
+    val capabilities: CapabilitySet = CapabilitySet.owner,
+    val syncState: SyncState = SyncState.SYNCED,
+) {
+    companion object { const val ENTITY_TYPE = "aiConversation" }
+}
+
+data class AiMessageRecord(
+    val id: String,
+    val ownerUserId: String,
+    val conversationId: String,
+    val role: String,
+    val content: String = "",
+    val attachments: List<String> = emptyList(),
+    val revision: Long = 0,
+    val createdAt: Long = 0,
+    val updatedAt: Long = 0,
+    val deletedAt: Long? = null,
+    val residency: Residency = Residency.OWNED,
+    val capabilities: CapabilitySet = CapabilitySet.owner,
+    val syncState: SyncState = SyncState.SYNCED,
+) {
+    companion object { const val ENTITY_TYPE = "aiMessage" }
+}

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ConnectedScreens.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/ConnectedScreens.kt
@@ -598,9 +598,18 @@ fun AiSettingsLiveRoute(
     bound: Boolean,
     onBack: () -> Unit,
     discoverModels: ModelDiscovery? = null,
+    mainSyncCounts: MainAiSyncCounts? = null,
 ) {
-    FullAiSettingsRoute(localAi, bound, onBack, discoverModels)
+    FullAiSettingsRoute(localAi, bound, onBack, discoverModels, mainSyncCounts)
 }
+
+data class MainAiSyncCounts(
+    val providers: Int = 0,
+    val memories: Int = 0,
+    val skills: Int = 0,
+    val env: Int = 0,
+    val conversations: Int = 0,
+)
 
 @Composable
 fun DiagnosticsLiveRoute(

--- a/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/FullAiSettings.kt
+++ b/zephyr_one/mobile/android/feature-tools/src/main/kotlin/one/zephyr/mobile/feature/tools/FullAiSettings.kt
@@ -36,7 +36,7 @@ import one.zephyr.mobile.ui.theme.ZephyrMotionTokens
 import one.zephyr.mobile.ui.theme.ZephyrSpacing
 import one.zephyr.mobile.ui.theme.ZephyrTheme
 
-private enum class AiSettingsPage { ROOT, PROVIDERS, PROVIDER_EDIT, MODELS, MODEL_EDIT, PERMISSIONS, MCP, ENV, MEMORIES, MEMORY_EDIT, SKILLS, SKILL_EDIT, SANDBOX }
+private enum class AiSettingsPage { ROOT, PROVIDERS, PROVIDER_EDIT, MODELS, MODEL_EDIT, PERMISSIONS, MCP, ENV, MEMORIES, MEMORY_EDIT, SKILLS, SKILL_EDIT, PLANS, PLAN_EDIT, SANDBOX, MAIN_SYNC }
 
 /**
  * Fetches the live model list for a provider draft. Implemented by the app layer, which owns the
@@ -54,6 +54,7 @@ fun FullAiSettingsRoute(
     bound: Boolean,
     onBack: () -> Unit,
     discoverModels: ModelDiscovery? = null,
+    mainSyncCounts: MainAiSyncCounts? = null,
 ) {
     val catalog by repository.observe().collectAsState(initial = LocalAiCatalog())
     val scope = rememberCoroutineScope()
@@ -62,17 +63,19 @@ fun FullAiSettingsRoute(
     var modelDraft by remember { mutableStateOf(LocalAiModel("")) }
     var memoryDraft by remember { mutableStateOf(LocalAiMemory()) }
     var skillDraft by remember { mutableStateOf(LocalAiSkill()) }
+    var planDraft by remember { mutableStateOf(LocalAiPlan()) }
     var parentProviderId by remember { mutableStateOf("") }
     val goBack = { when (page) {
         AiSettingsPage.PROVIDER_EDIT, AiSettingsPage.MODELS -> page = AiSettingsPage.PROVIDERS
         AiSettingsPage.MODEL_EDIT -> page = AiSettingsPage.MODELS
         AiSettingsPage.MEMORY_EDIT -> page = AiSettingsPage.MEMORIES
         AiSettingsPage.SKILL_EDIT -> page = AiSettingsPage.SKILLS
+        AiSettingsPage.PLAN_EDIT -> page = AiSettingsPage.PLANS
         AiSettingsPage.ROOT -> onBack()
         else -> page = AiSettingsPage.ROOT
     } }
     Column(Modifier.fillMaxSize()) {
-        PushedPageHeader(title = when(page){AiSettingsPage.ROOT->"AI 助理";AiSettingsPage.PROVIDERS->"模型供应商";AiSettingsPage.PROVIDER_EDIT->if(providerDraft.id.isBlank())"添加供应商" else "编辑供应商";AiSettingsPage.MODELS->"模型";AiSettingsPage.MODEL_EDIT->"模型详情";AiSettingsPage.PERMISSIONS->"工具与权限";AiSettingsPage.MCP->"MCP 服务器";AiSettingsPage.ENV->"AI 环境变量";AiSettingsPage.MEMORIES->"长期 Memory";AiSettingsPage.MEMORY_EDIT->"编辑 Memory";AiSettingsPage.SKILLS->"Skills 能力包";AiSettingsPage.SKILL_EDIT->"编辑 Skill";AiSettingsPage.SANDBOX->"本机沙箱"}, onBack = goBack)
+        PushedPageHeader(title = when(page){AiSettingsPage.ROOT->"AI 助理";AiSettingsPage.PROVIDERS->"模型供应商";AiSettingsPage.PROVIDER_EDIT->if(providerDraft.id.isBlank())"添加供应商" else "编辑供应商";AiSettingsPage.MODELS->"模型";AiSettingsPage.MODEL_EDIT->"模型详情";AiSettingsPage.PERMISSIONS->"工具与权限";AiSettingsPage.MCP->"MCP 服务器";AiSettingsPage.ENV->"AI 环境变量";AiSettingsPage.MEMORIES->"长期 Memory";AiSettingsPage.MEMORY_EDIT->"编辑 Memory";AiSettingsPage.SKILLS->"Skills 能力包";AiSettingsPage.SKILL_EDIT->"编辑 Skill";AiSettingsPage.PLANS->"任务计划";AiSettingsPage.PLAN_EDIT->"编辑计划";AiSettingsPage.SANDBOX->"本机沙箱";AiSettingsPage.MAIN_SYNC->"主端 AI 数据"}, onBack = goBack)
         AnimatedContent(
             targetState = page,
             transitionSpec = {
@@ -92,7 +95,10 @@ fun FullAiSettingsRoute(
             AiSettingsPage.MEMORY_EDIT -> MemoryEditor(memoryDraft){scope.launch{repository.upsertMemory(it);page=AiSettingsPage.MEMORIES}}
             AiSettingsPage.SKILLS -> ResourceList(catalog.skills.map{it.id to it.name},"Skill",{skillDraft=LocalAiSkill();page=AiSettingsPage.SKILL_EDIT},{id->skillDraft=catalog.skills.first{it.id==id};page=AiSettingsPage.SKILL_EDIT},{scope.launch{repository.deleteSkill(it)}})
             AiSettingsPage.SKILL_EDIT -> SkillEditor(skillDraft){scope.launch{repository.upsertSkill(it);page=AiSettingsPage.SKILLS}}
+            AiSettingsPage.PLANS -> ResourceList(catalog.plans.map{it.id to it.title.ifBlank{it.status}},"计划",{planDraft=LocalAiPlan();page=AiSettingsPage.PLAN_EDIT},{id->planDraft=catalog.plans.first{it.id==id};page=AiSettingsPage.PLAN_EDIT},{scope.launch{repository.deletePlan(it)}})
+            AiSettingsPage.PLAN_EDIT -> PlanEditor(planDraft){scope.launch{repository.upsertPlan(it);page=AiSettingsPage.PLANS}}
             AiSettingsPage.SANDBOX -> SandboxEditor(catalog){scope.launch{repository.save(it)}}
+            AiSettingsPage.MAIN_SYNC -> MainSyncStatus(bound, catalog, mainSyncCounts)
         } }
     }
 }
@@ -106,7 +112,22 @@ fun FullAiSettingsRoute(
         Nav("AI 环境变量","${c.environment.size} 个；值存 Android Keystore",AiSettingsPage.ENV,open)
         Nav("长期 Memory","${c.memories.size} / ${c.memoryMaxItems}",AiSettingsPage.MEMORIES,open)
         Nav("Skills 能力包","${c.skills.count{it.enabled}} 个启用",AiSettingsPage.SKILLS,open)
+        Nav("任务计划","${c.plans.size} 条",AiSettingsPage.PLANS,open)
         Nav("本机沙箱","L2 · ${if(c.sandbox.enabled)"启用" else "停用"} · 默认无网络",AiSettingsPage.SANDBOX,open,false)
+    }
+    if (c.providers.isNotEmpty()) {
+        Section("默认供应商")
+        Card {
+            Choice(
+                "默认供应商",
+                c.providers.firstOrNull { it.id == c.defaultProviderId }?.name ?: "未选择",
+                c.providers.map { it.name.ifBlank { it.id } },
+            ) { name ->
+                val chosen = c.providers.firstOrNull { it.name == name || it.id == name }
+                if (chosen != null) save(c.copy(defaultProviderId = chosen.id, defaultModel = chosen.defaultModel.ifBlank { c.defaultModel }))
+            }
+            Field("默认模型", c.defaultModel) { save(c.copy(defaultModel = it)) }
+        }
     }
     Section("上下文与规划")
     Card {
@@ -132,7 +153,10 @@ fun FullAiSettingsRoute(
             save(c.copy(planner = c.planner.copy(requirePlanBeforeTools = it)))
         }
     }
-    Section("可选同步"); Card { Toggle("从主端同步 AI 数据",if(bound)"可选增量来源；本机配置始终可编辑、可运行" else "绑定主端后可选；未绑定不影响任何 AI 功能",c.syncFromMainEnabled){save(c.copy(syncFromMainEnabled=it))} }
+    Section("可选同步"); Card {
+        Toggle("从主端同步 AI 数据",if(bound)"开启后把主端 Provider / Memory / Skill / 会话写入本机镜像，本机配置始终可编辑" else "绑定主端后可选；未绑定不影响任何 AI 功能",c.syncFromMainEnabled){save(c.copy(syncFromMainEnabled=it))}
+        if (bound) Nav("主端 AI 数据","Provider / Memory / Skill / 会话镜像状态",AiSettingsPage.MAIN_SYNC,open,false)
+    }
 } }
 
 @Composable private fun AiProviders(c:LocalAiCatalog,edit:(LocalAiProvider)->Unit,models:(LocalAiProvider)->Unit,delete:(String)->Unit){ AiScroll { PrimaryButton({edit(LocalAiProvider())},Modifier.fillMaxWidth()){Text("添加模型供应商")}; c.providers.forEach{p->Card{SettingsRow(p.name.ifBlank{"未命名"},subtitle="${p.type} · ${p.models.size} 模型 · ${p.source}",value=if(p.enabled)"启用" else "停用",showChevron=true,onClick={edit(p)});SettingsRow("模型列表",value="${p.models.size}",showChevron=true,onClick={models(p)});SettingsRow("删除供应商",titleColor=ZephyrTheme.palette.status.error,showDivider=false,onClick={delete(p.id)})}} } }
@@ -175,6 +199,48 @@ fun FullAiSettingsRoute(
 @Composable private fun ResourceList(items:List<Pair<String,String>>,label:String,add:()->Unit,edit:(String)->Unit,delete:(String)->Unit){AiScroll{PrimaryButton(add,Modifier.fillMaxWidth()){Text("添加 $label")};items.forEach{(id,name)->Card{SettingsRow(name.ifBlank{"未命名 $label"},showChevron=true,onClick={edit(id)});SettingsRow("删除",titleColor=ZephyrTheme.palette.status.error,showDivider=false,onClick={delete(id)})}}}}
 @Composable private fun MemoryEditor(i:LocalAiMemory,save:(LocalAiMemory)->Unit){var d by remember(i){mutableStateOf(i)};AiScroll{Card{Field("标题",d.title){d=d.copy(title=it)};Field("Scope",d.scope){d=d.copy(scope=it)};Field("Project",d.project){d=d.copy(project=it)};Field("关联连接 ID",d.connectionIds.joinToString(",")){d=d.copy(connectionIds=csv(it))};Field("标签",d.tags.joinToString(",")){d=d.copy(tags=csv(it))};Field("内容",d.content,false,7){d=d.copy(content=it)};Toggle("启用此 Memory",null,d.enabled){d=d.copy(enabled=it)}};PrimaryButton({save(d)},Modifier.fillMaxWidth(),d.title.isNotBlank()&&d.content.isNotBlank()){Text("保存 Memory")}}}
 @Composable private fun SkillEditor(i:LocalAiSkill,save:(LocalAiSkill)->Unit){var d by remember(i){mutableStateOf(i)};AiScroll{Card{Field("Skill 名称",d.name){d=d.copy(name=it)};Field("说明",d.description){d=d.copy(description=it)};Field("Skill 指令",d.prompt,false,9){d=d.copy(prompt=it)};Toggle("启用 Skill",null,d.enabled){d=d.copy(enabled=it)}};PrimaryButton({save(d)},Modifier.fillMaxWidth(),d.name.isNotBlank()&&d.prompt.isNotBlank()){Text("保存 Skill")}}}
+@Composable private fun PlanEditor(i:LocalAiPlan,save:(LocalAiPlan)->Unit){
+    var d by remember(i){mutableStateOf(i)}
+    AiScroll{
+        Card{
+            Field("标题",d.title){d=d.copy(title=it)}
+            Choice("状态",d.status,listOf("planned","running","paused","completed","failed","cancelled")){d=d.copy(status=it)}
+            Field("风险说明",d.risk,false,3){d=d.copy(risk=it)}
+            Field("备注",d.note,false,4){d=d.copy(note=it)}
+            Field("步骤（每行一步）",d.steps.joinToString("\n"){it.title},false,8){ lines ->
+                d=d.copy(steps=lines.lineSequence().map(String::trim).filter(String::isNotEmpty).mapIndexed{index,title->
+                    d.steps.getOrNull(index)?.copy(title=title) ?: LocalAiPlanStep(id="${index+1}", title=title)
+                }.toList())
+            }
+        }
+        PrimaryButton({save(d.copy(updatedAt=System.currentTimeMillis()))},Modifier.fillMaxWidth(),d.title.isNotBlank()){Text("保存计划")}
+    }
+}
+@Composable private fun MainSyncStatus(bound:Boolean, catalog:LocalAiCatalog, counts:MainAiSyncCounts?){
+    AiScroll{
+        Card{
+            SettingsRow("绑定状态", value=if(bound) "已绑定主端" else "本机模式")
+            SettingsRow("主端增量同步", value=if(catalog.syncFromMainEnabled) "开启" else "关闭")
+            SettingsRow("镜像供应商", value="${counts?.providers ?: 0}")
+            SettingsRow("镜像 Memory", value="${counts?.memories ?: 0}")
+            SettingsRow("镜像 Skill", value="${counts?.skills ?: 0}")
+            SettingsRow("镜像环境变量", value="${counts?.env ?: 0}")
+            SettingsRow("镜像会话", value="${counts?.conversations ?: 0}", showDivider=false)
+        }
+        Card{
+            SettingsRow("本机供应商", value="${catalog.providers.size}")
+            SettingsRow("本机 Memory", value="${catalog.memories.size}")
+            SettingsRow("本机 Skill", value="${catalog.skills.size}")
+            SettingsRow("本机计划", value="${catalog.plans.size}", showDivider=false)
+        }
+        Text(
+            if (bound) "主端 Provider / Memory / Skill / Env / 会话走 owned-sync 镜像。密钥只以设备信封进 SecretStore，payload 只有 hasApiKey / hasValue。"
+            else "未绑定主端时 AI 完全走本机 catalog，不请求主端。",
+            color=ZephyrTheme.palette.onFloatingMuted,
+            fontSize=12.sp,
+        )
+    }
+}
 @Composable private fun SandboxEditor(c:LocalAiCatalog,save:(LocalAiCatalog)->Unit){var x by remember(c){mutableStateOf(c)};AiScroll{Card{Toggle("启用本机沙箱","会话隔离目录 · 无 shell · 命令白名单 · 审计",x.sandbox.enabled){x=x.copy(sandbox=x.sandbox.copy(enabled=it));save(x)};NumberField("工作区配额 MB",x.sandbox.workspaceQuotaMb){x=x.copy(sandbox=x.sandbox.copy(workspaceQuotaMb=it.coerceIn(32,2048)));save(x)};NumberField("命令超时秒",x.sandbox.timeoutSeconds){x=x.copy(sandbox=x.sandbox.copy(timeoutSeconds=it.coerceIn(1,300)));save(x)};Toggle("默认允许网络","Android 沙箱强制关闭；需要网络请使用网页/MCP 工具",false){};Lines("允许命令",x.sandbox.allowedCommands){x=x.copy(sandbox=x.sandbox.copy(allowedCommands=it));save(x)}};Text("内置文本工具可直接运行；Python / Node / Go / Rust / FFmpeg 当前 APK 未打包时会明确报告 not-packaged，不会伪装成功。",color=ZephyrTheme.palette.onFloatingMuted,fontSize=12.sp)}}
 
 @Composable private fun AiScroll(content:@Composable androidx.compose.foundation.layout.ColumnScope.()->Unit){Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(horizontal=ZephyrSpacing.lg,vertical=8.dp).padding(bottom=140.dp),verticalArrangement=Arrangement.spacedBy(12.dp),content=content)}


### PR DESCRIPTION
## Why

A bound One device that pulled any AI provider page failed the whole sync round. `SecretPayloadSanitizer` treated canonical, non-secret fields as raw credentials:

- `hasApiKey` / `hasValue` (registry presence flags)
- `max_tokens`, `max_output_tokens`, `presence_penalty`, `contextWindowTokens`

That matches the user report: sync succeeds until the account contains Zephyr AI data.

## What

- Inbound sanitizer: presence flags and published numeric option fields pass; exact `token`/`apiKey` aliases and forged local presence writes still fail closed.
- Mirror models + `OwnedAiRepository` for `aiProvider` / `aiMemory` / `aiSkill` / `aiEnv` / `aiConversation` / `aiMessage`.
- Local task-plan catalog, settings default-provider + plan editor, main-end mirror counts.
- Local host tools: `web_search`, `fetch_url`, `memory_search`/`memory_save`, `list_env_vars`/`get_env_var`, `plan_task`/`plan_update`/`plan_delete`. Bound accounts still use the server `/api/ai/runtime` control plane.

## Tests

- `SecretPayloadSanitizerTest` canonical AI provider page + knowledge/history payloads
- `AiProviderMapperTest` round-trip of numeric options
- `LocalAiPlanCatalogTest`
- `AndroidAiWebToolsTest` DuckDuckGo HTML parse
- `tests/mobile-v1-ai-provider-entities.test.mjs` (7/7) including the new wire assertion

Local JVM is blocked on this host (PaX/grsecurity); Android unit tests run in CI.