### PR TITLE
fix(sync,android,ios): blank sshKeyId is not a broken route

### DIFF
--- a/mobile-v1-entities.js
+++ b/mobile-v1-entities.js
@@ -206,6 +206,14 @@ function coerceOwnedPayloadValue(key, value) {
             return [];
         }
     }
+    /* Main-end storage coalesces a missing sshKeyId to '' (TEXT column). One
+     * treats any non-null string as a live dependency, so the empty sentinel
+     * has to become JSON null on the owned-sync wire. Same for proxy/jump. */
+    if (key === 'sshKeyId' || key === 'proxyId' || key === 'jumpHostId') {
+        if (value == null) return null;
+        const text = String(value).trim();
+        return text ? text : null;
+    }
     return value;
 }
 

--- a/tests/mobile-v1-connection-blank-sshkey.test.mjs
+++ b/tests/mobile-v1-connection-blank-sshkey.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { projectPayload } = require(path.join(root, 'mobile-v1-entities.js'));
+
+const registry = JSON.parse(fs.readFileSync(
+  path.join(root, 'zephyr_one', 'mobile', 'contracts', 'registries', 'entity-registry.json'),
+  'utf8',
+));
+const spec = registry.entities.find((entity) => entity.type === 'connection');
+
+test('owned-sync wire turns empty sshKeyId TEXT into JSON null', () => {
+  const wire = projectPayload(spec, {
+    id: 'c-1',
+    ownerUserId: 'alice',
+    name: 'Yunyo FRA',
+    host: '10.0.0.1',
+    port: 22,
+    protocol: 'SSH',
+    username: 'root',
+    password: '',
+    privateKey: '',
+    sshKeyId: '',
+    proxyId: '',
+    jumpHostId: '   ',
+    jumpHostIds: [],
+    connectionMode: 'direct',
+  });
+  assert.equal(wire.sshKeyId, null);
+  assert.equal(wire.proxyId, null);
+  assert.equal(wire.jumpHostId, null);
+  assert.equal(wire.password, undefined);
+  assert.equal(wire.hasPassword, false);
+});
+
+test('owned-sync wire keeps a real sshKeyId', () => {
+  const wire = projectPayload(spec, {
+    id: 'c-1',
+    ownerUserId: 'alice',
+    name: 'Yunyo FRA',
+    host: '10.0.0.1',
+    protocol: 'SSH',
+    sshKeyId: 'key-1',
+    password: 'secret',
+  });
+  assert.equal(wire.sshKeyId, 'key-1');
+  assert.equal(wire.hasPassword, true);
+  assert.equal(wire.password, undefined);
+});

--- a/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/EntityCodec.kt
+++ b/zephyr_one/mobile/android/core-data/src/main/kotlin/one/zephyr/mobile/data/EntityCodec.kt
@@ -27,7 +27,10 @@ object EntityCodec {
     fun encode(payload: JsonObject): String = Converters.jsonObjectToText(payload)
 
     fun string(payload: JsonObject, key: String): String? =
-        (payload[key] as? JsonPrimitive)?.takeIf { it.isString || it.contentOrNull != null }?.contentOrNull
+        (payload[key] as? JsonPrimitive)
+            ?.takeIf { it.isString || it.contentOrNull != null }
+            ?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
 
     fun text(payload: JsonObject, key: String, fallback: String = ""): String = string(payload, key) ?: fallback
 

--- a/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/mapper/ConnectionMapperBlankIdTest.kt
+++ b/zephyr_one/mobile/android/core-data/src/test/kotlin/one/zephyr/mobile/data/mapper/ConnectionMapperBlankIdTest.kt
@@ -1,0 +1,74 @@
+package one.zephyr.mobile.data.mapper
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import one.zephyr.mobile.data.EntityCodec
+import one.zephyr.mobile.data.db.MirrorEntityRow
+import one.zephyr.mobile.model.ConnectionMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ConnectionMapperBlankIdTest {
+
+    @Test
+    fun `empty sshKeyId from the owned-sync wire is absent not a live dependency`() {
+        val connection = ConnectionMapper.fromRow(
+            row(
+                JsonObject(
+                    mapOf(
+                        "name" to JsonPrimitive("Yunyo FRA"),
+                        "host" to JsonPrimitive("10.0.0.1"),
+                        "port" to JsonPrimitive(22),
+                        "protocol" to JsonPrimitive("SSH"),
+                        "username" to JsonPrimitive("root"),
+                        "connectionMode" to JsonPrimitive("direct"),
+                        "sshKeyId" to JsonPrimitive(""),
+                        "proxyId" to JsonPrimitive(""),
+                    ),
+                ),
+            ),
+            pending = false,
+            conflicted = false,
+        )
+
+        assertNull(connection.sshKeyId)
+        assertNull(connection.proxyId)
+        assertEquals(ConnectionMode.DIRECT, connection.connectionMode)
+        assertEquals(emptyList<String>(), connection.dependencyIds)
+    }
+
+    @Test
+    fun `edit values emit JSON null for a cleared sshKeyId`() {
+        val connection = ConnectionMapper.fromRow(
+            row(
+                JsonObject(
+                    mapOf(
+                        "name" to JsonPrimitive("n"),
+                        "host" to JsonPrimitive("h"),
+                        "port" to JsonPrimitive(22),
+                        "protocol" to JsonPrimitive("SSH"),
+                    ),
+                ),
+            ),
+            pending = false,
+            conflicted = false,
+        )
+        val values = ConnectionMapper.editValues(connection, listOf("sshKeyId", "proxyId"))
+        assertEquals(JsonNull, values["sshKeyId"])
+        assertEquals(JsonNull, values["proxyId"])
+    }
+
+    private fun row(payload: JsonObject): MirrorEntityRow = MirrorEntityRow(
+        entityType = "connection",
+        entityId = "c-1",
+        ownerUserId = "user-1",
+        revision = 1,
+        payloadJson = EntityCodec.encode(payload),
+        secretPresenceJson = "{}",
+        deletedAt = null,
+        serverUpdatedAt = 1L,
+        localUpdatedAt = 1L,
+    )
+}

--- a/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraft.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/main/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraft.kt
@@ -223,6 +223,9 @@ data class ConnectionDraft(
             host = trimmedHost,
             username = current.username.trim(),
             tags = tags,
+            proxyId = current.proxyId?.takeIf { it.isNotBlank() },
+            sshKeyId = current.sshKeyId?.takeIf { it.isNotBlank() },
+            jumpHostIds = current.jumpHostIds.map { it.trim() }.filter { it.isNotEmpty() },
             rdp = current.rdp.copy(domain = current.rdp.domain.trim()),
         )
     }
@@ -314,10 +317,10 @@ data class ConnectionDraft(
      */
     fun routeIssues(inventory: RouteInventory): List<DraftIssue> = buildList {
         val candidate = current
-        candidate.proxyId?.let { id ->
+        candidate.proxyId?.takeIf { it.isNotBlank() }?.let { id ->
             if (id !in inventory.usableProxyIds) add(DraftIssue("proxyId", MSG_ROUTE_REPAIR))
         }
-        candidate.sshKeyId?.let { id ->
+        candidate.sshKeyId?.takeIf { it.isNotBlank() }?.let { id ->
             if (id !in inventory.usableSshKeyIds) add(DraftIssue("sshKeyId", MSG_ROUTE_REPAIR))
         }
         for (id in candidate.jumpHostIds) {
@@ -398,7 +401,11 @@ data class ConnectionDraft(
         fun edit(connection: Connection): ConnectionDraft =
             ConnectionDraft(
                 original = connection,
-                current = connection,
+                current = connection.copy(
+                    proxyId = connection.proxyId?.takeIf { it.isNotBlank() },
+                    sshKeyId = connection.sshKeyId?.takeIf { it.isNotBlank() },
+                    jumpHostIds = connection.jumpHostIds.map { it.trim() }.filter { it.isNotEmpty() },
+                ),
                 portWasEdited = connection.port != connection.protocol.defaultPort,
                 password = if (connection.password.hasValue) {
                     SecretState.Unchanged

--- a/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraftTest.kt
+++ b/zephyr_one/mobile/android/feature-connections/src/test/kotlin/one/zephyr/mobile/feature/connections/ConnectionDraftTest.kt
@@ -511,6 +511,26 @@ class ConnectionDraftTest {
     }
 
     @Test
+    fun `blank sshKeyId from the main-end TEXT column is not a missing dependency`() {
+        val stored = Fixtures.connection().copy(sshKeyId = "")
+        val draft = ConnectionDraft.edit(stored)
+        assertEquals(emptyList<DraftIssue>(), draft.routeIssues(Fixtures.inventory()))
+        assertNull(draft.normalized().sshKeyId)
+        assertTrue(draft.changedFields().contains("sshKeyId"))
+        assertTrue(draft.canSave)
+    }
+
+    @Test
+    fun `whitespace sshKeyId is treated as absent and does not block save`() {
+        val stored = Fixtures.connection().copy(sshKeyId = "   ")
+        val draft = ConnectionDraft.edit(stored)
+        assertEquals(emptyList<DraftIssue>(), draft.routeIssues(RouteInventory()))
+        assertNull(draft.normalized().sshKeyId)
+        assertTrue(draft.validate(RouteInventory()).none { it.field == "sshKeyId" })
+        assertTrue(draft.canSave)
+    }
+
+    @Test
     fun usableDependenciesRaiseNoRouteIssue() {
         val stored = Fixtures.connection().copy(
             connectionMode = ConnectionMode.JUMP,

--- a/zephyr_one/mobile/ios/Sources/ZephyrUI/ConnectionDraft.swift
+++ b/zephyr_one/mobile/ios/Sources/ZephyrUI/ConnectionDraft.swift
@@ -313,8 +313,20 @@ public struct ConnectionDraft: Equatable, Sendable {
         copy.host = trimmedHost
         copy.username = current.username.trimmingCharacters(in: .whitespaces)
         copy.tags = tags
+        copy.proxyId = Self.presentId(current.proxyId)
+        copy.sshKeyId = Self.presentId(current.sshKeyId)
+        copy.jumpHostIds = current.jumpHostIds
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
         copy.rdp.domain = current.rdp.domain.trimmingCharacters(in: .whitespaces)
         return copy
+    }
+
+    private static func presentId(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
     }
 
     /// The fieldMask for this save.
@@ -404,13 +416,16 @@ public struct ConnectionDraft: Equatable, Sendable {
     /// offer to clear each one.
     public func routeIssues(inventory: RouteInventory) -> [DraftIssue] {
         var issues: [DraftIssue] = []
-        if let proxyId = current.proxyId, !inventory.usableProxyIds.contains(proxyId) {
+        if let proxyId = current.proxyId, !proxyId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !inventory.usableProxyIds.contains(proxyId) {
             issues.append(DraftIssue(field: "proxyId", message: ConnectionDraft.msgRouteRepair))
         }
-        if let sshKeyId = current.sshKeyId, !inventory.usableSshKeyIds.contains(sshKeyId) {
+        if let sshKeyId = current.sshKeyId, !sshKeyId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !inventory.usableSshKeyIds.contains(sshKeyId) {
             issues.append(DraftIssue(field: "sshKeyId", message: ConnectionDraft.msgRouteRepair))
         }
-        for id in current.jumpHostIds where !inventory.usableJumpHostIds.contains(id) {
+        for id in current.jumpHostIds where !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !inventory.usableJumpHostIds.contains(id) {
             issues.append(DraftIssue(field: "jumpHostIds", message: ConnectionDraft.msgRouteRepair))
             break
         }
@@ -493,9 +508,15 @@ public struct ConnectionDraft: Equatable, Sendable {
     /// following the default when the protocol changes, while a custom port
     /// must survive the switch (ZEPHYR_PARITY.md 5.1).
     public static func edit(_ connection: Connection) -> ConnectionDraft {
-        ConnectionDraft(
+        var current = connection
+        current.proxyId = presentId(connection.proxyId)
+        current.sshKeyId = presentId(connection.sshKeyId)
+        current.jumpHostIds = connection.jumpHostIds
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return ConnectionDraft(
             original: connection,
-            current: connection,
+            current: current,
             portWasEdited: connection.port != connection.`protocol`.defaultPort
         )
     }

--- a/zephyr_one/mobile/ios/Tests/ZephyrUITests/ConnectionDraftTests.swift
+++ b/zephyr_one/mobile/ios/Tests/ZephyrUITests/ConnectionDraftTests.swift
@@ -279,6 +279,26 @@ final class ConnectionDraftTests: XCTestCase {
         )
     }
 
+    func testBlankSshKeyIdFromMainEndIsNotAMissingDependency() {
+        var stored = UiTestData.connection()
+        stored.sshKeyId = ""
+        let draft = ConnectionDraft.edit(stored)
+        XCTAssertEqual(draft.routeIssues(inventory: UiTestData.inventory()), [])
+        XCTAssertNil(draft.normalized().sshKeyId)
+        XCTAssertTrue(draft.changedFields().contains("sshKeyId"))
+        XCTAssertTrue(draft.canSave)
+    }
+
+    func testWhitespaceSshKeyIdDoesNotBlockSave() {
+        var stored = UiTestData.connection()
+        stored.sshKeyId = "   "
+        let draft = ConnectionDraft.edit(stored)
+        XCTAssertEqual(draft.routeIssues(inventory: RouteInventory()), [])
+        XCTAssertNil(draft.normalized().sshKeyId)
+        XCTAssertTrue(draft.validate(inventory: RouteInventory()).allSatisfy { $0.field != "sshKeyId" })
+        XCTAssertTrue(draft.canSave)
+    }
+
     func testRouteRepairIsReportedPerDependency() {
         var stored = UiTestData.connection()
         stored.proxyId = "p-gone"


### PR DESCRIPTION
## Why

Synced (and freshly saved) SSH connections opened the One editor on a red
`路由需要修复：依赖已不存在或权限已撤销` banner and refused to save until the
user tapped the SSH Key row. Screenshot: direct mode, no key selected.

Root cause: the main-end TEXT column stores a missing key as `''`. One treated
any non-null `sshKeyId` as a live dependency, so the empty sentinel failed
`usableSshKeyIds.contains("")`. Tapping the picker ran `RepairRoute`, which
cleared the field.

## What

- Server `projectPayload`: empty `sshKeyId` / `proxyId` / `jumpHostId` become JSON null
- Android `EntityCodec.string`: blank optional ids decode as absent
- Android + iOS drafts: ignore blank ids in route repair, strip them on edit/normalize so save can persist the cleanup

## Tests

- `tests/mobile-v1-connection-blank-sshkey.test.mjs` (local: 2/2)
- `ConnectionMapperBlankIdTest`
- `ConnectionDraftTest` / iOS `ConnectionDraftTests` blank-id cases